### PR TITLE
[KOGITO-494] Injecting KOGITO_DATAINDEX_URL in kogito runtime services

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ Change log level at runtime with the `DEBUG` environment variable. e.g. -
 ```bash
 $ make mod
 $ make clean
-$ DEBUG="true" operator-sdk up local --namespace=<namespace>
+$ DEBUG=true operator-sdk up local --namespace=<namespace>
 ```
 
 Before submitting PR, please be sure to read the [contributors guide](docs/CONTRIBUTING.MD).

--- a/cmd/kogito/command/test/common.go
+++ b/cmd/kogito/command/test/common.go
@@ -16,17 +16,16 @@ package test
 
 import (
 	"bytes"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
 	"github.com/spf13/cobra"
 	"path/filepath"
 	"strings"
 
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
-	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/util"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var (
@@ -45,8 +44,7 @@ const (
 
 // SetupFakeKubeCli will create a fake kube client for your tests
 func SetupFakeKubeCli(initObjs ...runtime.Object) *client.Client {
-	s := meta.GetRegisteredSchema()
-	return &client.Client{ControlCli: fake.NewFakeClientWithScheme(s, initObjs...)}
+	return test.CreateFakeClient(initObjs, nil, nil)
 }
 
 // SetupCliTest creates the infrastructure for the CLI test

--- a/deploy/examples/data-index.yaml
+++ b/deploy/examples/data-index.yaml
@@ -1,0 +1,42 @@
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoDataIndex
+metadata:
+  name: kogito-data-index
+spec:
+  # If not informed, these default values will be set for you
+  name: "kogito-data-index"
+  # environment variables to set in the runtime container. Example: JAVA_OPTIONS: "-Dquarkus.log.level=DEBUG"
+  #env:
+    # - name: JAVA_OPTIONS
+    #    value: "-Dquarkus.log.level=DEBUG"
+  # number of pods to be deployed
+  replicas: 1
+  # image to use for this deploy
+  image: "quay.io/kiegroup/kogito-data-index:latest"
+  # Limits and requests for the Data Index pod
+  memoryLimit: ""
+  memoryRequest: ""
+  cpuLimit: ""
+  cpuRequest: ""
+  # details about the kafka connection
+  kafka:
+    # the service name and port for the kafka cluster. Example: my-kafka-cluster:9092
+    serviceURI: my-cluster-kafka-bootstrap:9092
+  # details about the connected infinispan
+  infinispan:
+    # name of the auth realm. "default" is the realm name for
+    #authRealm: ""
+    # default to PLAIN
+    #saslMechanism: ""
+    # the service name and port of the infinispan cluster. Example: my-infinispan:11222
+    serviceURI: infinispan-server:11222
+      # will automatically set to true if the credentials are set
+      #useAuth: false
+      # auth credentials
+      #credentials:
+      # the secret used to store the Infinispan credentials
+      #secretName: ""
+      # username key defined in the secret to read from
+      #usernameKey: ""
+      # password key defined in the secret
+    #passwordKey: ""

--- a/deploy/examples/jbpm-quarkus-example.yaml
+++ b/deploy/examples/jbpm-quarkus-example.yaml
@@ -1,0 +1,13 @@
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoApp
+metadata:
+  name: example-quarkus
+spec:
+  build:
+    gitSource:
+      contextDir: jbpm-quarkus-example
+      uri: 'https://github.com/kiegroup/kogito-examples'
+    imageRuntime:
+      imageStreamTag: 0.5.0
+    imageS2I:
+      imageStreamTag: 0.5.0

--- a/pkg/apis/app/v1alpha1/kogitoapp_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoapp_types.go
@@ -185,6 +185,8 @@ const (
 type ReasonType string
 
 const (
+	// ServicesIntegrationFailedReason - Unable to inject external services to KogitoApp
+	ServicesIntegrationFailedReason ReasonType = "ServicesIntegrationFailed"
 	// ParseCRRequestFailedReason - Unable to resolve the CR request
 	ParseCRRequestFailedReason ReasonType = "ParseCRRequestFailed"
 	// RetrieveDeployedResourceFailedReason - Unable to retrieve the deployed resources

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -122,7 +122,7 @@ func buildKubeConnectionConfig() (*restclient.Config, error) {
 }
 
 func getKubeConfigFile() string {
-	kubeconfig := util.GetEnv(envVarKubeConfig, "")
+	kubeconfig := util.GetOSEnv(envVarKubeConfig, "")
 	if len(kubeconfig) > 0 {
 		log.Debugf("Kube config file read from %s environment variable: %s", envVarKubeConfig, kubeconfig)
 		return kubeconfig

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -24,7 +24,7 @@ import (
 
 func Test_getKubeConfigFile(t *testing.T) {
 	// safe backup to not jeopardize user's envs
-	oldEnvVar := util.GetEnv(envVarKubeConfig, "")
+	oldEnvVar := util.GetOSEnv(envVarKubeConfig, "")
 	tempEnvConfig := "/tmp/config"
 	defer func() {
 		os.Setenv(envVarKubeConfig, oldEnvVar)

--- a/pkg/client/meta/meta.go
+++ b/pkg/client/meta/meta.go
@@ -108,6 +108,10 @@ func GetRegisteredSchema() *runtime.Scheme {
 	s.AddKnownTypes(rbac.SchemeGroupVersion, &rbac.Role{}, &rbac.RoleBinding{})
 	s.AddKnownTypes(apiextensionsv1beta1.SchemeGroupVersion, &apiextensionsv1beta1.CustomResourceDefinition{})
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.KogitoApp{}, &v1alpha1.KogitoAppList{}, &v1alpha1.KogitoDataIndex{}, &v1alpha1.KogitoDataIndexList{})
+	s.AddKnownTypes(appsv1.GroupVersion, &appsv1.DeploymentConfig{}, &appsv1.DeploymentConfigList{})
+	s.AddKnownTypes(buildv1.GroupVersion, &buildv1.BuildConfig{})
+	s.AddKnownTypes(routev1.GroupVersion, &routev1.Route{})
+	s.AddKnownTypes(imgv1.GroupVersion, &imgv1.ImageStreamTag{}, &imgv1.ImageStream{})
 	s.AddKnownTypes(operatormkt.SchemeGroupVersion, &operatormkt.OperatorSource{}, &operatormkt.OperatorSourceList{})
 	// After upgrading to Operator SDK 0.11.0 we need to add CreateOptions to our own schema. See: https://issues.jboss.org/browse/KOGITO-493
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &metav1.CreateOptions{})

--- a/pkg/controller/kogitoapp/test/crd_validation_test.go
+++ b/pkg/controller/kogitoapp/test/crd_validation_test.go
@@ -45,7 +45,10 @@ func TestExampleCustomResources(t *testing.T) {
 		assert.NoError(t, err, "Error reading %v CR yaml", file)
 		var input map[string]interface{}
 		assert.NoError(t, yaml.Unmarshal([]byte(yamlString), &input))
-		assert.NoError(t, schema.Validate(input), "File %v does not validate against the CRD schema", file)
+		// only validates KogitoApp. TODO: add support for others CRDs
+		if input["kind"] == "KogitoApp" {
+			assert.NoError(t, schema.Validate(input), "File %v does not validate against the CRD schema", file)
+		}
 	}
 }
 

--- a/pkg/controller/kogitodataindex/kogitodataindex_controller.go
+++ b/pkg/controller/kogitodataindex/kogitodataindex_controller.go
@@ -16,6 +16,7 @@ package kogitodataindex
 
 import (
 	"fmt"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
 	"time"
 
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
@@ -129,6 +130,12 @@ type ReconcileKogitoDataIndex struct {
 func (r *ReconcileKogitoDataIndex) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.With("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling KogitoDataIndex")
+
+	// If it's an exclusion, the Data Index won't exist anymore. Routes need to be cleaned.
+	reqLogger.Infof("Injecting Data Index URL into KogitoApps in the namespace '%s'", request.Namespace)
+	if err := infrastructure.InjectDataIndexURLIntoKogitoApps(r.client, request.Namespace); err != nil {
+		return reconcile.Result{}, err
+	}
 
 	instances := &appv1alpha1.KogitoDataIndexList{}
 	if err := kubernetes.ResourceC(r.client).ListWithNamespace(request.Namespace, instances); err != nil {

--- a/pkg/controller/kogitodataindex/kogitodataindex_controller_test.go
+++ b/pkg/controller/kogitodataindex/kogitodataindex_controller_test.go
@@ -15,6 +15,7 @@
 package kogitodataindex
 
 import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
 	"testing"
 
 	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
@@ -35,10 +36,10 @@ func TestReconcileKogitoDataIndex_Reconcile(t *testing.T) {
 		},
 		Spec: v1alpha1.KogitoDataIndexSpec{},
 	}
-	client, s := test.CreateFakeClient([]runtime.Object{instance}, nil, nil)
+	client := test.CreateFakeClient([]runtime.Object{instance}, nil, nil)
 	r := &ReconcileKogitoDataIndex{
 		client: client,
-		scheme: s,
+		scheme: meta.GetRegisteredSchema(),
 	}
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/controller/kogitodataindex/resource/manage_resources_test.go
+++ b/pkg/controller/kogitodataindex/resource/manage_resources_test.go
@@ -43,7 +43,7 @@ func Test_ManageResources_WhenKafkaURIIsChanged(t *testing.T) {
 	cm := newProtobufConfigMap(instance)
 	secret := &corev1.Secret{}
 	statefulset := newStatefulset(instance, cm, *secret)
-	client, _ := test.CreateFakeClient([]runtime.Object{instance, cm, statefulset, secret}, nil, nil)
+	client := test.CreateFakeClient([]runtime.Object{instance, cm, statefulset, secret}, nil, nil)
 
 	err := ManageResources(instance, &KogitoDataIndexResources{StatefulSet: statefulset, ProtoBufConfigMap: cm}, client)
 	assert.NoError(t, err)
@@ -82,7 +82,7 @@ func Test_ManageResources_WhenWeChangeInfinispanVars(t *testing.T) {
 		},
 	}
 	statefulset := newStatefulset(instance, cm, *secret)
-	client, _ := test.CreateFakeClient([]runtime.Object{instance, cm, statefulset, secret}, nil, nil)
+	client := test.CreateFakeClient([]runtime.Object{instance, cm, statefulset, secret}, nil, nil)
 
 	// reconcile
 	err := ManageResources(instance, &KogitoDataIndexResources{StatefulSet: statefulset, ProtoBufConfigMap: cm}, client)
@@ -127,7 +127,7 @@ func Test_ManageResources_WhenTheresAMixOnEnvs(t *testing.T) {
 		Data: map[string][]byte{
 			"user": []byte(userBytes), "pass": []byte(passBytes),
 		}})
-	client, _ := test.CreateFakeClient([]runtime.Object{instance, cm, statefulset}, nil, nil)
+	client := test.CreateFakeClient([]runtime.Object{instance, cm, statefulset}, nil, nil)
 
 	// make sure that defaults were inserted
 	assert.Contains(t, statefulset.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
@@ -209,7 +209,7 @@ func Test_ensureProtoBufConfigMap(t *testing.T) {
 		},
 		Data: map[string]string{"file.proto": "this is a protofile"},
 	}
-	cli, _ := test.CreateFakeClient([]runtime.Object{dataIndex, cmWithFile}, nil, nil)
+	cli := test.CreateFakeClient([]runtime.Object{dataIndex, cmWithFile}, nil, nil)
 
 	// sanity check
 	assert.Len(t, cmWithFile.Data, 1)
@@ -243,7 +243,7 @@ func Test_ensureProtoBufConfigMap(t *testing.T) {
 		},
 	}
 
-	cli, _ = test.CreateFakeClient([]runtime.Object{dataIndex, cmWithFile, kogitoApp}, []runtime.Object{isTag}, nil)
+	cli = test.CreateFakeClient([]runtime.Object{dataIndex, cmWithFile, kogitoApp}, []runtime.Object{isTag}, nil)
 
 	ensureProtoBufConfigMap(dataIndex, cmWithFile, cli)
 	exist, err = kubernetes.ResourceC(cli).Fetch(cmWithFile)

--- a/pkg/controller/kogitodataindex/status/manage_status_test.go
+++ b/pkg/controller/kogitodataindex/status/manage_status_test.go
@@ -37,7 +37,7 @@ func Test_ManageStatus_WhenTheresStatusChange(t *testing.T) {
 			Replicas: 1,
 		},
 	}
-	client, _ := test.CreateFakeClient([]runtime.Object{instance}, nil, nil)
+	client := test.CreateFakeClient([]runtime.Object{instance}, nil, nil)
 	resources, err := resource.CreateOrFetchResources(instance, commonres.FactoryContext{Client: client})
 	assert.NoError(t, err)
 

--- a/pkg/infrastructure/integration.go
+++ b/pkg/infrastructure/integration.go
@@ -1,0 +1,76 @@
+// Copyright 2019 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/logger"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/util"
+)
+
+var log = logger.GetLogger("integration_kogitoapp")
+
+const (
+	kogitoDataIndexRouteEnv = "KOGITO_DATAINDEX_URL"
+)
+
+// InjectDataIndexURLIntoKogitoApps will query for every KogitoApp in the given namespace to inject the Data Index route to each one
+// Won't trigger an update if the KogitoApp already has the route set to avoid unnecessary reconciliation triggers
+func InjectDataIndexURLIntoKogitoApps(client *client.Client, namespace string) error {
+	log.Debugf("Querying KogitoApps in the namespace '%s' to inject Data Index Route ", namespace)
+	kogitoApps := &v1alpha1.KogitoAppList{}
+	if err := kubernetes.ResourceC(client).ListWithNamespace(namespace, kogitoApps); err != nil {
+		return err
+	}
+	route := ""
+	log.Debugf("Found %s KogitoApps in the namespace '%s' ", kogitoApps.Items, namespace)
+	if len(kogitoApps.Items) > 0 {
+		log.Debug("Querying Data Index route to inject into KogitoApps ")
+		var err error
+		route, err = getKogitoDataIndexRoute(client, namespace)
+		if err != nil {
+			return err
+		}
+		log.Debugf("Data Index route is '%s'", route)
+	}
+	for _, kogitoApp := range kogitoApps.Items {
+		// here we compare the current value to avoid updating the app evey time
+		oldRoute := util.GetEnvValue(kogitoDataIndexRouteEnv, kogitoApp.Spec.Env)
+		if oldRoute != route {
+			log.Debugf("Updating kogitoApp '%s' to inject route %s ", kogitoApp.GetName(), route)
+			kogitoApp.Spec.Env = util.AppendOrReplaceEnv(v1alpha1.Env{Name: kogitoDataIndexRouteEnv, Value: route}, kogitoApp.Spec.Env)
+			if err := kubernetes.ResourceC(client).Update(&kogitoApp); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// InjectEnvVarsFromExternalServices inject environment variables from external services that the KogitoApp runtime might need
+func InjectEnvVarsFromExternalServices(kogitoApp *v1alpha1.KogitoApp, client *client.Client) error {
+	log.Debugf("Querying Data Index route to inject into KogitoApp: %s", kogitoApp.GetName())
+	// We look for a deployed data index to inject into the runtime service
+	// later we could also integrate with other external services like Kafka, Infinispan and SSO
+	route, err := getKogitoDataIndexRoute(client, kogitoApp.GetNamespace())
+	if err != nil {
+		return err
+	}
+	log.Debugf("Data Index route is '%s'", route)
+	kogitoApp.Spec.Env = util.AppendOrReplaceEnv(v1alpha1.Env{Name: kogitoDataIndexRouteEnv, Value: route}, kogitoApp.Spec.Env)
+	return nil
+}

--- a/pkg/infrastructure/integration_test.go
+++ b/pkg/infrastructure/integration_test.go
@@ -1,0 +1,130 @@
+// Copyright 2019 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_InjectEnvironmentVarsFromExternalServices(t *testing.T) {
+	ns := t.Name()
+	name := "my-kogito-app"
+	expectedRoute := "http://dataindex-route.com"
+
+	kogitoApp := &v1alpha1.KogitoApp{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+	dataIndexes := &v1alpha1.KogitoDataIndexList{
+		Items: []v1alpha1.KogitoDataIndex{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kogito-data-index",
+					Namespace: ns,
+				},
+				Status: v1alpha1.KogitoDataIndexStatus{
+					Route: expectedRoute,
+				},
+			},
+		},
+	}
+	client := test.CreateFakeClient([]runtime.Object{kogitoApp, dataIndexes}, nil, nil)
+	err := InjectEnvVarsFromExternalServices(kogitoApp, client)
+	assert.NoError(t, err)
+	assert.Contains(t, kogitoApp.Spec.Env, v1alpha1.Env{Name: kogitoDataIndexRouteEnv, Value: expectedRoute})
+}
+
+func Test_InjectEnvironmentVarsFromExternalServices_NewRoute(t *testing.T) {
+	ns := t.Name()
+	name := "my-kogito-app"
+	oldRoute := "http://dataindex-route.com"
+	expectedRoute := "http://dataindex-route2.com"
+
+	kogitoApp := &v1alpha1.KogitoApp{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: v1alpha1.KogitoAppSpec{
+			Env: []v1alpha1.Env{
+				{
+					Name:  kogitoDataIndexRouteEnv,
+					Value: oldRoute,
+				},
+			},
+		},
+	}
+	dataIndexes := &v1alpha1.KogitoDataIndexList{
+		Items: []v1alpha1.KogitoDataIndex{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kogito-data-index",
+					Namespace: ns,
+				},
+				Status: v1alpha1.KogitoDataIndexStatus{
+					Route: expectedRoute,
+				},
+			},
+		},
+	}
+	client := test.CreateFakeClient([]runtime.Object{kogitoApp, dataIndexes}, nil, nil)
+	err := InjectEnvVarsFromExternalServices(kogitoApp, client)
+	assert.NoError(t, err)
+	assert.Contains(t, kogitoApp.Spec.Env, v1alpha1.Env{Name: kogitoDataIndexRouteEnv, Value: expectedRoute})
+}
+
+func TestInjectDataIndexURLIntoKogitoApps(t *testing.T) {
+	ns := t.Name()
+	name := "my-kogito-app"
+	expectedRoute := "http://dataindex-route.com"
+	kogitoApp := &v1alpha1.KogitoApp{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+	dataIndexes := &v1alpha1.KogitoDataIndexList{
+		Items: []v1alpha1.KogitoDataIndex{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kogito-data-index",
+					Namespace: ns,
+				},
+				Status: v1alpha1.KogitoDataIndexStatus{
+					Route: expectedRoute,
+				},
+			},
+		},
+	}
+	client := test.CreateFakeClient([]runtime.Object{kogitoApp, dataIndexes}, nil, nil)
+
+	err := InjectDataIndexURLIntoKogitoApps(client, ns)
+	assert.NoError(t, err)
+
+	exist, err := kubernetes.ResourceC(client).Fetch(kogitoApp)
+	assert.NoError(t, err)
+	assert.True(t, exist)
+	assert.Contains(t, kogitoApp.Spec.Env, v1alpha1.Env{Name: kogitoDataIndexRouteEnv, Value: expectedRoute})
+}

--- a/pkg/infrastructure/kogito_data_index.go
+++ b/pkg/infrastructure/kogito_data_index.go
@@ -12,40 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package infrastructure
 
 import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
-	"reflect"
-	"testing"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
 )
 
-func Test_EnvToMap(t *testing.T) {
-	type args struct {
-		env []v1alpha1.Env
+// getKogitoDataIndexRoute gets the deployed data index route
+func getKogitoDataIndexRoute(client *client.Client, namespace string) (string, error) {
+	route := ""
+	dataIndexes := &v1alpha1.KogitoDataIndexList{}
+	if err := kubernetes.ResourceC(client).ListWithNamespace(namespace, dataIndexes); err != nil {
+		return route, err
 	}
-	tests := []struct {
-		name string
-		args args
-		want map[string]string
-	}{
-		{"TestEnvToMap",
-			args{
-				[]v1alpha1.Env{
-					{Name: "test1", Value: "test1"},
-					{Name: "test2", Value: "test2"},
-				}},
-			map[string]string{
-				"test1": "test1",
-				"test2": "test2",
-			},
-		},
+	if len(dataIndexes.Items) > 0 {
+		// should be only one data index guaranteed by OLM, but still we are looking for the first one
+		route = dataIndexes.Items[0].Status.Route
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := EnvToMap(tt.args.env); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("envToMap() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	return route, nil
 }

--- a/pkg/infrastructure/kogito_data_index_test.go
+++ b/pkg/infrastructure/kogito_data_index_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/test"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func Test_getKogitoDataIndexRoute(t *testing.T) {
+	ns := t.Name()
+	expectedRoute := "http://dataindex-route.com"
+	dataIndexes := &v1alpha1.KogitoDataIndexList{
+		Items: []v1alpha1.KogitoDataIndex{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kogito-data-index",
+					Namespace: ns,
+				},
+				Status: v1alpha1.KogitoDataIndexStatus{
+					Route: expectedRoute,
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "kogito-data-index2",
+					Namespace: ns,
+				},
+				Status: v1alpha1.KogitoDataIndexStatus{
+					Route: "",
+				},
+			},
+		},
+	}
+	cli := test.SetupFakeKubeCli(dataIndexes)
+
+	route, err := getKogitoDataIndexRoute(cli, ns)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedRoute, route)
+}
+
+func Test_getKogitoDataIndexRoute_NoDataIndex(t *testing.T) {
+	cli := test.SetupFakeKubeCli()
+	route, err := getKogitoDataIndexRoute(cli, t.Name())
+	assert.NoError(t, err)
+	assert.Empty(t, route)
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -66,7 +66,7 @@ func GetLogger(name string) *zap.SugaredLogger {
 
 func getDefaultOpts() *Opts {
 	return &Opts{
-		Verbose: util.GetBoolEnv("DEBUG"),
+		Verbose: util.GetBoolOSEnv("DEBUG"),
 		Output:  defaultOutput,
 		Console: false,
 	}
@@ -79,13 +79,15 @@ func getLogger(name string, options *Opts) *zap.SugaredLogger {
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
 	logger := createLogger(options)
-	logger.Logger = logf.Log.WithName(name)
+	//logger.Logger = logf.Log.WithName(name)
 	return logger.SugaredLogger.Named(name)
 }
 
 func createLogger(options *Opts) (logger Logger) {
 	log := Logger{
-		Logger:        logzap.Logger(options.Verbose),
+		Logger: logzap.New(func(opts *logzap.Options) {
+			opts.Development = options.Verbose
+		}),
 		SugaredLogger: zapSugaredLogger(options),
 	}
 	defer log.SugaredLogger.Sync()

--- a/pkg/util/env_var.go
+++ b/pkg/util/env_var.go
@@ -52,3 +52,110 @@ func MapToEnvVar(env map[string]string) (envVars []corev1.EnvVar) {
 
 	return envVars
 }
+
+// GetEnvVar returns the position of the EnvVar found by name
+func GetEnvVar(envName string, env []corev1.EnvVar) int {
+	for pos, v := range env {
+		if v.Name == envName {
+			return pos
+		}
+	}
+	return -1
+}
+
+// EnvOverride replaces or appends the provided EnvVar to the collection
+func EnvOverride(dst []corev1.EnvVar, src ...corev1.EnvVar) []corev1.EnvVar {
+	for _, cre := range src {
+		pos := GetEnvVar(cre.Name, dst)
+		if pos != -1 {
+			dst[pos] = cre
+		} else {
+			dst = append(dst, cre)
+		}
+	}
+	return dst
+}
+
+//FromMapToEnvVar converts a map[string]string in the format KEY=VALUE into a EnvVar Kubernetes object
+func FromMapToEnvVar(mapEnv map[string]string) []corev1.EnvVar {
+	var envs []corev1.EnvVar
+
+	for key, value := range mapEnv {
+		envs = append(envs, corev1.EnvVar{
+			Name:  key,
+			Value: value,
+		})
+	}
+
+	return envs
+}
+
+// FromEnvVarToMap will convert EnvVar resource to a Map definition
+func FromEnvVarToMap(envs []corev1.EnvVar) map[string]string {
+	envMap := map[string]string{}
+
+	for _, env := range envs {
+		envMap[env.Name] = env.Value
+	}
+
+	return envMap
+}
+
+// GetEnvVarFromContainer get the environment variable from the container
+func GetEnvVarFromContainer(key string, container corev1.Container) string {
+	if &container == nil {
+		return ""
+	}
+
+	for _, env := range container.Env {
+		if env.Name == key {
+			return env.Value
+		}
+	}
+
+	return ""
+}
+
+// SetEnvVar will update or add the environment variable into the given container
+func SetEnvVar(key, value string, container *corev1.Container) {
+	if container == nil {
+		return
+	}
+
+	for i, env := range container.Env {
+		if env.Name == key {
+			container.Env[i].Value = value
+			return
+		}
+	}
+
+	container.Env = append(container.Env, corev1.EnvVar{Name: key, Value: value})
+}
+
+// EnvVarCheck checks whether the src and dst []EnvVar have the same values
+func EnvVarCheck(dst, src []corev1.EnvVar) bool {
+	for _, denv := range dst {
+		if !envVarEqual(denv, src) {
+			return false
+		}
+	}
+	for _, senv := range src {
+		if !envVarEqual(senv, dst) {
+			return false
+		}
+	}
+	return true
+}
+
+func envVarEqual(env corev1.EnvVar, envList []corev1.EnvVar) bool {
+	match := false
+	for _, e := range envList {
+		if env.Name == e.Name {
+			if env.Value == e.Value {
+				match = true
+				break
+			}
+		}
+	}
+	return match
+}

--- a/pkg/util/env_var_test.go
+++ b/pkg/util/env_var_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"reflect"
 	"testing"
@@ -154,4 +155,76 @@ func TestEnvVarArrayEquals(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEnvOverride(t *testing.T) {
+	src := []corev1.EnvVar{
+		{
+			Name:  "test1",
+			Value: "value1",
+		},
+		{
+			Name:  "test2",
+			Value: "value2",
+		},
+	}
+	dst := []corev1.EnvVar{
+		{
+			Name:  "test1",
+			Value: "valueX",
+		},
+		{
+			Name:  "test3",
+			Value: "value3",
+		},
+	}
+	result := EnvOverride(dst, src...)
+	assert.Equal(t, 3, len(result))
+	assert.Equal(t, result[0], dst[0])
+	assert.Equal(t, result[1], dst[1])
+	assert.Equal(t, result[2], src[1])
+}
+
+func TestGetEnvVar(t *testing.T) {
+	vars := []corev1.EnvVar{
+		{
+			Name:  "test1",
+			Value: "value1",
+		},
+		{
+			Name:  "test2",
+			Value: "value2",
+		},
+	}
+	pos := GetEnvVar("test1", vars)
+	assert.Equal(t, 0, pos)
+
+	pos = GetEnvVar("other", vars)
+	assert.Equal(t, -1, pos)
+}
+
+func TestEnvVarCheck(t *testing.T) {
+	empty := []corev1.EnvVar{}
+	a := []corev1.EnvVar{
+		{Name: "A", Value: "1"},
+	}
+	b := []corev1.EnvVar{
+		{Name: "A", Value: "2"},
+	}
+	c := []corev1.EnvVar{
+		{Name: "A", Value: "1"},
+		{Name: "B", Value: "1"},
+	}
+
+	assert.True(t, EnvVarCheck(empty, empty))
+	assert.True(t, EnvVarCheck(a, a))
+
+	assert.False(t, EnvVarCheck(empty, a))
+	assert.False(t, EnvVarCheck(a, empty))
+
+	assert.False(t, EnvVarCheck(a, b))
+	assert.False(t, EnvVarCheck(b, a))
+
+	assert.False(t, EnvVarCheck(a, c))
+	assert.False(t, EnvVarCheck(c, b))
 }

--- a/pkg/util/envs.go
+++ b/pkg/util/envs.go
@@ -15,14 +15,13 @@
 package util
 
 import (
-	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	"os"
 	"strconv"
 )
 
-// GetBoolEnv gets a env variable as a boolean
-func GetBoolEnv(key string) bool {
-	val := GetEnv(key, "false")
+// GetBoolOSEnv gets a env variable as a boolean
+func GetBoolOSEnv(key string) bool {
+	val := GetOSEnv(key, "false")
 	ret, err := strconv.ParseBool(val)
 	if err != nil {
 		return false
@@ -30,8 +29,8 @@ func GetBoolEnv(key string) bool {
 	return ret
 }
 
-// GetEnv gets a env variable
-func GetEnv(key, fallback string) string {
+// GetOSEnv gets a env variable
+func GetOSEnv(key, fallback string) string {
 	value, exists := os.LookupEnv(key)
 	if !exists {
 		value = fallback
@@ -45,15 +44,4 @@ func GetHomeDir() string {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
-}
-
-// EnvToMap converts an array of Env to a map
-func EnvToMap(env []v1alpha1.Env) map[string]string {
-	envMap := map[string]string{}
-
-	for _, e := range env {
-		envMap[e.Name] = e.Value
-	}
-
-	return envMap
 }

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -14,113 +14,42 @@
 
 package util
 
-import (
-	corev1 "k8s.io/api/core/v1"
-)
+import "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 
-// GetEnvVar returns the position of the EnvVar found by name
-func GetEnvVar(envName string, env []corev1.EnvVar) int {
-	for pos, v := range env {
-		if v.Name == envName {
-			return pos
-		}
-	}
-	return -1
-}
-
-// EnvOverride replaces or appends the provided EnvVar to the collection
-func EnvOverride(dst []corev1.EnvVar, src ...corev1.EnvVar) []corev1.EnvVar {
-	for _, cre := range src {
-		pos := GetEnvVar(cre.Name, dst)
-		if pos != -1 {
-			dst[pos] = cre
-		} else {
-			dst = append(dst, cre)
-		}
-	}
-	return dst
-}
-
-//FromMapToEnvVar converts a map[string]string in the format KEY=VALUE into a EnvVar Kubernetes object
-func FromMapToEnvVar(mapEnv map[string]string) []corev1.EnvVar {
-	var envs []corev1.EnvVar
-
-	for key, value := range mapEnv {
-		envs = append(envs, corev1.EnvVar{
-			Name:  key,
-			Value: value,
-		})
-	}
-
-	return envs
-}
-
-// FromEnvVarToMap will convert EnvVar resource to a Map definition
-func FromEnvVarToMap(envs []corev1.EnvVar) map[string]string {
+// EnvToMap converts an array of Env to a map
+func EnvToMap(env []v1alpha1.Env) map[string]string {
 	envMap := map[string]string{}
 
-	for _, env := range envs {
-		envMap[env.Name] = env.Value
+	for _, e := range env {
+		envMap[e.Name] = e.Value
 	}
 
 	return envMap
 }
 
-// GetEnvVarFromContainer get the environment variable from the container
-func GetEnvVarFromContainer(key string, container corev1.Container) string {
-	if &container == nil {
-		return ""
+// AppendOrReplaceEnv add a new env or replace the exist one
+func AppendOrReplaceEnv(env v1alpha1.Env, envs []v1alpha1.Env) []v1alpha1.Env {
+	if envs == nil {
+		envs = []v1alpha1.Env{}
 	}
 
-	for _, env := range container.Env {
-		if env.Name == key {
-			return env.Value
+	for pos, e := range envs {
+		if e.Name == env.Name {
+			envs[pos] = env
+			return envs
 		}
 	}
 
+	envs = append(envs, env)
+	return envs
+}
+
+// GetEnvValue gets the value from the env by it's key
+func GetEnvValue(key string, envs []v1alpha1.Env) string {
+	for _, e := range envs {
+		if e.Name == key {
+			return e.Value
+		}
+	}
 	return ""
-}
-
-// SetEnvVar will update or add the environment variable into the given container
-func SetEnvVar(key, value string, container *corev1.Container) {
-	if container == nil {
-		return
-	}
-
-	for i, env := range container.Env {
-		if env.Name == key {
-			container.Env[i].Value = value
-			return
-		}
-	}
-
-	container.Env = append(container.Env, corev1.EnvVar{Name: key, Value: value})
-}
-
-// EnvVarCheck checks whether the src and dst []EnvVar have the same values
-func EnvVarCheck(dst, src []corev1.EnvVar) bool {
-	for _, denv := range dst {
-		if !envVarEqual(denv, src) {
-			return false
-		}
-	}
-	for _, senv := range src {
-		if !envVarEqual(senv, dst) {
-			return false
-		}
-	}
-	return true
-}
-
-func envVarEqual(env corev1.EnvVar, envList []corev1.EnvVar) bool {
-	match := false
-	for _, e := range envList {
-		if env.Name == e.Name {
-			if env.Value == e.Value {
-				match = true
-				break
-			}
-		}
-	}
-	return match
 }

--- a/pkg/util/resources_test.go
+++ b/pkg/util/resources_test.go
@@ -15,80 +15,37 @@
 package util
 
 import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 )
 
-func TestEnvOverride(t *testing.T) {
-	src := []corev1.EnvVar{
-		{
-			Name:  "test1",
-			Value: "value1",
-		},
-		{
-			Name:  "test2",
-			Value: "value2",
-		},
+func Test_EnvToMap(t *testing.T) {
+	type args struct {
+		env []v1alpha1.Env
 	}
-	dst := []corev1.EnvVar{
-		{
-			Name:  "test1",
-			Value: "valueX",
-		},
-		{
-			Name:  "test3",
-			Value: "value3",
-		},
-	}
-	result := EnvOverride(dst, src...)
-	assert.Equal(t, 3, len(result))
-	assert.Equal(t, result[0], dst[0])
-	assert.Equal(t, result[1], dst[1])
-	assert.Equal(t, result[2], src[1])
-}
-
-func TestGetEnvVar(t *testing.T) {
-	vars := []corev1.EnvVar{
-		{
-			Name:  "test1",
-			Value: "value1",
-		},
-		{
-			Name:  "test2",
-			Value: "value2",
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{"TestEnvToMap",
+			args{
+				[]v1alpha1.Env{
+					{Name: "test1", Value: "test1"},
+					{Name: "test2", Value: "test2"},
+				}},
+			map[string]string{
+				"test1": "test1",
+				"test2": "test2",
+			},
 		},
 	}
-	pos := GetEnvVar("test1", vars)
-	assert.Equal(t, 0, pos)
-
-	pos = GetEnvVar("other", vars)
-	assert.Equal(t, -1, pos)
-}
-
-func TestEnvVarCheck(t *testing.T) {
-	empty := []corev1.EnvVar{}
-	a := []corev1.EnvVar{
-		{Name: "A", Value: "1"},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EnvToMap(tt.args.env); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("envToMap() = %v, want %v", got, tt.want)
+			}
+		})
 	}
-	b := []corev1.EnvVar{
-		{Name: "A", Value: "2"},
-	}
-	c := []corev1.EnvVar{
-		{Name: "A", Value: "1"},
-		{Name: "B", Value: "1"},
-	}
-
-	assert.True(t, EnvVarCheck(empty, empty))
-	assert.True(t, EnvVarCheck(a, a))
-
-	assert.False(t, EnvVarCheck(empty, a))
-	assert.False(t, EnvVarCheck(a, empty))
-
-	assert.False(t, EnvVarCheck(a, b))
-	assert.False(t, EnvVarCheck(b, a))
-
-	assert.False(t, EnvVarCheck(a, c))
-	assert.False(t, EnvVarCheck(c, b))
 }

--- a/test/e2e/customresources.go
+++ b/test/e2e/customresources.go
@@ -35,7 +35,7 @@ func getKogitoServiceStub(appName string, namespace string) *v1alpha1.KogitoApp 
 			Build: &v1alpha1.KogitoAppBuildObject{
 				Env: []v1alpha1.Env{v1alpha1.Env{
 					Name:  "MAVEN_MIRROR_URL",
-					Value: util.GetEnv("MAVEN_MIRROR_URL", ""),
+					Value: util.GetOSEnv("MAVEN_MIRROR_URL", ""),
 				}},
 				GitSource: &v1alpha1.GitSource{},
 			},

--- a/test/e2e/kogitoapp_test.go
+++ b/test/e2e/kogitoapp_test.go
@@ -56,7 +56,7 @@ func TestKogitoApp(t *testing.T) {
 	}
 
 	// Specifies what tests should be executed
-	tests := util.GetEnv("TESTS", "full")
+	tests := util.GetOSEnv("TESTS", "full")
 	if tests == "jvm" {
 		// Run just JVM tests
 		t.Run("kogitoapp", func(t *testing.T) {
@@ -151,7 +151,7 @@ func deployKogitoServiceApp(t *testing.T, kogitoService *v1alpha1.KogitoApp, f *
 		log.Fatal(err)
 	}
 	appName := kogitoService.Name
-	tag := util.GetEnv("KOGITO_IMAGE_TAG", resource.ImageStreamTag)
+	tag := util.GetOSEnv("KOGITO_IMAGE_TAG", resource.ImageStreamTag)
 	log.Infof("Using image tag %s", tag)
 
 	// set tags (used in devel for non-released versions)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,9 +34,9 @@ github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/coreos/prometheus-operator v0.33.0 => github.com/coreos/prometheus-operator v0.31.1
 github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1
 github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1
+github.com/coreos/prometheus-operator/pkg/client/versioned/fake
 github.com/coreos/prometheus-operator/pkg/apis/monitoring
 github.com/coreos/prometheus-operator/pkg/client/versioned/scheme
-github.com/coreos/prometheus-operator/pkg/client/versioned/fake
 github.com/coreos/prometheus-operator/pkg/client/versioned
 github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1/fake
 # github.com/davecgh/go-spew v1.1.1
@@ -577,7 +577,6 @@ k8s.io/utils/buffer
 k8s.io/utils/trace
 k8s.io/utils/integer
 # sigs.k8s.io/controller-runtime v0.2.2
-sigs.k8s.io/controller-runtime/pkg/client/fake
 sigs.k8s.io/controller-runtime/pkg/client/config
 sigs.k8s.io/controller-runtime/pkg/manager
 sigs.k8s.io/controller-runtime/pkg/manager/signals
@@ -591,10 +590,10 @@ sigs.k8s.io/controller-runtime/pkg/source
 sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
 sigs.k8s.io/controller-runtime/pkg/log
 sigs.k8s.io/controller-runtime/pkg/log/zap
+sigs.k8s.io/controller-runtime/pkg/client/fake
 sigs.k8s.io/controller-runtime/pkg/runtime/scheme
-sigs.k8s.io/controller-runtime/pkg/client/apiutil
-sigs.k8s.io/controller-runtime/pkg/internal/objectutil
 sigs.k8s.io/controller-runtime/pkg/internal/log
+sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/internal/recorder
 sigs.k8s.io/controller-runtime/pkg/leaderelection
 sigs.k8s.io/controller-runtime/pkg/metrics
@@ -607,6 +606,7 @@ sigs.k8s.io/controller-runtime/pkg/predicate
 sigs.k8s.io/controller-runtime/pkg/event
 sigs.k8s.io/controller-runtime/pkg/source/internal
 sigs.k8s.io/controller-runtime/pkg/cache/informertest
+sigs.k8s.io/controller-runtime/pkg/internal/objectutil
 sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/certwatcher
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-494

In this PR we introduce the `integration` package that will handle calls to the deployed infrastructure to inject service/URLs to the Kogito Runtime Services. For this JIRA, we're adding the Data Index route if one exists in the namespace.

Also, a small refactoring to the `CreateFakeClient` function to avoid repetition in the unit tests. If you need a mock kubernetes client, use this one from the `pkg/test` package.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster