### PR TITLE
[KOGITO-127] - Limiting s2i builds CPU and Memory resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,4 @@ addheaders:
 
 .PHONY: run-e2e
 run-e2e:
-	./hack/run-e2e.sh $(namespace) $(tag)
+	./hack/run-e2e.sh $(namespace) $(tag) $(native) $(maven_mirror)

--- a/README.md
+++ b/README.md
@@ -464,12 +464,21 @@ $ oc describe operatorsource.operators.coreos.com/kogitocloud-operator -n opensh
 If you have an OpenShift cluster and admin privileges, you can run e2e tests with the following command:
 
 ```bash
-$ make run-e2e namespace=<namespace> tag=<tag>
+$ make run-e2e namespace=<namespace> tag=<tag> native=<true|false> maven_mirror=<maven_mirror_url>
 ```
 
-Where `namespace` is a given temporary namespace where the test will run. You don't need to create the namespace, since it will be created and deleted after running the tests.
+Where:
 
-The next parameter, `tag`, is the image tag for the Kogito image builds, for example: `0.4.0-rc1`. Useful for situations where [Kogito Cloud images](https://github.com/kiegroup/kogito-cloud/tree/master/s2i) haven't released yet and are under a temporary tag.
+1. `namespace` (required) is a given temporary namespace where the test will run. You don't need to create the namespace, since it will be created and deleted after running the tests
+2. `tag` (optional, default is current release) is the image tag for the Kogito image builds, for example: `0.4.0-rc1`. Useful on situations where [Kogito Cloud images](https://github.com/kiegroup/kogito-cloud/tree/master/s2i) haven't released yet and are under a temporary tag
+3. `native` (optional, default is `false`) indicates if the e2e test should use native or jvm builds. See [Native X JVM Builds](#native-x-jvm-builds)
+4. `maven_mirror` (optional, default is blank) the Maven mirror URL. Useful when you need to speed up the build time by referring to a closer maven repository
+
+In case of errors while running this test, a huge log dump will appear in your terminal. To save the test output in a local file to be analysed later, use the command below:
+
+```bash
+make run-e2e namespace=kogito-e2e  2>&1 | tee log.out
+```
 
 ### Running Locally
 

--- a/deploy/crds/app_v1alpha1_kogitoapp_crd-0.4.0.yaml
+++ b/deploy/crds/app_v1alpha1_kogitoapp_crd-0.4.0.yaml
@@ -85,6 +85,45 @@ spec:
                     be compiled to run on native mode when Runtime is quarkus. See:
                     https://www.graalvm.org/docs/reference-manual/aot-compilation/'
                   type: boolean
+                resources:
+                  description: Resources for build pods. Default limits are 1GB RAM/0.5
+                    cpu on jvm and 4GB RAM/1 cpu for native builds.
+                  properties:
+                    limits:
+                      items:
+                        properties:
+                          resource:
+                            description: Resource type like cpu and memory
+                            enum:
+                            - cpu
+                            - memory
+                            type: string
+                          value:
+                            description: Value of this resource in Kubernetes format
+                            type: string
+                        required:
+                        - resource
+                        - value
+                        type: object
+                      type: array
+                    requests:
+                      items:
+                        properties:
+                          resource:
+                            description: Resource type like cpu and memory
+                            enum:
+                            - cpu
+                            - memory
+                            type: string
+                          value:
+                            description: Value of this resource in Kubernetes format
+                            type: string
+                        required:
+                        - resource
+                        - value
+                        type: object
+                      type: array
+                  type: object
                 webhooks:
                   description: WebHook secrets for build configs
                   items:

--- a/deploy/olm-catalog/kogito-cloud-operator/0.4.0/app_v1alpha1_kogitoapp_crd.yaml
+++ b/deploy/olm-catalog/kogito-cloud-operator/0.4.0/app_v1alpha1_kogitoapp_crd.yaml
@@ -85,6 +85,45 @@ spec:
                     be compiled to run on native mode when Runtime is quarkus. See:
                     https://www.graalvm.org/docs/reference-manual/aot-compilation/'
                   type: boolean
+                resources:
+                  description: Resources for build pods. Default limits are 1GB RAM/0.5
+                    cpu on jvm and 4GB RAM/1 cpu for native builds.
+                  properties:
+                    limits:
+                      items:
+                        properties:
+                          resource:
+                            description: Resource type like cpu and memory
+                            enum:
+                            - cpu
+                            - memory
+                            type: string
+                          value:
+                            description: Value of this resource in Kubernetes format
+                            type: string
+                        required:
+                        - resource
+                        - value
+                        type: object
+                      type: array
+                    requests:
+                      items:
+                        properties:
+                          resource:
+                            description: Resource type like cpu and memory
+                            enum:
+                            - cpu
+                            - memory
+                            type: string
+                          value:
+                            description: Value of this resource in Kubernetes format
+                            type: string
+                        required:
+                        - resource
+                        - value
+                        type: object
+                      type: array
+                  type: object
                 webhooks:
                   description: WebHook secrets for build configs
                   items:

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -17,10 +17,18 @@
 # runs end-2-end tests for the operator into a given namespace
 namespace=$1
 tag=$2
+native=$3
+maven_mirror=$4
 
 # creates the namespace
 oc create namespace ${namespace}
+# gives permissions
+oc create -f deploy/role.yaml
+oc create -f deploy/service_account.yaml
+oc create -f deploy/role_binding.yaml
+
 # performs the test
-DEBUG=true KOGITO_IMAGE_TAG=${tag} operator-sdk test local ./test/e2e --namespace ${namespace} --up-local --debug
+DEBUG=true KOGITO_IMAGE_TAG=${tag} NATIVE=${native} MAVEN_MIRROR_URL=${maven_mirror} operator-sdk test local ./test/e2e --namespace ${namespace} --up-local --debug --go-test-flags "-timeout 30m"
+
 # clean up
 oc delete namespace ${namespace}

--- a/pkg/apis/app/v1alpha1/kogitoapp_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoapp_types.go
@@ -90,6 +90,8 @@ type KogitoAppBuildObject struct {
 	ImageRuntime Image `json:"imageRuntime,omitempty"`
 	// Native indicates if the Kogito Service built should be compiled to run on native mode when Runtime is quarkus. See: https://www.graalvm.org/docs/reference-manual/aot-compilation/
 	Native bool `json:"native,omitempty"`
+	// Resources for build pods. Default limits are 1GB RAM/0.5 cpu on jvm and 4GB RAM/1 cpu for native builds.
+	Resources Resources `json:"resources,omitempty"`
 }
 
 // KogitoAppServiceObject Data to define the service of the kogito app

--- a/pkg/apis/app/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.deepcopy.go
@@ -226,6 +226,7 @@ func (in *KogitoAppBuildObject) DeepCopyInto(out *KogitoAppBuildObject) {
 	}
 	out.ImageS2I = in.ImageS2I
 	out.ImageRuntime = in.ImageRuntime
+	in.Resources.DeepCopyInto(&out.Resources)
 	return
 }
 

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -370,12 +370,18 @@ func schema_pkg_apis_app_v1alpha1_KogitoAppBuildObject(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resources for build pods. Default limits are 1GB RAM/0.5 cpu on jvm and 4GB RAM/1 cpu for native builds.",
+							Ref:         ref("github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Resources"),
+						},
+					},
 				},
 				Required: []string{"gitSource"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Env", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.GitSource", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Image", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.WebhookSecret"},
+			"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Env", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.GitSource", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Image", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Resources", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.WebhookSecret"},
 	}
 }
 

--- a/pkg/controller/kogitoapp/builder/build_config_s2i_test.go
+++ b/pkg/controller/kogitoapp/builder/build_config_s2i_test.go
@@ -1,0 +1,59 @@
+// Copyright 2019 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"testing"
+
+	buildv1 "github.com/openshift/api/build/v1"
+)
+
+func Test_getBCS2ILimitsAsIntString(t *testing.T) {
+	type args struct {
+		buildConfig *buildv1.BuildConfig
+	}
+	var tests = []struct {
+		name            string
+		args            args
+		wantLimitCPU    string
+		wantLimitMemory string
+	}{
+		{"With Limits", args{buildConfig: &buildv1.BuildConfig{
+			Spec: buildv1.BuildConfigSpec{
+				CommonSpec: buildv1.CommonSpec{
+					Resources: v1.ResourceRequirements{
+						Limits: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceCPU:    resource.MustParse("1"),
+							v1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+				},
+			},
+		}}, "1", "536870912"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLimitCPU, gotLimitMemory := getBCS2ILimitsAsIntString(tt.args.buildConfig)
+			if gotLimitCPU != tt.wantLimitCPU {
+				t.Errorf("getBCS2ILimitsAsIntString() gotLimitCPU = %v, want %v", gotLimitCPU, tt.wantLimitCPU)
+			}
+			if gotLimitMemory != tt.wantLimitMemory {
+				t.Errorf("getBCS2ILimitsAsIntString() gotLimitMemory = %v, want %v", gotLimitMemory, tt.wantLimitMemory)
+			}
+		})
+	}
+}

--- a/pkg/controller/kogitoapp/builder/deployment_config.go
+++ b/pkg/controller/kogitoapp/builder/deployment_config.go
@@ -75,7 +75,7 @@ func NewDeploymentConfig(kogitoApp *v1alpha1.KogitoApp, runnerBC *buildv1.BuildC
 							// this conversion will be removed in future versions
 							Env: shared.FromEnvToEnvVar(kogitoApp.Spec.Env),
 							// this conversion will be removed in future versions
-							Resources:       *shared.FromResourcesToResourcesRequirements(kogitoApp.Spec.Resources),
+							Resources:       shared.FromResourcesToResourcesRequirements(kogitoApp.Spec.Resources),
 							Image:           runnerBC.Spec.Output.To.Name,
 							ImagePullPolicy: corev1.PullAlways,
 						},

--- a/pkg/controller/kogitoapp/shared/utils.go
+++ b/pkg/controller/kogitoapp/shared/utils.go
@@ -37,14 +37,14 @@ func FromEnvToEnvVar(envs []v1alpha1.Env) (envVars []corev1.EnvVar) {
 }
 
 // FromResourcesToResourcesRequirements Convert the exposed data structure Resources to Kube Core ResourceRequirements
-func FromResourcesToResourcesRequirements(resources v1alpha1.Resources) (resReq *corev1.ResourceRequirements) {
+func FromResourcesToResourcesRequirements(resources v1alpha1.Resources) (resReq corev1.ResourceRequirements) {
 	if &resources == nil {
-		return nil
+		return corev1.ResourceRequirements{}
 	}
 	if len(resources.Limits) == 0 && len(resources.Requests) == 0 {
-		return &corev1.ResourceRequirements{}
+		return corev1.ResourceRequirements{}
 	}
-	resReq = &corev1.ResourceRequirements{}
+	resReq = corev1.ResourceRequirements{}
 	// only build what is need to not conflict with DeepCopy later
 	if len(resources.Limits) > 0 {
 		resReq.Limits = corev1.ResourceList{}
@@ -62,4 +62,14 @@ func FromResourcesToResourcesRequirements(resources v1alpha1.Resources) (resReq 
 	}
 
 	return resReq
+}
+
+// ContainsResource checks whether or not the resource is presented in resources
+func ContainsResource(resource v1alpha1.ResourceKind, resources []v1alpha1.ResourceMap) bool {
+	for _, res := range resources {
+		if res.Resource == resource {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-127

In this PR:

1. Fixed the resources used by s2i builds when deploying Kogito Runtime Services
2. Enhanced e2e tests to make it easy to verify build time

During my tests, the JVM builds (using `drools-quarkus-example` as benchmark) preformed really well with 1GB RAM and 0.5 CPUs.

For Native builds, things got really complicated and I had to raise memory to 4GB and CPU to 1 core. Unfortunately there isn't much to do since GraalVM is a resource killer.

Here's an illustration of the JVM build being limited:

![](https://i.ibb.co/v4BVwSw/Screenshot-2019-09-17-example-quarkus-builder-1-Details-Red-Hat-Open-Shift-Container-Platform.png)

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster