### PR TITLE
[KOGITO-376] - Removing 'LastSavedKogitoApp' to avoid marshall problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,5 @@ jobs:
       - run: go mod vendor
       - run: go fmt ./...
       - run: go vet ./...
-      # let's disable the cmd tests for now, should take a look at it on KOGITO-341
-      # not working on CircleCI
-      #- run: CGO_ENABLED=0 go test -mod=vendor ./cmd/... -count=1
+      - run: CGO_ENABLED=0 go test -mod=vendor ./cmd/... -count=1
       - run: CGO_ENABLED=0 go test -mod=vendor ./pkg/... -count=1

--- a/cmd/kogito/command/deploy/deploy_service.go
+++ b/cmd/kogito/command/deploy/deploy_service.go
@@ -209,7 +209,6 @@ func (i *deployCommand) Exec(cmd *cobra.Command, args []string) error {
 	if err := kubernetes.ResourceC(i.Client).Create(kogitoApp); err != nil {
 		return fmt.Errorf("Error while creating a new KogitoApp in the context: %v", err)
 	}
-	config.LastKogitoAppCreated = *kogitoApp
 	config.Namespace = kogitoApp.Namespace
 	config.Save()
 

--- a/cmd/kogito/command/deploy/deploy_service_test.go
+++ b/cmd/kogito/command/deploy/deploy_service_test.go
@@ -50,24 +50,36 @@ func Test_DeployCmd_CustomDeployment(t *testing.T) {
 								--build-limits cpu=1 --build-limits memory=1Gi --build-requests cpu=1,memory=2Gi`)
 	// clean up all the mess we did ^
 	cli = strings.Join(strings.Fields(cli), " ")
-	test.SetupCliTest(cli,
+	ctx := test.SetupCliTest(cli,
 		context.CommandFactory{BuildCommands: BuildCommands},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kogito"}},
 		&apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.KogitoAppCRDName}})
 	// start the test
 	_, _, err := test.ExecuteCli()
-	config := context.ReadConfig()
+	assert.NoError(t, err)
+
+	// the should be created, see the command above
+	kogitoApp := &v1alpha1.KogitoApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-drools",
+			Namespace: "kogito",
+		},
+	}
+
+	exist, err := kubernetes.ResourceC(ctx.Client).Fetch(kogitoApp)
+	assert.NoError(t, err)
+	assert.True(t, exist)
 
 	assert.NoError(t, err)
-	assert.NotNil(t, config.LastKogitoAppCreated)
-	assert.Equal(t, v1alpha1.QuarkusRuntimeType, config.LastKogitoAppCreated.Spec.Runtime)
-	assert.Contains(t, config.LastKogitoAppCreated.Spec.Resources.Limits, v1alpha1.ResourceMap{Resource: v1alpha1.ResourceCPU, Value: "1"})
-	assert.Contains(t, config.LastKogitoAppCreated.Spec.Resources.Requests, v1alpha1.ResourceMap{Resource: v1alpha1.ResourceMemory, Value: "1Gi"})
-	assert.Contains(t, config.LastKogitoAppCreated.Spec.Build.Resources.Limits, v1alpha1.ResourceMap{Resource: v1alpha1.ResourceCPU, Value: "1"})
-	assert.Contains(t, config.LastKogitoAppCreated.Spec.Build.Resources.Requests, v1alpha1.ResourceMap{Resource: v1alpha1.ResourceMemory, Value: "2Gi"})
-	assert.Equal(t, config.LastKogitoAppCreated.Spec.Build.ImageS2I.ImageStreamName, "myimage")
-	assert.Equal(t, config.LastKogitoAppCreated.Spec.Build.ImageRuntime.ImageStreamName, "myimage")
-	assert.Equal(t, config.LastKogitoAppCreated.Spec.Build.ImageRuntime.ImageStreamTag, "0.2")
+	assert.NotNil(t, kogitoApp)
+	assert.Equal(t, v1alpha1.QuarkusRuntimeType, kogitoApp.Spec.Runtime)
+	assert.Contains(t, kogitoApp.Spec.Resources.Limits, v1alpha1.ResourceMap{Resource: v1alpha1.ResourceCPU, Value: "1"})
+	assert.Contains(t, kogitoApp.Spec.Resources.Requests, v1alpha1.ResourceMap{Resource: v1alpha1.ResourceMemory, Value: "1Gi"})
+	assert.Contains(t, kogitoApp.Spec.Build.Resources.Limits, v1alpha1.ResourceMap{Resource: v1alpha1.ResourceCPU, Value: "1"})
+	assert.Contains(t, kogitoApp.Spec.Build.Resources.Requests, v1alpha1.ResourceMap{Resource: v1alpha1.ResourceMemory, Value: "2Gi"})
+	assert.Equal(t, kogitoApp.Spec.Build.ImageS2I.ImageStreamName, "myimage")
+	assert.Equal(t, kogitoApp.Spec.Build.ImageRuntime.ImageStreamName, "myimage")
+	assert.Equal(t, kogitoApp.Spec.Build.ImageRuntime.ImageStreamTag, "0.2")
 }
 
 func Test_DeployCmd_CustomImage(t *testing.T) {


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-376

The problem here was a problem with an unmarshal feature from Viper when handling timestamps. Since we are not using the "saved" KogitoApp in the config file, I removed. Once we need a cache from the created CR, we can then handle the unmarshal problem and also only save the data that will be needed.

Also, I panic'ed all errors regarding manipulating the configuration file since it's being write/read in the user's home. If we got an error there, the command flow should interrupt right away to not spawn the bug to other features.

Now let's see the CI behavior.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster