### PR TITLE
[KOGITO-504] - Increasing default limit to 2 CPUs and 2Gi for JVM

### DIFF
--- a/pkg/controller/kogitoapp/resource/build_config_s2i.go
+++ b/pkg/controller/kogitoapp/resource/build_config_s2i.go
@@ -40,13 +40,13 @@ const (
 
 var (
 	// DefaultBuildS2IJVMCPULimit is the default CPU limit for JVM s2i builds
-	DefaultBuildS2IJVMCPULimit = v1alpha1.ResourceMap{Resource: v1alpha1.ResourceCPU, Value: "500m"}
+	DefaultBuildS2IJVMCPULimit = v1alpha1.ResourceMap{Resource: v1alpha1.ResourceCPU, Value: "2"}
 	// DefaultBuildS2IJVMMemoryLimit is the default Memory limit for JVM s2i builds
-	DefaultBuildS2IJVMMemoryLimit = v1alpha1.ResourceMap{Resource: v1alpha1.ResourceMemory, Value: "1Gi"}
+	DefaultBuildS2IJVMMemoryLimit = v1alpha1.ResourceMap{Resource: v1alpha1.ResourceMemory, Value: "2Gi"}
 	// DefaultBuildS2IJVMLimits is the default resource limits for JVM s2i builds
 	DefaultBuildS2IJVMLimits = []v1alpha1.ResourceMap{DefaultBuildS2IJVMCPULimit, DefaultBuildS2IJVMMemoryLimit}
 	// DefaultBuildS2INativeCPULimit is the default CPU limit for Native s2i builds
-	DefaultBuildS2INativeCPULimit = v1alpha1.ResourceMap{Resource: v1alpha1.ResourceCPU, Value: "1"}
+	DefaultBuildS2INativeCPULimit = v1alpha1.ResourceMap{Resource: v1alpha1.ResourceCPU, Value: "2"}
 	// DefaultBuildS2INativeMemoryLimit is the default Memory limit for Native s2i builds
 	DefaultBuildS2INativeMemoryLimit = v1alpha1.ResourceMap{Resource: v1alpha1.ResourceMemory, Value: "10Gi"}
 	// DefaultBuildS2INativeLimits is the default resource limits for Native s2i builds


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-504

OCP 4.x is resource hungry for building from source. After some investigations, I opened this bug (https://bugzilla.redhat.com/show_bug.cgi?id=1768533) and increased the limit to handle the image puller/signature step for s2i builds.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster