### PR TITLE
[KOGITO-171] - Adding a custom role for service discovery

### DIFF
--- a/pkg/client/meta/meta.go
+++ b/pkg/client/meta/meta.go
@@ -7,6 +7,7 @@ import (
 	imgv1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +33,9 @@ var (
 	// KindDeploymentConfig for a DeploymentConfig
 	KindDeploymentConfig = DefinitionKind{"DeploymentConfig", true, appsv1.GroupVersion}
 	// KindRoleBinding for a RoleBinding
-	KindRoleBinding = DefinitionKind{"RoleBinding", false, corev1.SchemeGroupVersion}
+	KindRoleBinding = DefinitionKind{"RoleBinding", false, rbacv1.SchemeGroupVersion}
+	// KindRole for a Role
+	KindRole = DefinitionKind{"Role", false, rbacv1.SchemeGroupVersion}
 	// KindServiceAccount for a ServiceAccount
 	KindServiceAccount = DefinitionKind{"ServiceAccount", false, corev1.SchemeGroupVersion}
 	// KindRoute for a Route

--- a/pkg/controller/kogitoapp/builder/inventory.go
+++ b/pkg/controller/kogitoapp/builder/inventory.go
@@ -16,6 +16,7 @@ type KogitoAppInventory struct {
 	ResourceInventoryStatus
 	ServiceAccount     *corev1.ServiceAccount
 	RoleBinding        *rbacv1.RoleBinding
+	Role               *rbacv1.Role
 	BuildConfigS2I     *buildv1.BuildConfig
 	BuildConfigService *buildv1.BuildConfig
 	DeploymentConfig   *appsv1.DeploymentConfig
@@ -32,6 +33,7 @@ type ResourceInventoryStatusKind struct {
 type ResourceInventoryStatus struct {
 	ServiceAccountStatus     ResourceInventoryStatusKind
 	RoleBindingStatus        ResourceInventoryStatusKind
+	RoleStatus               ResourceInventoryStatusKind
 	BuildConfigS2IStatus     ResourceInventoryStatusKind
 	BuildConfigServiceStatus ResourceInventoryStatusKind
 	DeploymentConfigStatus   ResourceInventoryStatusKind


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-171

With onboarding example we get (no other services available):

```log
2019-08-21 23:50:02,513 WARN  [org.kie.kog.clo.wor.ser.dis.BaseServiceDiscovery] (executor-thread-1) Haven't found any endpoint in the namespace kogito-cli with labels employeeValidation:null
2019-08-21 23:50:02,513 ERROR [org.jbp.wor.ins.imp.WorkflowProcessInstanceImpl] (executor-thread-1) Unexpected error (id 16de14b4-9552-42a3-aa6f-d1253eb1885a) while executing node Validate employee in process instance f656ecc7-40bc-4b0c-8d87-d209d1c12ddc: org.jbpm.workflow.instance.WorkflowRuntimeException: [onboarding.onboarding:f656ecc7-40bc-4b0c-8d87-d209d1c12ddc - Validate employee:7] -- No endpoint found for service employeeValidation
```

The service discovery can now works OOTB with Operator. The role `view` does not exists by default on new OpenShift installations, that's why the former approach won't work.

Output of the policy commad:

```bash
$oc policy who-can get services
resourceaccessreviewresponse.authorization.openshift.io/<unknown> 

Namespace: kogito-cli
Verb:      get
Resource:  services

Users:  system:admin
        system:kube-scheduler
        system:serviceaccount:istio-operator:istio-operator
        system:serviceaccount:istio-system:istio-pilot-service-account
        system:serviceaccount:knative-serving:controller
        system:serviceaccount:kogito-cli:kogito-service <<<<<<<<<<<<<<<
        system:serviceaccount:kube-system:clusterrole-aggregation-controller
        system:serviceaccount:kube-system:endpoint-controller
        system:serviceaccount:kube-system:expand-controller
        system:serviceaccount:kube-system:generic-garbage-collector
        system:serviceaccount:kube-system:namespace-controller
        system:serviceaccount:kube-system:persistent-volume-binder
        system:serviceaccount:kube-system:service-controller
        system:serviceaccount:openshift-apiserver-operator:openshift-apiserver-operator
        system:serviceaccount:openshift-apiserver:openshift-apiserver-sa
        system:serviceaccount:openshift-authentication-operator:authentication-operator
        system:serviceaccount:openshift-authentication:oauth-openshift
        system:serviceaccount:openshift-cluster-node-tuning-operator:cluster-node-tuning-operator
        system:serviceaccount:openshift-cluster-version:default
        system:serviceaccount:openshift-controller-manager-operator:openshift-controller-manager-operator
        system:serviceaccount:openshift-controller-manager:openshift-controller-manager-sa
        system:serviceaccount:openshift-dns-operator:dns-operator
        system:serviceaccount:openshift-image-registry:cluster-image-registry-operator
        system:serviceaccount:openshift-infra:ingress-to-route-controller
        system:serviceaccount:openshift-infra:sdn-controller
        system:serviceaccount:openshift-infra:serviceaccount-pull-secrets-controller
        system:serviceaccount:openshift-infra:template-instance-controller
        system:serviceaccount:openshift-infra:template-instance-finalizer-controller
        system:serviceaccount:openshift-infra:template-service-broker
        system:serviceaccount:openshift-ingress-operator:ingress-operator
        system:serviceaccount:openshift-kube-apiserver-operator:kube-apiserver-operator
        system:serviceaccount:openshift-kube-apiserver:installer-sa
        system:serviceaccount:openshift-kube-controller-manager-operator:kube-controller-manager-operator
        system:serviceaccount:openshift-kube-controller-manager:installer-sa
        system:serviceaccount:openshift-kube-scheduler-operator:openshift-kube-scheduler-operator
        system:serviceaccount:openshift-kube-scheduler:installer-sa
        system:serviceaccount:openshift-kube-scheduler:openshift-kube-scheduler-sa
        system:serviceaccount:openshift-machine-api:cluster-autoscaler
        system:serviceaccount:openshift-machine-config-operator:default
        system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
        system:serviceaccount:openshift-monitoring:prometheus-adapter
        system:serviceaccount:openshift-monitoring:prometheus-operator
        system:serviceaccount:openshift-network-operator:default
        system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount
        system:serviceaccount:openshift-operators:knative-serving-operator
        system:serviceaccount:openshift-sdn:sdn
        system:serviceaccount:openshift-service-ca-operator:service-ca-operator
        system:serviceaccount:openshift-service-ca:service-serving-cert-signer-sa
        system:serviceaccount:openshift-service-catalog-apiserver-operator:openshift-service-catalog-apiserver-operator
        system:serviceaccount:openshift-service-catalog-controller-manager-operator:openshift-service-catalog-controller-manager-operator
Groups: system:cluster-admins
        system:cluster-readers
        system:masters
```

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster