### PR TITLE
[KOGITO-163] - Setting resource owner reference to objects created by CR

### DIFF
--- a/pkg/client/meta/meta.go
+++ b/pkg/client/meta/meta.go
@@ -42,6 +42,8 @@ var (
 	KindRoute = DefinitionKind{"Route", true, routev1.SchemeGroupVersion}
 	// KindImageStreamTag for a ImageStreamTag
 	KindImageStreamTag = DefinitionKind{"ImageStreamTag", true, imgv1.SchemeGroupVersion}
+	// KindImageStream for a ImageStream
+	KindImageStream = DefinitionKind{"ImageStream", true, imgv1.SchemeGroupVersion}
 	// KindBuildRequest for a BuildRequest
 	KindBuildRequest = DefinitionKind{"BuildRequest", true, buildv1.SchemeGroupVersion}
 	// KindNamespace for a Namespace

--- a/pkg/client/openshift/buildconfig.go
+++ b/pkg/client/openshift/buildconfig.go
@@ -51,10 +51,10 @@ func (b *buildConfig) EnsureImageBuild(bc *buildv1.BuildConfig, labelSelector st
 	if img, err := ImageStreamC(b.client).FetchDockerImage(bcNamed); err != nil {
 		return state, err
 	} else if img == nil {
-		log.Infof("Image not found for build %s", bc.Name)
+		log.Debugf("Image not found for build %s", bc.Name)
 		state.ImageExists = false
 		if running, err := b.BuildIsRunning(bc, labelSelector); running {
-			log.Infof("Build %s is still running", bc.Name)
+			log.Debugf("Build %s is still running", bc.Name)
 			state.BuildRunning = true
 			return state, nil
 		} else if err != nil {

--- a/pkg/controller/kogitoapp/builder/builder.go
+++ b/pkg/controller/kogitoapp/builder/builder.go
@@ -4,6 +4,7 @@ import (
 	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/openshift"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -12,7 +13,12 @@ import (
 type Context struct {
 	//KogitoApp is the cached instance of the created CR
 	KogitoApp *v1alpha1.KogitoApp
-	Client    *client.Client
+	// Client will be used to communicate with the cluster
+	Client *client.Client
+	// PostCreate is a function that will be called after building the object in the cluster
+	PostCreate func(object meta.ResourceObject) error
+	// PreCreate is a function called before the object persistence in the cluster
+	PreCreate func(object meta.ResourceObject) error
 }
 
 type builderChain struct {
@@ -47,28 +53,56 @@ func BuildOrFetchObjects(context *Context) (inv *KogitoAppInventory, err error) 
 	return chain.Inventory, chain.Error
 }
 
+func callPostCreate(isNew bool, object meta.ResourceObject, chain *builderChain) *builderChain {
+	if isNew && chain.Context.PostCreate != nil {
+		if chain.Error == nil {
+			chain.Error = chain.Context.PostCreate(object)
+		}
+	}
+	return chain
+}
+
+func callPreCreate(object meta.ResourceObject, chain *builderChain) error {
+	if chain.Error == nil && chain.Context.PreCreate != nil {
+		return chain.Context.PreCreate(object)
+	}
+	return nil
+}
+
 func serviceAccountBuilder(chain *builderChain) *builderChain {
 	sa := NewServiceAccount(chain.Context.KogitoApp)
+	if err := callPreCreate(&sa, chain); err != nil {
+		chain.Error = err
+		return chain
+	}
 	chain.Inventory.ServiceAccountStatus.IsNew, chain.Error =
 		kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(&sa)
 	chain.Inventory.ServiceAccount = &sa
-	return chain
+	return callPostCreate(chain.Inventory.ServiceAccountStatus.IsNew, &sa, chain)
 }
 
 func roleBuilder(chain *builderChain) *builderChain {
 	role := NewRole(chain.Context.KogitoApp)
+	if err := callPreCreate(&role, chain); err != nil {
+		chain.Error = err
+		return chain
+	}
 	chain.Inventory.RoleStatus.IsNew, chain.Error =
 		kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(&role)
 	chain.Inventory.Role = &role
-	return chain
+	return callPostCreate(chain.Inventory.RoleStatus.IsNew, &role, chain)
 }
 
 func roleBindingBuilder(chain *builderChain) *builderChain {
 	rb := NewRoleBinding(chain.Context.KogitoApp, chain.Inventory.ServiceAccount, chain.Inventory.Role)
+	if err := callPreCreate(&rb, chain); err != nil {
+		chain.Error = err
+		return chain
+	}
 	chain.Inventory.RoleBindingStatus.IsNew, chain.Error =
 		kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(&rb)
 	chain.Inventory.RoleBinding = &rb
-	return chain
+	return callPostCreate(chain.Inventory.RoleBindingStatus.IsNew, &rb, chain)
 }
 
 func buildConfigS2IBuilder(chain *builderChain) *builderChain {
@@ -77,10 +111,14 @@ func buildConfigS2IBuilder(chain *builderChain) *builderChain {
 		chain.Error = err
 		return chain
 	}
+	if err := callPreCreate(&bc, chain); err != nil {
+		chain.Error = err
+		return chain
+	}
 	chain.Inventory.BuildConfigS2IStatus.IsNew, chain.Error =
 		kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(&bc)
 	chain.Inventory.BuildConfigS2I = &bc
-	return chain
+	return callPostCreate(chain.Inventory.BuildConfigS2IStatus.IsNew, &bc, chain)
 }
 
 func buildConfigServiceBuilder(chain *builderChain) *builderChain {
@@ -92,28 +130,44 @@ func buildConfigServiceBuilder(chain *builderChain) *builderChain {
 		chain.Error = err
 		return chain
 	}
+	if err := callPreCreate(&bc, chain); err != nil {
+		chain.Error = err
+		return chain
+	}
 	chain.Inventory.BuildConfigServiceStatus.IsNew, chain.Error =
 		kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(&bc)
 	chain.Inventory.BuildConfigService = &bc
-	return chain
+	return callPostCreate(chain.Inventory.BuildConfigServiceStatus.IsNew, &bc, chain)
 }
 
 func imageStreamBuilder(chain *builderChain) *builderChain {
-	_, chain.Error =
-		openshift.ImageStreamC(chain.Context.Client).CreateTagIfNotExists(
-			NewImageStreamTag(chain.Context.KogitoApp, chain.Inventory.BuildConfigS2I.Name),
-		)
+	created := false
+
+	is := NewImageStreamTag(chain.Context.KogitoApp, chain.Inventory.BuildConfigS2I.Name)
+	if err := callPreCreate(is, chain); err != nil {
+		chain.Error = err
+		return chain
+	}
+	created, chain.Error = kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(is) //openshift.ImageStreamC(chain.Context.Client).CreateTagIfNotExists(is)
 	if chain.Error != nil {
 		return chain
 	}
-	_, chain.Error =
-		openshift.ImageStreamC(chain.Context.Client).CreateTagIfNotExists(
-			NewImageStreamTag(chain.Context.KogitoApp, chain.Inventory.BuildConfigService.Name),
-		)
+	chain = callPostCreate(created, is, chain)
 	if chain.Error != nil {
 		return chain
 	}
-	return chain
+
+	is = NewImageStreamTag(chain.Context.KogitoApp, chain.Inventory.BuildConfigService.Name)
+	if err := callPreCreate(is, chain); err != nil {
+		chain.Error = err
+		return chain
+	}
+	created, chain.Error = kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(is)
+	if chain.Error != nil {
+		return chain
+	}
+
+	return callPostCreate(created, is, chain)
 }
 
 func deploymentConfigBuilder(chain *builderChain) *builderChain {
@@ -136,9 +190,14 @@ func deploymentConfigBuilder(chain *builderChain) *builderChain {
 			chain.Error = err
 			return chain
 		}
+		if err := callPreCreate(dc, chain); err != nil {
+			chain.Error = err
+			return chain
+		}
 		chain.Inventory.DeploymentConfigStatus.IsNew, chain.Error =
 			kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(dc)
 		chain.Inventory.DeploymentConfig = dc
+		chain = callPostCreate(chain.Inventory.DeploymentConfigStatus.IsNew, dc, chain)
 	} else {
 		log.Warnf("Couldn't find an image with name '%s' in the namespace '%s'. The DeploymentConfig will be created once the build is done.", bcNamespacedName.Name, bcNamespacedName.Namespace)
 	}
@@ -150,9 +209,14 @@ func serviceBuilder(chain *builderChain) *builderChain {
 	if chain.Inventory.DeploymentConfig != nil {
 		svc := NewService(chain.Context.KogitoApp, chain.Inventory.DeploymentConfig)
 		if svc != nil {
+			if err := callPreCreate(svc, chain); err != nil {
+				chain.Error = err
+				return chain
+			}
 			chain.Inventory.ServiceStatus.IsNew, chain.Error =
 				kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(svc)
 			chain.Inventory.Service = svc
+			chain = callPostCreate(chain.Inventory.ServiceStatus.IsNew, svc, chain)
 		}
 	}
 	return chain
@@ -166,9 +230,14 @@ func routeBuilder(chain *builderChain) *builderChain {
 			chain.Error = err
 			return chain
 		}
+		if err := callPreCreate(route, chain); err != nil {
+			chain.Error = err
+			return chain
+		}
 		chain.Inventory.RouteStatus.IsNew, chain.Error =
 			kubernetes.ResourceC(chain.Context.Client).CreateIfNotExists(route)
 		chain.Inventory.Route = route
+		chain = callPostCreate(chain.Inventory.RouteStatus.IsNew, route, chain)
 	}
 	return chain
 }

--- a/pkg/controller/kogitoapp/builder/builder_test.go
+++ b/pkg/controller/kogitoapp/builder/builder_test.go
@@ -45,6 +45,7 @@ var (
 func TestBuildResources_CreateAllWithoutImage(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DeploymentConfig{}, &buildv1.BuildConfig{})
+	s.AddKnownTypes(imgv1.SchemeGroupVersion, &imgv1.ImageStreamTag{}, &imgv1.ImageStream{})
 
 	inv, err := BuildOrFetchObjects(&Context{
 		Client:    &client.Client{ControlCli: fake.NewFakeClient(), ImageCli: imgfake.NewSimpleClientset().ImageV1()},
@@ -64,6 +65,7 @@ func TestBuildResources_CreateAllWithoutImage(t *testing.T) {
 func TestBuildResources_CreateAllSuccess(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DeploymentConfig{}, &buildv1.BuildConfig{}, &routev1.Route{})
+	s.AddKnownTypes(imgv1.SchemeGroupVersion, &imgv1.ImageStreamTag{}, &imgv1.ImageStream{})
 	dockerImageRaw, err := json.Marshal(&dockerv10.DockerImage{
 		Config: &dockerv10.DockerConfig{
 			Labels: map[string]string{

--- a/pkg/controller/kogitoapp/builder/image_stream_tag.go
+++ b/pkg/controller/kogitoapp/builder/image_stream_tag.go
@@ -1,40 +1,46 @@
 package builder
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/openshift"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1alpha1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	imgv1 "github.com/openshift/api/image/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NewImageStreamTag creates a new ImageStreamTag on the OpenShift cluster using the tag reference name.
 // tagRefName refers to a full tag name like kogito-app:latest. If no tag is passed (e.g. kogito-app), "latest" will be used for the tag
-func NewImageStreamTag(kogitoApp *v1alpha1.KogitoApp, tagRefName string) *imgv1.ImageStreamTag {
+func NewImageStreamTag(kogitoApp *v1alpha1.KogitoApp, tagRefName string) *imgv1.ImageStream {
 	result := strings.Split(tagRefName, ":")
 	if len(result) == 1 {
 		result = append(result, openshift.ImageTagLatest)
 	}
 
-	is := &imgv1.ImageStreamTag{
+	is := &imgv1.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s:%s", result[0], result[1]),
+			Name:      result[0],
 			Namespace: kogitoApp.Namespace,
 		},
-		Tag: &imgv1.TagReference{
-			Name: result[1],
-			ReferencePolicy: imgv1.TagReferencePolicy{
-				Type: imgv1.LocalTagReferencePolicy,
+		Spec: imgv1.ImageStreamSpec{
+			LookupPolicy: imgv1.ImageLookupPolicy{
+				Local: true,
+			},
+			Tags: []imgv1.TagReference{
+				{
+					Name: result[1],
+					ReferencePolicy: imgv1.TagReferencePolicy{
+						Type: imgv1.LocalTagReferencePolicy,
+					},
+				},
 			},
 		},
 	}
 
 	addDefaultMeta(&is.ObjectMeta, kogitoApp)
-	meta.SetGroupVersionKind(&is.TypeMeta, meta.KindImageStreamTag)
+	meta.SetGroupVersionKind(&is.TypeMeta, meta.KindImageStream)
 
 	return is
 }


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-163

In this PR you'll find:

1. Handlers for `PreCreate` and `PostCreate` for the builder function. These handlers add the possibility to execute functions before and after object creations in the cluster
2. With the `PreCreate` handler we added the feature to set the CR as a reference for the object, this way we solve KOGITO-163
3. The controller now doesn't create a `ImageStreamTag`, instead we rely on an `ImageStream`. Creating only `tag` (like in previous versions), the cluster would create a `ImageStream`, thus jeopardizing any references that we add to the object. That said, we now have a builder for `ImageStream`. The `tag` is automatically pushed by the `build`.
4. Small refactoring in the log messages

Example of an object owned by the CR:

```
apiVersion: build.openshift.io/v1
kind: BuildConfig
metadata:
  annotations:
    org.kie.kogito/managed-by: Kogito Operator
    org.kie.kogito/operator-crd: KogitoApp
  creationTimestamp: "2019-08-26T16:25:45Z"
  labels:
    app: example-drools
    buildtype: service
  name: example-drools
  namespace: kogito-owner
  ownerReferences:
  - apiVersion: app.kiegroup.org/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: KogitoApp
    name: example-drools
    uid: 26c34fbb-c81e-11e9-8894-0a76b78ac33a
  resourceVersion: "4926876"
  selfLink: /apis/build.openshift.io/v1/namespaces/kogito-owner/buildconfigs/example-drools
  uid: 279cf093-c81e-11e9-bd5e-0a580a810159
....
```

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster