### PR TITLE
[KOGITO-84] - Introduction to definitions package

### DIFF
--- a/pkg/controller/kogitoapp/constants/constants.go
+++ b/pkg/controller/kogitoapp/constants/constants.go
@@ -9,10 +9,6 @@ const (
 	ImageStreamTag = "0.2.0"
 	// ImageStreamNamespace default namespace for the ImageStreams
 	ImageStreamNamespace = "openshift"
-	// ServiceAccountName default name for the SA running in the pods
-	ServiceAccountName = "kogito-service"
-	// ServiceAccountRole default role given to the SA running in the pods
-	ServiceAccountRole = "view"
 )
 
 // RuntimeImageDefaults ...

--- a/pkg/controller/kogitoapp/definitions/build_config.go
+++ b/pkg/controller/kogitoapp/definitions/build_config.go
@@ -1,0 +1,77 @@
+package definitions
+
+import (
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	buildv1 "github.com/openshift/api/build/v1"
+)
+
+const (
+	kindImageStreamTag = "ImageStreamTag"
+	tagLatest          = "latest"
+	// ImageStreamTag default tag name for the ImageStreams
+	ImageStreamTag = "0.2.0"
+	// ImageStreamNamespace default namespace for the ImageStreams
+	ImageStreamNamespace = "openshift"
+	// S2IBuildType source to image build type will take a source code and transform it into an executable service
+	S2IBuildType BuildType = "s2i"
+	// RunnerBuildType will create a image with a Kogito Service available
+	RunnerBuildType BuildType = "runner"
+)
+
+// BuildImageStreams are the image streams needed to perform the initial builds
+var BuildImageStreams = map[BuildType]map[v1alpha1.RuntimeType]v1alpha1.Image{
+	S2IBuildType: {
+		v1alpha1.QuarkusRuntimeType: v1alpha1.Image{
+			ImageStreamName:      "kogito-quarkus-centos-s2i",
+			ImageStreamNamespace: ImageStreamNamespace,
+			ImageStreamTag:       ImageStreamTag,
+		},
+		v1alpha1.SpringbootRuntimeType: v1alpha1.Image{
+			ImageStreamName:      "kogito-springboot-centos-s2i",
+			ImageStreamNamespace: ImageStreamNamespace,
+			ImageStreamTag:       ImageStreamTag,
+		},
+	},
+	RunnerBuildType: {
+		v1alpha1.QuarkusRuntimeType: v1alpha1.Image{
+			ImageStreamName:      "kogito-quarkus-centos",
+			ImageStreamNamespace: ImageStreamNamespace,
+			ImageStreamTag:       ImageStreamTag,
+		},
+		v1alpha1.SpringbootRuntimeType: v1alpha1.Image{
+			ImageStreamName:      "kogito-springboot-centos",
+			ImageStreamNamespace: ImageStreamNamespace,
+			ImageStreamTag:       ImageStreamTag,
+		},
+	},
+}
+
+// BuildType which build can we perform? Supported are s2i and runner
+type BuildType string
+
+// BuildConfigComposition is the composition of the build configuration for the Kogito App
+type BuildConfigComposition struct {
+	BuildS2I    buildv1.BuildConfig
+	BuildRunner buildv1.BuildConfig
+	AsMap       map[BuildType]*buildv1.BuildConfig
+}
+
+// NewBuildConfig creates the BuildConfig resource structure for the KogitoApp CRD
+func NewBuildConfig(kogitoApp *v1alpha1.KogitoApp) (buildConfig BuildConfigComposition, err error) {
+	buildConfig = BuildConfigComposition{}
+
+	if buildConfig.BuildS2I, err = newBCS2I(kogitoApp, BuildImageStreams[S2IBuildType][kogitoApp.Spec.Runtime]); err != nil {
+		return buildConfig, err
+	}
+	if buildConfig.BuildRunner, err = newBCRunner(kogitoApp, &buildConfig.BuildS2I, BuildImageStreams[RunnerBuildType][kogitoApp.Spec.Runtime]); err != nil {
+		return buildConfig, err
+	}
+
+	// transform the builds to a map to facilitate the redesign on controller side.
+	// we should remove it after having inventory package to handle the objects
+	buildConfig.AsMap = map[BuildType]*buildv1.BuildConfig{
+		S2IBuildType:    &buildConfig.BuildS2I,
+		RunnerBuildType: &buildConfig.BuildRunner,
+	}
+	return buildConfig, err
+}

--- a/pkg/controller/kogitoapp/definitions/build_config_runner.go
+++ b/pkg/controller/kogitoapp/definitions/build_config_runner.go
@@ -1,0 +1,72 @@
+package definitions
+
+import (
+	"errors"
+	"fmt"
+
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	buildv1 "github.com/openshift/api/build/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	destinationDir   = "."
+	runnerSourcePath = "/home/kogito/bin"
+)
+
+func newBCRunner(kogitoApp *v1alpha1.KogitoApp, fromBuild *buildv1.BuildConfig, image v1alpha1.Image) (buildConfig buildv1.BuildConfig, err error) {
+	if fromBuild == nil {
+		err = errors.New("Impossible to create a runner build configuration without a s2i build definition")
+		return buildConfig, err
+	}
+	// headers and base information
+	buildConfig = buildv1.BuildConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kogitoApp.Spec.Name,
+			Namespace: kogitoApp.Namespace,
+		},
+	}
+	buildConfig.Spec.Output.To = &corev1.ObjectReference{Kind: kindImageStreamTag, Name: fmt.Sprintf("%s:%s", kogitoApp.Spec.Name, tagLatest)}
+	setBCRunnerSource(kogitoApp, &buildConfig, fromBuild)
+	setBCRunnerStrategy(kogitoApp, &buildConfig, &image)
+	setBCRunnerTriggers(&buildConfig, fromBuild)
+	setGroupVersionKind(&buildConfig.TypeMeta, BuildConfigKind)
+	addDefaultMeta(&buildConfig.ObjectMeta, kogitoApp)
+	return buildConfig, err
+}
+
+func setBCRunnerSource(kogitoApp *v1alpha1.KogitoApp, buildConfig *buildv1.BuildConfig, fromBuildConfig *buildv1.BuildConfig) {
+	buildConfig.Spec.Source.Type = buildv1.BuildSourceImage
+	buildConfig.Spec.Source.Images = []buildv1.ImageSource{
+		{
+			From: *fromBuildConfig.Spec.Output.To,
+			Paths: []buildv1.ImageSourcePath{
+				{
+					DestinationDir: destinationDir,
+					SourcePath:     runnerSourcePath,
+				},
+			},
+		},
+	}
+}
+
+func setBCRunnerStrategy(kogitoApp *v1alpha1.KogitoApp, buildConfig *buildv1.BuildConfig, image *v1alpha1.Image) {
+	buildConfig.Spec.Strategy.Type = buildv1.SourceBuildStrategyType
+	buildConfig.Spec.Strategy.SourceStrategy = &buildv1.SourceBuildStrategy{
+		From: corev1.ObjectReference{
+			Name:      fmt.Sprintf("%s:%s", image.ImageStreamName, image.ImageStreamTag),
+			Namespace: image.ImageStreamNamespace,
+			Kind:      kindImageStreamTag,
+		},
+	}
+}
+
+func setBCRunnerTriggers(buildConfig *buildv1.BuildConfig, fromBuildConfig *buildv1.BuildConfig) {
+	buildConfig.Spec.Triggers = []buildv1.BuildTriggerPolicy{
+		{
+			Type:        buildv1.ImageChangeBuildTriggerType,
+			ImageChange: &buildv1.ImageChangeTrigger{From: fromBuildConfig.Spec.Output.To},
+		},
+	}
+}

--- a/pkg/controller/kogitoapp/definitions/build_config_s2i.go
+++ b/pkg/controller/kogitoapp/definitions/build_config_s2i.go
@@ -1,0 +1,56 @@
+package definitions
+
+import (
+	"errors"
+	"fmt"
+
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/controller/kogitoapp/shared"
+	buildv1 "github.com/openshift/api/build/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	nameSuffix = "-builder"
+)
+
+func newBCS2I(kogitoApp *v1alpha1.KogitoApp, image v1alpha1.Image) (buildConfig buildv1.BuildConfig, err error) {
+	if kogitoApp.Spec.Build == nil || kogitoApp.Spec.Build.GitSource == nil {
+		return buildConfig, errors.New("GitSource in the Kogito App Spec is required to create new build configurations")
+	}
+	// headers and base information
+	buildConfig = buildv1.BuildConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s%s", kogitoApp.Spec.Name, nameSuffix),
+			Namespace: kogitoApp.Namespace,
+		},
+	}
+	buildConfig.Spec.Output.To = &corev1.ObjectReference{Kind: kindImageStreamTag, Name: fmt.Sprintf("%s:%s", buildConfig.Name, tagLatest)}
+	setBCS2ISource(kogitoApp, &buildConfig)
+	setBCS2IStrategy(kogitoApp, &buildConfig, &image)
+	setGroupVersionKind(&buildConfig.TypeMeta, BuildConfigKind)
+	addDefaultMeta(&buildConfig.ObjectMeta, kogitoApp)
+	return buildConfig, nil
+}
+
+func setBCS2ISource(kogitoApp *v1alpha1.KogitoApp, buildConfig *buildv1.BuildConfig) {
+	buildConfig.Spec.Source.ContextDir = kogitoApp.Spec.Build.GitSource.ContextDir
+	buildConfig.Spec.Source.Git = &buildv1.GitBuildSource{
+		URI: *kogitoApp.Spec.Build.GitSource.URI,
+		Ref: kogitoApp.Spec.Build.GitSource.Reference,
+	}
+}
+
+func setBCS2IStrategy(kogitoApp *v1alpha1.KogitoApp, buildConfig *buildv1.BuildConfig, image *v1alpha1.Image) {
+	buildConfig.Spec.Strategy.Type = buildv1.SourceBuildStrategyType
+	buildConfig.Spec.Strategy.SourceStrategy = &buildv1.SourceBuildStrategy{
+		From: corev1.ObjectReference{
+			Name:      fmt.Sprintf("%s:%s", image.ImageStreamName, image.ImageStreamTag),
+			Namespace: image.ImageStreamNamespace,
+			Kind:      kindImageStreamTag,
+		},
+		Env:         shared.FromEnvToEnvVar(kogitoApp.Spec.Build.Env),
+		Incremental: &kogitoApp.Spec.Build.Incremental,
+	}
+}

--- a/pkg/controller/kogitoapp/definitions/build_config_test.go
+++ b/pkg/controller/kogitoapp/definitions/build_config_test.go
@@ -1,0 +1,37 @@
+package definitions
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_buildConfigResource_New(t *testing.T) {
+	uri := "https://github.com/kiegroup/kogito-examples"
+	kogitoApp := &v1alpha1.KogitoApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.KogitoAppSpec{
+			Name: "test",
+			Build: &v1alpha1.KogitoAppBuildObject{
+				GitSource: &v1alpha1.GitSource{
+					URI:        &uri,
+					ContextDir: "jbpm-quarkus-example",
+				},
+			},
+		},
+	}
+	b, err := NewBuildConfig(kogitoApp)
+	assert.Nil(t, err)
+	assert.NotNil(t, b.BuildRunner)
+	assert.NotNil(t, b.BuildS2I)
+	assert.Contains(t, b.BuildS2I.Spec.Output.To.Name, nameSuffix)
+	assert.NotContains(t, b.BuildRunner.Spec.Output.To.Name, nameSuffix)
+	assert.Len(t, b.BuildRunner.Spec.Triggers, 1)
+	assert.Len(t, b.BuildS2I.Spec.Triggers, 0)
+	assert.Equal(t, b.BuildRunner.Spec.Source.Images[0].From, *b.BuildS2I.Spec.Output.To)
+}

--- a/pkg/controller/kogitoapp/definitions/deployment_config.go
+++ b/pkg/controller/kogitoapp/definitions/deployment_config.go
@@ -1,0 +1,177 @@
+package definitions
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/controller/kogitoapp/shared"
+	appsv1 "github.com/openshift/api/apps/v1"
+	buildv1 "github.com/openshift/api/build/v1"
+	dockerv10 "github.com/openshift/api/image/docker10"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	defaultReplicas         = int32(1)
+	labelNamespaceSep       = "/"
+	orgKieNamespaceLabelKey = "org.kie" + labelNamespaceSep
+	labelExposeServices     = "io.openshift.expose-services"
+	dockerLabelServicesSep  = ","
+	portSep                 = ":"
+	portFormatWrongMessage  = "Service %s on " + labelExposeServices + " label in wrong format. Won't be possible to expose Services for this application. Should be PORT_NUMBER:PROTOCOL. e.g. 8080:http"
+	defaultExportedProtocol = "http"
+)
+
+var defaultProbe = &corev1.Probe{
+	TimeoutSeconds:   int32(1),
+	PeriodSeconds:    int32(10),
+	SuccessThreshold: int32(1),
+	FailureThreshold: int32(3),
+}
+
+// NewDeploymentConfig creates a new DeploymentConfig resource for the KogitoApp based on the BuildConfig runner image
+func NewDeploymentConfig(kogitoApp *v1alpha1.KogitoApp, runnerBC *buildv1.BuildConfig, sa *corev1.ServiceAccount, dockerImage *dockerv10.DockerImage) (dc *appsv1.DeploymentConfig, err error) {
+	if err = checkDeploymentDependencies(runnerBC, sa); err != nil {
+		return dc, err
+	}
+
+	dc = &appsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kogitoApp.Spec.Name,
+			Namespace: kogitoApp.Namespace,
+		},
+		Spec: appsv1.DeploymentConfigSpec{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.DeploymentStrategyTypeRolling,
+			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: kogitoApp.Spec.Name,
+							// this conversion will be removed in future versions
+							Env: shared.FromEnvToEnvVar(kogitoApp.Spec.Env),
+							// this conversion will be removed in future versions
+							Resources:       *shared.FromResourcesToResourcesRequirements(kogitoApp.Spec.Resources),
+							Image:           runnerBC.Spec.Output.To.Name,
+							ImagePullPolicy: corev1.PullAlways,
+						},
+					},
+					ServiceAccountName: sa.Name,
+				},
+			},
+			Triggers: appsv1.DeploymentTriggerPolicies{
+				{Type: appsv1.DeploymentTriggerOnConfigChange},
+				{
+					Type: appsv1.DeploymentTriggerOnImageChange,
+					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
+						Automatic:      true,
+						ContainerNames: []string{kogitoApp.Spec.Name},
+						From:           *runnerBC.Spec.Output.To,
+					},
+				},
+			},
+		},
+	}
+
+	setGroupVersionKind(&dc.TypeMeta, DeploymentConfigKind)
+	addDefaultMeta(&dc.ObjectMeta, kogitoApp)
+	addDefaultMeta(&dc.Spec.Template.ObjectMeta, kogitoApp)
+	addDefaultLabels(&dc.Spec.Selector, kogitoApp)
+	addLabelsFromDockerImage(dc, dockerImage)
+	discoverPortsAndProbesFromImage(dc, dockerImage)
+	setReplicas(kogitoApp, dc)
+
+	return dc, nil
+}
+
+// checkDeploymentDependencies sanity check to create the DeploymentConfig properly
+func checkDeploymentDependencies(bc *buildv1.BuildConfig, sa *corev1.ServiceAccount) (err error) {
+	if bc == nil {
+		return fmt.Errorf("Impossible to create the DeploymentConfig without a reference to a the service BuildConfig")
+	} else if sa == nil {
+		return fmt.Errorf("Impossible to create the DeploymentConfig without a reference to a the Kogito ServiceAccount")
+	}
+
+	return nil
+}
+
+// setReplicas defines the number of container replicas that this DeploymentConfig will have
+func setReplicas(kogitoApp *v1alpha1.KogitoApp, dc *appsv1.DeploymentConfig) {
+	replicas := defaultReplicas
+	if kogitoApp.Spec.Replicas != nil {
+		replicas = *kogitoApp.Spec.Replicas
+	}
+	dc.Spec.Replicas = replicas
+}
+
+// addLabelsFromDockerImage retrieves org.kie labels from DockerImage and adds them to the DeploymentConfig
+func addLabelsFromDockerImage(dc *appsv1.DeploymentConfig, dockerImage *dockerv10.DockerImage) {
+	if !dockerImageHasLabels(dockerImage) {
+		return
+	}
+	for key, value := range dockerImage.Config.Labels {
+		if strings.Contains(key, orgKieNamespaceLabelKey) {
+			splitedKey := strings.Split(key, labelNamespaceSep)
+			importedKey := splitedKey[len(splitedKey)-1]
+			dc.Labels[importedKey] = value
+			dc.Spec.Selector[importedKey] = value
+			dc.Spec.Template.Labels[importedKey] = value
+		}
+	}
+}
+
+// discoverPortsAndProbesFromImage set Ports and Probes based on labels set on the DockerImage of this DeploymentConfig
+func discoverPortsAndProbesFromImage(dc *appsv1.DeploymentConfig, dockerImage *dockerv10.DockerImage) {
+	if !dockerImageHasLabels(dockerImage) {
+		return
+	}
+	containerPorts := []corev1.ContainerPort{}
+	var nonSecureProbe *corev1.Probe
+	for key, value := range dockerImage.Config.Labels {
+		if key == labelExposeServices {
+			services := strings.Split(value, dockerLabelServicesSep)
+			for _, service := range services {
+				ports := strings.Split(service, portSep)
+				if len(ports) == 0 {
+					log.Warnf(portFormatWrongMessage, service)
+					continue
+				}
+				portNumber, err := strconv.Atoi(strings.Split(service, portSep)[0])
+				if err != nil {
+					log.Warnf(portFormatWrongMessage, service)
+					continue
+				}
+				portName := ports[1]
+				containerPorts = append(containerPorts, corev1.ContainerPort{Name: portName, ContainerPort: int32(portNumber), Protocol: corev1.ProtocolTCP})
+				// we have at least one service exported using default HTTP protocols, let's used as a probe!
+				if portName == defaultExportedProtocol {
+					nonSecureProbe = defaultProbe
+					nonSecureProbe.Handler.TCPSocket = &corev1.TCPSocketAction{Port: intstr.FromInt(portNumber)}
+				}
+			}
+			break
+		}
+	}
+	// set the ports we've found
+	if len(containerPorts) != 0 {
+		dc.Spec.Template.Spec.Containers[0].Ports = containerPorts
+		if nonSecureProbe != nil {
+			dc.Spec.Template.Spec.Containers[0].LivenessProbe = nonSecureProbe
+			dc.Spec.Template.Spec.Containers[0].ReadinessProbe = nonSecureProbe
+		}
+	}
+}
+
+func dockerImageHasLabels(dockerImage *dockerv10.DockerImage) bool {
+	if dockerImage == nil || dockerImage.Config == nil || dockerImage.Config.Labels == nil {
+		return false
+	}
+	return true
+}

--- a/pkg/controller/kogitoapp/definitions/deployment_config_test.go
+++ b/pkg/controller/kogitoapp/definitions/deployment_config_test.go
@@ -1,0 +1,80 @@
+package definitions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	dockerv10 "github.com/openshift/api/image/docker10"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_deploymentConfigResource_NewWithValidDocker(t *testing.T) {
+	uri := "https://github.com/kiegroup/kogito-examples"
+	kogitoApp := &v1alpha1.KogitoApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.KogitoAppSpec{
+			Name: "test",
+			Build: &v1alpha1.KogitoAppBuildObject{
+				GitSource: &v1alpha1.GitSource{
+					URI:        &uri,
+					ContextDir: "jbpm-quarkus-example",
+				},
+			},
+		},
+	}
+	dockerImage := &dockerv10.DockerImage{
+		Config: &dockerv10.DockerConfig{
+			Labels: map[string]string{
+				// notice the semicolon
+				labelExposeServices:                  "8080:http,8181;https",
+				orgKieNamespaceLabelKey + "operator": "kogito",
+			},
+		},
+	}
+	bc, _ := NewBuildConfig(kogitoApp)
+	sa := NewServiceAccount(kogitoApp)
+	dc, err := NewDeploymentConfig(kogitoApp, &bc.BuildRunner, &sa, dockerImage)
+	assert.Nil(t, err)
+	assert.NotNil(t, dc)
+	// we should have only one port. the 8181 is invalid.
+	assert.Len(t, dc.Spec.Template.Spec.Containers[0].Ports, 1)
+	assert.Equal(t, int32(8080), dc.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+	// this one where added by the docker image :)
+	assert.Equal(t, "kogito", dc.Labels["operator"])
+}
+
+func Test_deploymentConfigResource_NewWithInvalidDocker(t *testing.T) {
+	uri := "https://github.com/kiegroup/kogito-examples"
+	kogitoApp := &v1alpha1.KogitoApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.KogitoAppSpec{
+			Name: "test",
+			Build: &v1alpha1.KogitoAppBuildObject{
+				GitSource: &v1alpha1.GitSource{
+					URI:        &uri,
+					ContextDir: "jbpm-quarkus-example",
+				},
+			},
+		},
+	}
+	bc, _ := NewBuildConfig(kogitoApp)
+	sa := NewServiceAccount(kogitoApp)
+	dc, err := NewDeploymentConfig(kogitoApp, &bc.BuildRunner, &sa, &dockerv10.DockerImage{})
+	assert.Nil(t, err)
+	assert.NotNil(t, dc)
+	assert.Len(t, dc.Spec.Selector, 1)
+	assert.Len(t, dc.Spec.Template.Spec.Containers, 1)
+	assert.Equal(t, bc.BuildRunner.Spec.Output.To.Name, dc.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, sa.Name, dc.Spec.Template.Spec.ServiceAccountName)
+	assert.Equal(t, "test", dc.Labels[labelAppName])
+	assert.Equal(t, "test", dc.Spec.Selector[labelAppName])
+	assert.Equal(t, "test", dc.Spec.Template.Labels[labelAppName])
+}

--- a/pkg/controller/kogitoapp/definitions/main.go
+++ b/pkg/controller/kogitoapp/definitions/main.go
@@ -1,0 +1,5 @@
+package definitions
+
+import "github.com/kiegroup/kogito-cloud-operator/pkg/controller/kogitoapp/logs"
+
+var log = logs.GetLogger("definitions_kogitoapp")

--- a/pkg/controller/kogitoapp/definitions/meta.go
+++ b/pkg/controller/kogitoapp/definitions/meta.go
@@ -1,0 +1,63 @@
+package definitions
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	appsv1 "github.com/openshift/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var defaultAnnotations = map[string]string{
+	"org.kie.kogito/managed-by":   "Kogito Operator",
+	"org.kie.kogito/operator-crd": "KogitoApp",
+}
+
+// DefinitionKind is a resource kind representation from a Kubernetes/Openshift cluster
+type DefinitionKind string
+
+const (
+	// ServiceKind for service
+	ServiceKind DefinitionKind = "Service"
+	// BuildConfigKind for a buildConfig
+	BuildConfigKind DefinitionKind = "BuildConfig"
+	// DeploymentConfigKind for a DeploymentConfig
+	DeploymentConfigKind DefinitionKind = "DeploymentConfig"
+	// RoleBindingKind for a RoleBinding
+	RoleBindingKind DefinitionKind = "RoleBinding"
+	// ServiceAccountKind for a ServiceAccount
+	ServiceAccountKind DefinitionKind = "ServiceAccount"
+	// RouteKind for a Route
+	RouteKind DefinitionKind = "Route"
+)
+
+const (
+	labelAppName = "app"
+)
+
+// addDefaultMeta adds the default annotations and labels
+func addDefaultMeta(objectMeta *metav1.ObjectMeta, kogitoApp *v1alpha1.KogitoApp) {
+	if objectMeta != nil {
+		if objectMeta.Annotations == nil {
+			objectMeta.Annotations = map[string]string{}
+		}
+		if objectMeta.Labels == nil {
+			objectMeta.Labels = map[string]string{}
+		}
+		for key, value := range defaultAnnotations {
+			objectMeta.Annotations[key] = value
+		}
+		//objectMeta.Labels[labelAppName] = kogitoApp.Spec.Name
+		addDefaultLabels(&objectMeta.Labels, kogitoApp)
+	}
+}
+
+// addDefaultLabels adds the default labels
+func addDefaultLabels(m *map[string]string, kogitoApp *v1alpha1.KogitoApp) {
+	if *m == nil {
+		(*m) = map[string]string{}
+	}
+	(*m)[labelAppName] = kogitoApp.Spec.Name
+}
+
+func setGroupVersionKind(typeMeta *metav1.TypeMeta, kind DefinitionKind) {
+	typeMeta.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind(string(kind)))
+}

--- a/pkg/controller/kogitoapp/definitions/meta_test.go
+++ b/pkg/controller/kogitoapp/definitions/meta_test.go
@@ -1,0 +1,45 @@
+package definitions
+
+import (
+	"testing"
+
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var kogitoApp = &v1alpha1.KogitoApp{
+	Spec: v1alpha1.KogitoAppSpec{
+		Name: "test",
+	},
+}
+
+func Test_addDefaultMeta_whenLabelsAreNotDefined(t *testing.T) {
+	objectMeta := &metav1.ObjectMeta{}
+	addDefaultMeta(objectMeta, kogitoApp)
+	assert.True(t, objectMeta.Labels[labelAppName] == "test")
+}
+
+func Test_addDefaultMeta_whenAlreadyHasLabels(t *testing.T) {
+	objectMeta := &metav1.ObjectMeta{
+		Labels: map[string]string{
+			"app":      "test123",
+			"operator": "kogito",
+		},
+	}
+	addDefaultMeta(objectMeta, kogitoApp)
+	assert.True(t, objectMeta.Labels[labelAppName] == "test")
+	assert.True(t, objectMeta.Labels["operator"] == "kogito")
+}
+
+func Test_addDefaultMeta_whenAlreadyHasAnnotation(t *testing.T) {
+	objectMeta := &metav1.ObjectMeta{
+		Annotations: map[string]string{
+			"test": "test",
+		},
+	}
+	addDefaultMeta(objectMeta, kogitoApp)
+	assert.True(t, objectMeta.Annotations["test"] == "test")
+	assert.True(t, objectMeta.Annotations["org.kie.kogito/managed-by"] == "Kogito Operator")
+}

--- a/pkg/controller/kogitoapp/definitions/role_binding.go
+++ b/pkg/controller/kogitoapp/definitions/role_binding.go
@@ -1,0 +1,38 @@
+package definitions
+
+import (
+	"fmt"
+
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	defaultRoleName = "view"
+	defaultRoleType = "Role"
+)
+
+// NewRoleBinding creates the RoleBinding definition for the KogitoApp that will be bound to the Kogito ServiceAccount
+func NewRoleBinding(kogitoApp *v1alpha1.KogitoApp, serviceAccount *corev1.ServiceAccount) (roleBinding rbacv1.RoleBinding) {
+	roleBinding = rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: serviceAccount.Namespace,
+			Name:      fmt.Sprintf("%s-%s", ServiceAccountName, defaultRoleName),
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: defaultRoleType,
+			Name: defaultRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      string(RoleBindingKind),
+				Namespace: serviceAccount.Namespace,
+				Name:      serviceAccount.Name,
+			},
+		},
+	}
+	addDefaultMeta(&roleBinding.ObjectMeta, kogitoApp)
+	return roleBinding
+}

--- a/pkg/controller/kogitoapp/definitions/route.go
+++ b/pkg/controller/kogitoapp/definitions/route.go
@@ -1,0 +1,32 @@
+package definitions
+
+import (
+	"fmt"
+
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// NewRoute creates a new Route resource based on the Service created for the KogitoApp container
+func NewRoute(kogitoApp *v1alpha1.KogitoApp, service *corev1.Service) (route *routev1.Route, err error) {
+	if service == nil {
+		return route, fmt.Errorf("Impossible to create a Route without a service on Kogito app %s", kogitoApp.Name)
+	}
+	route = &routev1.Route{
+		ObjectMeta: service.ObjectMeta,
+		Spec: routev1.RouteSpec{
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromString(defaultExportedProtocol),
+			},
+			To: routev1.RouteTargetReference{
+				Kind: string(ServiceKind),
+				Name: service.Name,
+			},
+		},
+	}
+	addDefaultMeta(&route.ObjectMeta, kogitoApp)
+	setGroupVersionKind(&route.TypeMeta, RouteKind)
+	return route, nil
+}

--- a/pkg/controller/kogitoapp/definitions/service.go
+++ b/pkg/controller/kogitoapp/definitions/service.go
@@ -1,0 +1,52 @@
+package definitions
+
+import (
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	appsv1 "github.com/openshift/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// NewService creates a Service resource based on the DC Containers ports exposed. Returns nil if no ports is found on Deployment Config
+func NewService(kogitoApp *v1alpha1.KogitoApp, deploymentConfig *appsv1.DeploymentConfig) (service *corev1.Service) {
+	ports := buildServicePorts(deploymentConfig)
+	if len(ports) == 0 {
+		return nil
+	}
+
+	service = &corev1.Service{
+		ObjectMeta: deploymentConfig.ObjectMeta,
+		Spec: corev1.ServiceSpec{
+			Selector: deploymentConfig.Spec.Selector,
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports:    ports,
+		},
+	}
+
+	setGroupVersionKind(&service.TypeMeta, ServiceKind)
+	addDefaultMeta(&service.ObjectMeta, kogitoApp)
+
+	return service
+}
+
+func buildServicePorts(deploymentConfig *appsv1.DeploymentConfig) (ports []corev1.ServicePort) {
+	ports = []corev1.ServicePort{}
+
+	// for now, we should have at least 1 container defined.
+	if len(deploymentConfig.Spec.Template.Spec.Containers) == 0 ||
+		len(deploymentConfig.Spec.Template.Spec.Containers[0].Ports) == 0 {
+		log.Warnf("The deploymentConfig spec '%s' doesn't have any ports exposed", deploymentConfig.Name)
+		return ports
+	}
+
+	for _, port := range deploymentConfig.Spec.Template.Spec.Containers[0].Ports {
+		ports = append(ports, corev1.ServicePort{
+			Name:       port.Name,
+			Protocol:   port.Protocol,
+			Port:       port.ContainerPort,
+			TargetPort: intstr.FromInt(int(port.ContainerPort)),
+		},
+		)
+	}
+	return ports
+}

--- a/pkg/controller/kogitoapp/definitions/service_account.go
+++ b/pkg/controller/kogitoapp/definitions/service_account.go
@@ -1,0 +1,25 @@
+package definitions
+
+import (
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// ServiceAccountName default name for the SA responsible for running on Kogito App
+	ServiceAccountName = "kogito-service"
+)
+
+// NewServiceAccount creates the ServiceAccount resource structure for the KogitoApp
+func NewServiceAccount(kogitoApp *v1alpha1.KogitoApp) (serviceAccount corev1.ServiceAccount) {
+	serviceAccount = corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceAccountName,
+			Namespace: kogitoApp.Namespace,
+		},
+	}
+	setGroupVersionKind(&serviceAccount.TypeMeta, ServiceAccountKind)
+	addDefaultMeta(&serviceAccount.ObjectMeta, kogitoApp)
+	return serviceAccount
+}

--- a/pkg/controller/kogitoapp/definitions/service_test.go
+++ b/pkg/controller/kogitoapp/definitions/service_test.go
@@ -1,0 +1,49 @@
+package definitions
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	dockerv10 "github.com/openshift/api/image/docker10"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_serviceResource_NewWithAndWithoutDockerImg(t *testing.T) {
+	uri := "https://github.com/kiegroup/kogito-examples"
+	kogitoApp := &v1alpha1.KogitoApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.KogitoAppSpec{
+			Name: "test",
+			Build: &v1alpha1.KogitoAppBuildObject{
+				GitSource: &v1alpha1.GitSource{
+					URI:        &uri,
+					ContextDir: "jbpm-quarkus-example",
+				},
+			},
+		},
+	}
+	dockerImage := &dockerv10.DockerImage{
+		Config: &dockerv10.DockerConfig{
+			Labels: map[string]string{
+				// notice the semicolon
+				labelExposeServices:                  "8080:http",
+				orgKieNamespaceLabelKey + "operator": "kogito",
+			},
+		},
+	}
+	bc, _ := NewBuildConfig(kogitoApp)
+	sa := NewServiceAccount(kogitoApp)
+	dc, _ := NewDeploymentConfig(kogitoApp, &bc.BuildRunner, &sa, nil)
+	svc := NewService(kogitoApp, dc)
+	assert.Nil(t, svc)
+	// try again, now with ports
+	dc, _ = NewDeploymentConfig(kogitoApp, &bc.BuildRunner, &sa, dockerImage)
+	svc = NewService(kogitoApp, dc)
+	assert.NotNil(t, svc)
+	assert.Len(t, svc.Spec.Ports, 1)
+	assert.Equal(t, int32(8080), svc.Spec.Ports[0].Port)
+}


### PR DESCRIPTION
**Note:** I'll leave this PR opened for others to take a look while we work on the redesign. 

This first PR intends to add the "definition" concept to the architecture, which are the data structures that define how the Kubernetes/OpenShift resources will be created to attend the CRD requirement.

The implementation can be viewed on `pkg/controller/<crd>/definitions`. Each file represents a Kubernetes/OpenShift resource  that know how to create each object.

@sutaakar @errantepiphany please chime in. @tchughesiv only if you have the time. :stuck_out_tongue: 

Reference: https://docs.google.com/presentation/d/1xpWaqcTbvb87_uAfNZW1EJg4zJnV5zVLwYRU04D-Kms