### PR TITLE
[KOGITO-184] Script for Kogito CLI release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,10 @@ build:
 	./hack/go-build.sh
 
 .PHONY: build-cli
+release = false
+version = ""
 build-cli:
-	./hack/go-build-cli.sh
+	./hack/go-build-cli.sh $(release) $(version)
 
 .PHONY: install-cli
 install-cli:

--- a/vendor/github.com/google/uuid/go.mod
+++ b/vendor/github.com/google/uuid/go.mod
@@ -1,1 +1,3 @@
 module github.com/google/uuid
+
+go 1.12

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
@@ -1,1 +1,3 @@
 module github.com/konsorten/go-windows-terminal-sequences
+
+go 1.12

--- a/vendor/github.com/magiconair/properties/go.mod
+++ b/vendor/github.com/magiconair/properties/go.mod
@@ -1,1 +1,3 @@
 module github.com/magiconair/properties
+
+go 1.12

--- a/vendor/github.com/mitchellh/go-homedir/go.mod
+++ b/vendor/github.com/mitchellh/go-homedir/go.mod
@@ -1,1 +1,3 @@
 module github.com/mitchellh/go-homedir
+
+go 1.12

--- a/vendor/github.com/mitchellh/mapstructure/go.mod
+++ b/vendor/github.com/mitchellh/mapstructure/go.mod
@@ -1,1 +1,3 @@
 module github.com/mitchellh/mapstructure
+
+go 1.12

--- a/vendor/go.opencensus.io/go.mod
+++ b/vendor/go.opencensus.io/go.mod
@@ -7,6 +7,7 @@ require (
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd // indirect
 	golang.org/x/text v0.3.2 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb // indirect
 	google.golang.org/grpc v1.20.1
 )

--- a/vendor/gopkg.in/yaml.v2/go.mod
+++ b/vendor/gopkg.in/yaml.v2/go.mod
@@ -1,5 +1,3 @@
-module "gopkg.in/yaml.v2"
+module gopkg.in/yaml.v2
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/vendor/gopkg.in/yaml.v2/go.sum
+++ b/vendor/gopkg.in/yaml.v2/go.sum
@@ -1,0 +1,1 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-184

Small script to release the CLI bits.

@xiezhang7 @spolti  could you guys please take a look? 

```
 make build-cli release=true version=v0.5.0
```

Generates this:

```
ll build/_output/release/
total 52048
-rw-rw-r--. 1 ricferna ricferna 17754135 Oct 14 12:11 kogito-v0.5.0-darwin-amd64.tar.gz
-rw-rw-r--. 1 ricferna ricferna 17786332 Oct 14 12:11 kogito-v0.5.0-linux-amd64.tar.gz
-rw-rw-r--. 1 ricferna ricferna 17751530 Oct 14 12:11 kogito-v0.5.0-windows-amd64.zip
```

There's also mod's updates.