### PR TITLE
[KOGITO-485] Small patch for the Kogito CLI 0.5.1 release

### DIFF
--- a/cmd/kogito/command/context/root.go
+++ b/cmd/kogito/command/context/root.go
@@ -15,7 +15,7 @@
 package context
 
 import (
-	"github.com/kiegroup/kogito-cloud-operator/version"
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/version"
 	"github.com/spf13/cobra"
 	"io"
 )

--- a/cmd/kogito/version/version.go
+++ b/cmd/kogito/version/version.go
@@ -1,0 +1,20 @@
+// Copyright 2019 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+var (
+	// Version of Kogito CLI
+	Version = "0.5.1"
+)


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-485

Small workaround to have the `kogito --version` to display the correct version. 

To have more context, please refer to the JIRA

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster