### PR TITLE
[KOGITO-569] Inject all data index topics automatically from one kafk…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Table of Contents
       * [Deploy Data Index Service](#deploy-data-index-service)
          * [Deploy Infinispan](#deploy-infinispan)
          * [Deploy Strimzi](#deploy-strimzi)
+            * [Create Required Topics](#creating-required-topics)
          * [Install Data Index Service](#install-data-index-service)
             * [Retrieve Kafka and Infinispan internal urls](#retrieve-kafka-and-infinispan-internal-urls)
             * [Install Data Index Service with Kogito CLI](#install-data-index-service-with-kogito-cli)
@@ -298,9 +299,18 @@ my-cluster-zookeeper-nodes    ClusterIP   None             <none>        2181/TC
 
 The service you're interested in is `my-cluster-kafka-bootstrap:9092`. We will use it to deploy the Data Index Service later.
 
-Having the cluster up and running, the next step is creating the `Kafka Topic`s required by the Data Index Service: `kogito-processinstances-events` and `kogito-usertaskinstances-events`.
+#### Create Required Topics
 
-In the OpenShift Web Console, go to the Installed Operators, Strimzi Operator, Kafka Topic tab. From there, create a new `Kafka Topic` and name it as `kogito-processinstances-events` like in the example below:
+Having the cluster up and running, the next step is to create the `Kafka Topic`s required by the Data Index Service: 
+
+- `kogito-processinstances-events`
+- `kogito-usertaskinstances-events` 
+- `kogito-processdomain-events`
+- `kogito-usertaskdomain-events`
+
+To create the required topics, in the OpenShift Web Console go to the Installed Operators, Strimzi Operator, Kafka Topic tab. 
+
+From there, create a new `Kafka Topic` and name it as `kogito-processinstances-events` like in the example below:
 
 ```yaml
 apiVersion: kafka.strimzi.io/v1beta1
@@ -317,7 +327,7 @@ spec:
     retention.ms: 604800000
     segment.bytes: 1073741824
 ```
-And then do the same for the `kogito-usertaskinstances-events` topic.
+And then do the same for the others topics listed above.
 
 To check if everything was created successfully run the following command:
 
@@ -347,7 +357,7 @@ Spec:
 Events:                      <none>
 ```
 
-Now that you have the required infrastrucuture, it's safe to deploy the Kogito Data Index Service.
+Now that you have the required infrastructure, it's safe to deploy the Kogito Data Index Service.
 
 ### Install Data Index Service
 

--- a/deploy/crds/app.kiegroup.org_v1alpha1_kogitodataindex_cr.yaml
+++ b/deploy/crds/app.kiegroup.org_v1alpha1_kogitodataindex_cr.yaml
@@ -3,10 +3,8 @@ kind: KogitoDataIndex
 metadata:
   name: kogito-data-index
 spec:
-  # If not informed, these default values will be set for you
-  name: "kogito-data-index"
   # environment variables to set in the runtime container. Example: JAVAOPTS: "-Dquarkus.log.level=DEBUG"
-  env: {}
+  # env: {}
   # number of pods to be deployed
   replicas: 1
   # image to use for this deploy
@@ -19,7 +17,7 @@ spec:
   # details about the kafka connection
   kafka:
     # the service name and port for the kafka cluster. Example: my-kafka-cluster:9092
-    serviceURI: my-cluster-kafka-bootstrap:9092
+    serviceURI: kogito-kafka-kafka-bootstrap:9092
   # details about the connected infinispan
   infinispan:
     # name of the auth realm. "default" is the realm name for 
@@ -27,7 +25,7 @@ spec:
     # default to PLAIN
     #saslMechanism: ""
     # the service name and port of the infinispan cluster. Example: my-infinispan:11222
-    serviceURI: infinispan-server:11222
+    serviceURI: kogito-infinispan:11222
     # will automatically set to true if the credentials are set
     #useAuth: false
     # auth credentials

--- a/deploy/examples/data-index.yaml
+++ b/deploy/examples/data-index.yaml
@@ -3,8 +3,6 @@ kind: KogitoDataIndex
 metadata:
   name: kogito-data-index
 spec:
-  # If not informed, these default values will be set for you
-  name: "kogito-data-index"
   # environment variables to set in the runtime container. Example: JAVA_OPTIONS: "-Dquarkus.log.level=DEBUG"
   #env:
     # - name: JAVA_OPTIONS
@@ -12,7 +10,7 @@ spec:
   # number of pods to be deployed
   replicas: 1
   # image to use for this deploy
-  image: "quay.io/kiegroup/kogito-data-index:latest"
+  image: "quay.io/kiegroup/kogito-data-index:0.5.1"
   # Limits and requests for the Data Index pod
   memoryLimit: ""
   memoryRequest: ""
@@ -21,7 +19,7 @@ spec:
   # details about the kafka connection
   kafka:
     # the service name and port for the kafka cluster. Example: my-kafka-cluster:9092
-    serviceURI: my-cluster-kafka-bootstrap:9092
+    serviceURI: kogito-kafka-kafka-bootstrap:9092
   # details about the connected infinispan
   infinispan:
     # name of the auth realm. "default" is the realm name for
@@ -29,7 +27,7 @@ spec:
     # default to PLAIN
     #saslMechanism: ""
     # the service name and port of the infinispan cluster. Example: my-infinispan:11222
-    serviceURI: infinispan-server:11222
+    serviceURI: kogito-infinispan:11222
       # will automatically set to true if the credentials are set
       #useAuth: false
       # auth credentials

--- a/deploy/olm-catalog/kogito-cloud-operator/0.6.0/kogito-cloud-operator.v0.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-cloud-operator/0.6.0/kogito-cloud-operator.v0.6.0.clusterserviceversion.yaml
@@ -6,6 +6,27 @@ metadata:
       [
         {
           "apiVersion": "app.kiegroup.org/v1alpha1",
+          "kind": "KogitoDataIndex",
+          "metadata": {
+            "name": "kogito-data-index"
+          },
+          "spec": {
+            "cpuLimit": "",
+            "cpuRequest": "",
+            "image": "quay.io/kiegroup/kogito-data-index:latest",
+            "infinispan": {
+              "serviceURI": "kogito-infinispan:11222"
+            },
+            "kafka": {
+              "serviceURI": "kogito-kafka-kafka-bootstrap:9092"
+            },
+            "memoryLimit": "",
+            "memoryRequest": "",
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "app.kiegroup.org/v1alpha1",
           "kind": "KogitoApp",
           "metadata": {
             "name": "example-quarkus"
@@ -17,29 +38,6 @@ metadata:
                 "uri": "https://github.com/kiegroup/kogito-examples"
               }
             }
-          }
-        },
-        {
-          "apiVersion": "app.kiegroup.org/v1alpha1",
-          "kind": "KogitoDataIndex",
-          "metadata": {
-            "name": "kogito-data-index"
-          },
-          "spec": {
-            "cpuLimit": "",
-            "cpuRequest": "",
-            "env": {},
-            "image": "quay.io/kiegroup/kogito-data-index:latest",
-            "infinispan": {
-              "serviceURI": "infinispan-server:11222"
-            },
-            "kafka": {
-              "serviceURI": "my-cluster-kafka-bootstrap:9092"
-            },
-            "memoryLimit": "",
-            "memoryRequest": "",
-            "name": "kogito-data-index",
-            "replicas": 1
           }
         }
       ]

--- a/pkg/controller/kogitodataindex/resource/defaults.go
+++ b/pkg/controller/kogitodataindex/resource/defaults.go
@@ -51,7 +51,10 @@ const (
 	infinispanEnvKeyCredSecret string = "INFINISPAN_CREDENTIAL_SECRET"
 	interfaceEnvKeyServiceURI  string = "QUARKUS_INFINISPAN_CLIENT_SERVER_LIST"
 
-	kafkaEnvKeyServiceURI string = "MP_MESSAGING_INCOMING_KOGITO_PROCESSINSTANCES_EVENTS_BOOTSTRAP_SERVERS"
+	kafkaEnvKeyProcessInstancesServer string = "MP_MESSAGING_INCOMING_KOGITO_PROCESSINSTANCES_EVENTS_BOOTSTRAP_SERVERS"
+	kafkaEnvKeyUserTaskInstanceServer string = "MP_MESSAGING_INCOMING_KOGITO_USERTASKINSTANCES_EVENTS_BOOTSTRAP_SERVERS"
+	kafkaEnvKeyProcessDomainServer    string = "MP_MESSAGING_INCOMING_KOGITO_PROCESSDOMAIN_EVENTS_BOOTSTRAP_SERVERS"
+	kafkaEnvKeyUserTaskDomainServer   string = "MP_MESSAGING_INCOMING_KOGITO_USERTASKDOMAIN_EVENTS_BOOTSTRAP_SERVERS"
 )
 
 // managedEnvKeys are a collection of reserved keys
@@ -61,7 +64,10 @@ var managedEnvKeys = []string{
 }
 
 var managedKafkaKeys = []string{
-	kafkaEnvKeyServiceURI,
+	kafkaEnvKeyProcessInstancesServer,
+	kafkaEnvKeyUserTaskInstanceServer,
+	kafkaEnvKeyProcessDomainServer,
+	kafkaEnvKeyUserTaskDomainServer,
 }
 
 var managedInfinispanKeys = []string{

--- a/pkg/controller/kogitodataindex/resource/kafka.go
+++ b/pkg/controller/kogitodataindex/resource/kafka.go
@@ -23,7 +23,9 @@ func fromKafkaToStringMap(kafka v1alpha1.KafkaConnectionProperties) map[string]s
 	}
 
 	if len(kafka.ServiceURI) > 0 {
-		propsmap[kafkaEnvKeyServiceURI] = kafka.ServiceURI
+		for _, envKey := range managedKafkaKeys {
+			propsmap[envKey] = kafka.ServiceURI
+		}
 	}
 
 	return propsmap

--- a/pkg/controller/kogitodataindex/resource/manage_resources.go
+++ b/pkg/controller/kogitodataindex/resource/manage_resources.go
@@ -178,13 +178,15 @@ func ensureKafka(instance *v1alpha1.KogitoDataIndex, statefulset *appsv1.Statefu
 		return false
 	}
 
-	currentURI := util.GetEnvVarFromContainer(kafkaEnvKeyServiceURI, statefulset.Spec.Template.Spec.Containers[0])
-	if instance.Spec.Kafka.ServiceURI != currentURI {
-		log.Debugf("Found differences in the Kafka ServiceURI (%s). Updating to '%s'.", currentURI, instance.Spec.Kafka.ServiceURI)
-		util.SetEnvVar(kafkaEnvKeyServiceURI, instance.Spec.Kafka.ServiceURI, &statefulset.Spec.Template.Spec.Containers[0])
-
-		return true
+	updated := false
+	for _, kafkaEnv := range managedKafkaKeys {
+		currentURI := util.GetEnvVarFromContainer(kafkaEnv, statefulset.Spec.Template.Spec.Containers[0])
+		if instance.Spec.Kafka.ServiceURI != currentURI {
+			log.Debugf("Found differences in the Kafka ServiceURI (%s). Updating to '%s'.", currentURI, instance.Spec.Kafka.ServiceURI)
+			util.SetEnvVar(kafkaEnv, instance.Spec.Kafka.ServiceURI, &statefulset.Spec.Template.Spec.Containers[0])
+			updated = true
+		}
 	}
 
-	return false
+	return updated
 }

--- a/pkg/controller/kogitodataindex/resource/manage_resources_test.go
+++ b/pkg/controller/kogitodataindex/resource/manage_resources_test.go
@@ -47,12 +47,16 @@ func Test_ManageResources_WhenKafkaURIIsChanged(t *testing.T) {
 
 	err := ManageResources(instance, &KogitoDataIndexResources{StatefulSet: statefulset, ProtoBufConfigMap: cm}, client)
 	assert.NoError(t, err)
-	assert.NotContains(t, statefulset.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: kafkaEnvKeyServiceURI, Value: serviceuri})
+	for _, kafkaKey := range managedKafkaKeys {
+		assert.NotContains(t, statefulset.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: kafkaKey, Value: serviceuri})
+	}
 
 	instance.Spec.Kafka = v1alpha1.KafkaConnectionProperties{ServiceURI: serviceuri}
 	err = ManageResources(instance, &KogitoDataIndexResources{StatefulSet: statefulset, ProtoBufConfigMap: cm}, client)
 	assert.NoError(t, err)
-	assert.Contains(t, statefulset.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: kafkaEnvKeyServiceURI, Value: serviceuri})
+	for _, kafkaKey := range managedKafkaKeys {
+		assert.Contains(t, statefulset.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: kafkaKey, Value: serviceuri})
+	}
 }
 
 func Test_ManageResources_WhenWeChangeInfinispanVars(t *testing.T) {


### PR DESCRIPTION
…a endpoint

See: https://issues.jboss.org/browse/KOGITO-569

Now with just :

```
kogito install data-index -p kogito --infinispan-url infinispan-server:11222 --kafka-url my-cluster-kafka-bootstrap:9092 
```
We have all topics injected:

```
2019-11-08 19:34:39,411 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Connecting mediators
2019-11-08 19:34:39,413 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Attempt to resolve org.kie.kogito.index.messaging.ReactiveMessagingEventConsumer#onProcessInstanceDomainEvent
2019-11-08 19:34:39,414 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Connecting org.kie.kogito.index.messaging.ReactiveMessagingEventConsumer#onProcessInstanceDomainEvent to `kogito-processdomain-events` (org.eclipse.microprofile.reactive.streams.operators.core.PublisherBuilderImpl@4a8a60bc)
2019-11-08 19:34:39,415 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Attempt to resolve org.kie.kogito.index.messaging.ReactiveMessagingEventConsumer#onUserTaskInstanceEvent
2019-11-08 19:34:39,416 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Connecting org.kie.kogito.index.messaging.ReactiveMessagingEventConsumer#onUserTaskInstanceEvent to `kogito-usertaskinstances-events` (org.eclipse.microprofile.reactive.streams.operators.core.PublisherBuilderImpl@361c294e)
2019-11-08 19:34:39,416 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Attempt to resolve org.kie.kogito.index.messaging.ReactiveMessagingEventConsumer#onUserTaskInstanceDomainEvent
2019-11-08 19:34:39,417 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Connecting org.kie.kogito.index.messaging.ReactiveMessagingEventConsumer#onUserTaskInstanceDomainEvent to `kogito-usertaskdomain-events` (org.eclipse.microprofile.reactive.streams.operators.core.PublisherBuilderImpl@7859e786)
2019-11-08 19:34:39,418 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Attempt to resolve org.kie.kogito.index.messaging.ReactiveMessagingEventConsumer#onProcessInstanceEvent
2019-11-08 19:34:39,419 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Connecting org.kie.kogito.index.messaging.ReactiveMessagingEventConsumer#onProcessInstanceEvent to `kogito-processinstances-events` (org.eclipse.microprofile.reactive.streams.operators.core.PublisherBuilderImpl@285d851a)
2019-11-08 19:34:39,487 INFO  [org.apa.kaf.cli.con.KafkaConsumer] (vert.x-kafka-consumer-thread-0) [Consumer clientId=consumer-4, groupId=4e3bcbc0-c1c4-49f6-b569-eeb95e9907ab] Subscribed to topic(s): kogito-processinstances-events
2019-11-08 19:34:39,500 INFO  [org.apa.kaf.cli.con.KafkaConsumer] (vert.x-kafka-consumer-thread-1) [Consumer clientId=consumer-3, groupId=dc8b3e93-0fd7-4946-bb4a-241d4cad7210] Subscribed to topic(s): kogito-usertaskinstances-events
2019-11-08 19:34:39,506 INFO  [org.apa.kaf.cli.con.KafkaConsumer] (vert.x-kafka-consumer-thread-3) [Consumer clientId=consumer-2, groupId=289534ea-25ec-4eba-b103-b0fa00961c70] Subscribed to topic(s): kogito-processinstances-events
2019-11-08 19:34:39,505 INFO  [org.apa.kaf.cli.con.KafkaConsumer] (vert.x-kafka-consumer-thread-2) [Consumer clientId=consumer-1, groupId=08d901ab-2994-491f-acc5-008f7e92eca1] Subscribed to topic(s): kogito-usertaskinstances-events
```

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster