### PR TITLE
[KOGITO-148] - Implementation of deploy command to CLI

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1550,6 +1550,7 @@
     "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",

--- a/cmd/kogito/app.go
+++ b/cmd/kogito/app.go
@@ -8,7 +8,7 @@ import (
 )
 
 var appCmd *cobra.Command
-var appName string
+var appCmdName string
 
 var _ = RegisterCommandVar(func() {
 	appCmd = &cobra.Command{
@@ -24,7 +24,7 @@ var _ = RegisterCommandVar(func() {
 
 var _ = RegisterCommandInit(func() {
 	rootCmd.AddCommand(appCmd)
-	appCmd.Flags().StringVarP(&appName, "name", "n", "", "The app name")
+	appCmd.Flags().StringVarP(&appCmdName, "name", "n", "", "The app name")
 })
 
 func appExec(cmd *cobra.Command, args []string) error {
@@ -36,16 +36,16 @@ func appExec(cmd *cobra.Command, args []string) error {
 			log.Infof("Application in the context is '%s'. Use 'kogito deploy SOURCE' to deploy a new application.", config.Namespace)
 			return nil
 		}
-		appName = args[0]
+		appCmdName = args[0]
 	}
 
-	if ns, err := kubernetes.NamespaceC(kubeCli).Fetch(appName); err != nil {
+	if ns, err := kubernetes.NamespaceC(kubeCli).Fetch(appCmdName); err != nil {
 		return fmt.Errorf("Error while trying to look for the namespace. Are you logged in? %s", err)
 	} else if ns != nil {
-		config.Namespace = appName
-		log.Infof("Application set to '%s'", appName)
+		config.Namespace = appCmdName
+		log.Infof("Application set to '%s'", appCmdName)
 		return nil
 	}
 
-	return fmt.Errorf("Application '%s' not found. Try running 'kogito new-app %s' to create your application first", appName, appName)
+	return fmt.Errorf("Application '%s' not found. Try running 'kogito new-app %s' to create your application first", appCmdName, appCmdName)
 }

--- a/cmd/kogito/common_test.go
+++ b/cmd/kogito/common_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"strings"
 
-	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
 
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func runKogito() error {
@@ -15,7 +16,8 @@ func runKogito() error {
 }
 
 func setupFakeKubeCli(initObjs ...runtime.Object) {
-	kubeCli = &client.Client{ControlCli: fake.NewFakeClient(initObjs...)}
+	s := meta.GetRegisteredSchema()
+	kubeCli = &client.Client{ControlCli: fake.NewFakeClientWithScheme(s, initObjs...)}
 }
 
 func kogitoCliTestSetup(arg string) (*bytes.Buffer, *bytes.Buffer) {

--- a/cmd/kogito/config.go
+++ b/cmd/kogito/config.go
@@ -61,7 +61,7 @@ func (c *configuration) initConfig(configFile string) {
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		viper.Unmarshal(&config)
-		log.Info("Using config file:", viper.ConfigFileUsed())
+		log.Debug("Using config file:", viper.ConfigFileUsed())
 	}
 }
 

--- a/cmd/kogito/deploy.go
+++ b/cmd/kogito/deploy.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/spf13/cobra"
+)
+
+type deployFlags struct {
+	name             string
+	namespace        string
+	runtime          string
+	replicas         int32
+	env              []string
+	limits           []string
+	requests         []string
+	serviceLabels    []string
+	incrementalBuild bool
+	buildenv         []string
+	reference        string
+	contextdir       string
+}
+
+const (
+	defaultDeployReplicas = 1
+	defaultDeployRuntime  = "quarkus"
+)
+
+var (
+	deployCmd                 *cobra.Command
+	deployCmdFlags            = deployFlags{}
+	deployRuntimeValidEntries = [...]string{"quarkus", "springboot"}
+)
+
+var _ = RegisterCommandVar(func() {
+	deployCmd = &cobra.Command{
+		Use:   "deploy NAME SOURCE",
+		Short: "Deploys a new Kogito Service into the application context",
+		Long: `'deploy' will create a new Kogito Service from source in the application context.
+		Application context is the namespace (Kubernetes) or project (OpenShift) where the service will be deployed. 
+		To know what's your context, use "kogito app". To set a new context use "kogito app NAME".
+		
+		Please note that this command requires the Kogito Operator installed in the cluster.
+		For more information about the Kogito Operator installation please refer to https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#installation.
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deployExec(cmd, args)
+		},
+		PostRun: saveConfiguration,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("requires 2 args, received %v", len(args))
+			}
+			if _, err := url.ParseRequestURI(args[1]); err != nil {
+				return fmt.Errorf("source is not a valid URL, received %s", args[1])
+			}
+			return nil
+		},
+	}
+})
+
+var _ = RegisterCommandInit(func() {
+	rootCmd.AddCommand(deployCmd)
+	deployCmd.Flags().StringVar(&deployCmdFlags.namespace, "app", "", "Application context (namespace) where the Kogito Service will be deployed.")
+	deployCmd.Flags().StringVarP(&deployCmdFlags.runtime, "runtime", "r", defaultDeployRuntime, "The runtime which should be used to build the service. Valid values are 'quarkus' or 'springboot'. Default to '"+defaultDeployRuntime+"'.")
+	deployCmd.Flags().StringVarP(&deployCmdFlags.reference, "branch", "b", "", "Git branch to use in the git repository")
+	deployCmd.Flags().StringVarP(&deployCmdFlags.contextdir, "context", "c", "", "Context/subdirectory where the code is located, relatively to repo root")
+	deployCmd.Flags().Int32Var(&deployCmdFlags.replicas, "replicas", defaultDeployReplicas, "Number of pod replicas that should be deployed.")
+	deployCmd.Flags().StringSliceVarP(&deployCmdFlags.env, "env", "e", nil, "Key/pair value environment variables that will be set to the Kogito Service. For example 'MY_VAR=my_value'. Can be set more than once.")
+	deployCmd.Flags().StringSliceVar(&deployCmdFlags.limits, "limits", nil, "Resource limits for the Kogito Service pod. Valid values are 'cpu' and 'memory'. For example 'cpu=1'. Can be set more than once.")
+	deployCmd.Flags().StringSliceVar(&deployCmdFlags.requests, "requests", nil, "Resource requests for the Kogito Service pod. Valid values are 'cpu' and 'memory'. For example 'cpu=1'. Can be set more than once.")
+	deployCmd.Flags().StringSliceVarP(&deployCmdFlags.serviceLabels, "svc-labels", "s", nil, "Labels that should be applied to the internal endpoint of the Kogito Service. Used by the service discovery engine. Example: 'label=value'. Can be set more than once.")
+	deployCmd.Flags().BoolVar(&deployCmdFlags.incrementalBuild, "incremental-build", true, "Build should be incremental?")
+	deployCmd.Flags().StringSliceVarP(&deployCmdFlags.buildenv, "build-env", "u", nil, "Key/pair value environment variables that will be set during the build. For example 'MAVEN_URL=http://myinternalmaven.com'. Can be set more than once.")
+})
+
+func deployExec(cmd *cobra.Command, args []string) error {
+
+	return nil
+}

--- a/cmd/kogito/deploy_test.go
+++ b/cmd/kogito/deploy_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_WhenThereAreNoOperator(t *testing.T) {
+	cli := fmt.Sprintf("deploy example-drools https://github.com/kiegroup/kogito-examples --context drools-quarkus-example --app kogito")
+	lines, _, err := executeCli(cli, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kogito"}})
+	assert.Error(t, err)
+	assert.Contains(t, lines, "Couldn't find the Kogito Operator")
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
 
 	corev1 "k8s.io/api/core/v1"
@@ -17,7 +19,7 @@ import (
 
 	buildv1 "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
 	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
-	"k8s.io/client-go/kubernetes/scheme"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	controllercli "sigs.k8s.io/controller-runtime/pkg/client"
@@ -97,13 +99,12 @@ func (r *restScope) Name() apimeta.RESTScopeName {
 func newControllerCliOptions() controllercli.Options {
 	options := controllercli.Options{}
 
-	s := scheme.Scheme
-	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Namespace{})
-
 	mapper := apimeta.NewDefaultRESTMapper([]schema.GroupVersion{})
 	mapper.Add(corev1.SchemeGroupVersion.WithKind(meta.KindNamespace.Name), &restScope{name: apimeta.RESTScopeNameRoot})
+	mapper.Add(apiextensionsv1beta1.SchemeGroupVersion.WithKind(meta.KindCRD.Name), &restScope{name: apimeta.RESTScopeNameRoot})
+	mapper.Add(v1alpha1.SchemeGroupVersion.WithKind(meta.KindKogitoApp.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
 
-	options.Scheme = s
+	options.Scheme = meta.GetRegisteredSchema()
 	options.Mapper = mapper
 	return options
 }

--- a/pkg/client/meta/meta.go
+++ b/pkg/client/meta/meta.go
@@ -1,13 +1,17 @@
 package meta
 
 import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	imgv1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // DefinitionKind is a resource kind representation from a Kubernetes/Openshift cluster
@@ -39,6 +43,10 @@ var (
 	KindBuildRequest = DefinitionKind{"BuildRequest", true, buildv1.SchemeGroupVersion}
 	// KindNamespace for a Namespace
 	KindNamespace = DefinitionKind{"Namespace", false, corev1.SchemeGroupVersion}
+	// KindCRD for a CustomResourceDefinition
+	KindCRD = DefinitionKind{"CustomResourceDefinition", false, apiextensionsv1beta1.SchemeGroupVersion}
+	// KindKogitoApp for a KogitoApp controller
+	KindKogitoApp = DefinitionKind{"KogitoApp", false, v1alpha1.SchemeGroupVersion}
 )
 
 // SetGroupVersionKind sets the group, version and kind for the resource
@@ -48,4 +56,14 @@ func SetGroupVersionKind(typeMeta *metav1.TypeMeta, kind DefinitionKind) {
 		Version: kind.GroupVersion.Version,
 		Kind:    kind.Name,
 	})
+}
+
+// GetRegisteredSchema gets all schema and types registered for use with CLI, unit tests, custom clients and so on
+func GetRegisteredSchema() *runtime.Scheme {
+	s := scheme.Scheme
+	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Namespace{})
+	s.AddKnownTypes(apiextensionsv1beta1.SchemeGroupVersion, &apiextensionsv1beta1.CustomResourceDefinition{})
+	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.KogitoApp{}, &v1alpha1.KogitoAppList{})
+
+	return s
 }

--- a/pkg/util/arrays.go
+++ b/pkg/util/arrays.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+const keyPairSeparator = "="
+
+// FromStringsKeyPairToMap converts a string array in the key/pair format (key=value) to a map. Unconvertable strings will be skipped.
+func FromStringsKeyPairToMap(array []string) map[string]string {
+	if array == nil || len(array) == 0 {
+		return nil
+	}
+	kp := map[string]string{}
+	for _, item := range array {
+		spplited := strings.SplitN(item, keyPairSeparator, 2)
+		if len(spplited) == 0 {
+			break
+		}
+
+		if len(spplited) == 2 {
+			kp[spplited[0]] = spplited[1]
+		} else if len(spplited) == 1 {
+			kp[spplited[0]] = ""
+		}
+	}
+	return kp
+}
+
+// ParseStringsForKeyPair will parse the given string array for a valid key=pair format on each item.
+// Returns an error if any item is not in the valid format.
+func ParseStringsForKeyPair(array []string) error {
+	if array == nil || len(array) == 0 {
+		return nil
+	}
+	for _, item := range array {
+		if !strings.Contains(item, keyPairSeparator) {
+			return fmt.Errorf("Item %s does not contain the key/pair separator '%s'", item, keyPairSeparator)
+		}
+	}
+	return nil
+}

--- a/pkg/util/arrays.go
+++ b/pkg/util/arrays.go
@@ -7,6 +7,19 @@ import (
 
 const keyPairSeparator = "="
 
+// Contains checks if the s string are within the array
+func Contains(s string, array []string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, item := range array {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
 // FromStringsKeyPairToMap converts a string array in the key/pair format (key=value) to a map. Unconvertable strings will be skipped.
 func FromStringsKeyPairToMap(array []string) map[string]string {
 	if array == nil || len(array) == 0 {
@@ -16,6 +29,10 @@ func FromStringsKeyPairToMap(array []string) map[string]string {
 	for _, item := range array {
 		spplited := strings.SplitN(item, keyPairSeparator, 2)
 		if len(spplited) == 0 {
+			break
+		}
+
+		if len(spplited[0]) == 0 {
 			break
 		}
 
@@ -37,6 +54,9 @@ func ParseStringsForKeyPair(array []string) error {
 	for _, item := range array {
 		if !strings.Contains(item, keyPairSeparator) {
 			return fmt.Errorf("Item %s does not contain the key/pair separator '%s'", item, keyPairSeparator)
+		}
+		if strings.HasPrefix(item, keyPairSeparator) {
+			return fmt.Errorf("Item %s starts with key/pair separator '%s'", item, keyPairSeparator)
 		}
 	}
 	return nil

--- a/pkg/util/arrays_test.go
+++ b/pkg/util/arrays_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFromStringsKeyPairToMap(t *testing.T) {
+	type args struct {
+		array []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{"happy path", args{[]string{"env1=value", "env2=value"}}, map[string]string{"env1": "value", "env2": "value"}},
+		{"happy path2", args{[]string{"env1=value"}}, map[string]string{"env1": "value"}},
+		{"only key", args{[]string{"env1="}}, map[string]string{"env1": ""}},
+		{"only key without sep", args{[]string{"env1"}}, map[string]string{"env1": ""}},
+		{"no key no value", args{[]string{""}}, map[string]string{}},
+		{"no key with value", args{[]string{"=value"}}, map[string]string{}},
+		{"various seps", args{[]string{"env1=value=value"}}, map[string]string{"env1": "value=value"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FromStringsKeyPairToMap(tt.args.array); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FromStringsKeyPairToMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
See: https://issues.jboss.org/browse/KOGITO-148

This PR adds the option `deploy` to CLI, for example:

```bash
kogito deploy example-drools https://github.com/kiegroup/kogito-examples --context drools-quarkus-example --app kogito
```

The command above will deploy a new Kogito Service from https://github.com/kiegroup/kogito-examples in the context directory `drools-quarkus-example`. The OpenShift application will be named as **example-drools** and deployed in the namespace `kogito`.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster