### PR TITLE
[KOGITO-130] - Fixing makefile e2e parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,9 @@ addheaders:
 	./hack/addheaders.sh
 
 .PHONY: run-e2e
+namespace = ""
+tag = ""
+native = "false"
+maven_mirror = ""
 run-e2e:
 	./hack/run-e2e.sh $(namespace) $(tag) $(native) $(maven_mirror)

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -20,12 +20,23 @@ tag=$2
 native=$3
 maven_mirror=$4
 
+if [ -z "$namespace" ]; then
+  echo "Please inform the namespace where the tests will run"
+  exit 1
+fi
+
+if [ -z "$tag" ]; then
+  echo "-------- tag is empty, assuming default from the Operator"
+fi
+
+echo "-------- Running e2e tests with namespace=${namespace}, tag=${tag}, native=${native} and maven_mirror=${maven_mirror}"
+
 # creates the namespace
 oc create namespace ${namespace}
 # gives permissions
-oc create -f deploy/role.yaml
-oc create -f deploy/service_account.yaml
-oc create -f deploy/role_binding.yaml
+oc create -f deploy/role.yaml -n ${namespace}
+oc create -f deploy/service_account.yaml -n ${namespace}
+oc create -f deploy/role_binding.yaml -n ${namespace}
 
 # performs the test
 DEBUG=true KOGITO_IMAGE_TAG=${tag} NATIVE=${native} MAVEN_MIRROR_URL=${maven_mirror} operator-sdk test local ./test/e2e --namespace ${namespace} --up-local --debug --go-test-flags "-timeout 30m"


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-130

@sutaakar as we talked, here a fix to the `Makefile` to treat correctly the passed parameters to the test script. 

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster