### PR TITLE
KOGITO-470: Kogito CLI cannot find operator template files when trying to install it into the namespace

### DIFF
--- a/hack/go-build-cli.sh
+++ b/hack/go-build-cli.sh
@@ -13,6 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+BASEDIR=`pwd`
+KOGITO_CMD_DIR="cmd/kogito"
+
+function packTemplateFiles(){
+  cd ${BASEDIR}/${KOGITO_CMD_DIR} && packr2 -v
+  cd ${BASEDIR}
+}
+
+function cleanTemplateFiles(){
+  cd ${BASEDIR}/${KOGITO_CMD_DIR} && packr2 clean -v
+  cd ${BASEDIR}
+}
+
 release=$1
 version=$2
 
@@ -36,14 +49,14 @@ if [ "$release" = "true" ]; then
   do
     rm -rf build/_output/bin/kogito
 
-    packr2 -v
+    packTemplateFiles
     CGO_ENABLED=0 GOOS="${i}" GOARCH="${arch}" go build -v -a -o build/_output/bin/kogito github.com/kiegroup/kogito-cloud-operator/cmd/kogito
     if [ $? -ne 0 ]; then
       echo "Failed to build for OS ${i} and Architecture ${arch}"
-      packr2 clean -v
+      cleanTemplateFiles 
       exit 1
     fi
-    packr2 clean -v
+    cleanTemplateFiles
 
     if [ "${i}" = "windows" ]; then
       zip -j "build/_output/release/kogito-${version}-${i}-${arch}.zip" build/_output/bin/kogito
@@ -59,9 +72,7 @@ if [ "$release" = "true" ]; then
   done
   echo "--- Finishing building Kogito CLI ${version}"
 else
-  packr2 -v
-
+  packTemplateFiles
   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -a -o build/_output/bin/kogito github.com/kiegroup/kogito-cloud-operator/cmd/kogito
-
-  packr2 clean -v
+  cleanTemplateFiles
 fi


### PR DESCRIPTION
https://issues.jboss.org/browse/KOGITO-470

Corrected inclusion of template files into kogito cli binaries.

Many thanks for submiting your Pull Request :heart:! 
Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster