### PR TITLE
KOGITO-558: Error when building operator: thrift used for two different places

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ replace (
 )
 
 // thrift moved to github
-replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+//replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
 
 // Pinned to kubernetes-1.14.1
 replace (
@@ -55,3 +55,5 @@ replace (
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
+
+go 1.13


### PR DESCRIPTION
https://issues.jboss.org/browse/KOGITO-558

Error:
github.com/apache/thrift@v0.12.0 used for two different module paths

Fix found: https://github.com/hashicorp/vault/issues/7475

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster