### PR TITLE
[KOGITO-589] bash script should have bash shebang

### DIFF
--- a/hack/go-build-cli.sh
+++ b/hack/go-build-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env bash
 # Copyright 2019 Red Hat, Inc. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,17 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BASEDIR=`pwd`
+BASEDIR=$(pwd)
 KOGITO_CMD_DIR="cmd/kogito"
 
 function packTemplateFiles(){
-  cd ${BASEDIR}/${KOGITO_CMD_DIR} && packr2 -v
-  cd ${BASEDIR}
+  cd "${BASEDIR}"/"${KOGITO_CMD_DIR}" && packr2 -v
+  cd "${BASEDIR}"
 }
 
 function cleanTemplateFiles(){
-  cd ${BASEDIR}/${KOGITO_CMD_DIR} && packr2 clean -v
-  cd ${BASEDIR}
+  cd "${BASEDIR}"/"${KOGITO_CMD_DIR}" && packr2 clean -v
+  cd "${BASEDIR}"
 }
 
 release=$1
@@ -53,7 +53,7 @@ if [ "$release" = "true" ]; then
     CGO_ENABLED=0 GOOS="${i}" GOARCH="${arch}" go build -v -a -o build/_output/bin/kogito github.com/kiegroup/kogito-cloud-operator/cmd/kogito
     if [ $? -ne 0 ]; then
       echo "Failed to build for OS ${i} and Architecture ${arch}"
-      cleanTemplateFiles 
+      cleanTemplateFiles
       exit 1
     fi
     cleanTemplateFiles

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env bash
 # Copyright 2019 Red Hat, Inc. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,8 +41,8 @@ if [[ -z ${CI} ]]; then
         MD5=$(md5sum ${TAR} | awk {'print $1'})
         rm ${TAR}
 
-        echo ${CFLAGS}
-        cekit build ${CFLAGS} \
+        echo "${CFLAGS}"
+        cekit build "${CFLAGS}" \
             --overrides "{'artifacts': [{'name': 'kogito-cloud-operator.tar.gz', 'md5': '${MD5}', 'url': '${URL}'}]}"
     fi
 else

--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env bash
 # Copyright 2019 Red Hat, Inc. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env bash
 # Copyright 2019 Red Hat, Inc. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 dirs=(cmd pkg version)
 for dir in "${dirs[@]}"
 do
-    if ! golint -set_exit_status ${dir}/...; then
+    if ! golint -set_exit_status "${dir}"/...; then
         code=1
     fi
 done

--- a/hack/go-mod-env.sh
+++ b/hack/go-mod-env.sh
@@ -18,9 +18,9 @@
 setGoModEnv() {
   pwdPath=$(pwd -P 2>/dev/null || env PWD= pwd)
   goPath=$(go env GOPATH)
-  cd $goPath || exit
+  cd "$goPath" || exit
   goPath=$(pwd -P 2>/dev/null || env PWD= pwd)
-  cd $pwdPath || exit
+  cd "$pwdPath" || exit
   if [ "${pwdPath#"$goPath"}" != "${pwdPath}" ]; then
     export GO111MODULE=on
   fi

--- a/hack/go-test.sh
+++ b/hack/go-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env bash
 # Copyright 2019 Red Hat, Inc. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env bash
 # Copyright 2019 Red Hat, Inc. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hack/run-e2e-cli.sh
+++ b/hack/run-e2e-cli.sh
@@ -46,7 +46,7 @@ fi
 # performs the test
 echo "-------- Running e2e tests with namespace=${namespace}, tag=${tag}, native=${native} and maven_mirror=${maven_mirror}"
 
-./build/_output/bin/kogito use-project ${namespace}
+./build/_output/bin/kogito use-project "${namespace}"
 ./build/_output/bin/kogito install operator #should exist on OCP 4, on OCP 3 will install it, so no error
 
 echo "-------- Deploying the Kogito app"
@@ -54,7 +54,7 @@ echo "-------- Deploying the Kogito app"
 
 count=0
 echo "-------- Waiting for deployment to finish"
-until desired=$(oc get dc/kogito-example -n ${namespace} | grep kogito-example | awk '{ print $4 }'); [ "${desired}" == "1" ]
+until desired=$(oc get dc/kogito-example -n "${namespace}" | grep kogito-example | awk '{ print $4 }'); [ "${desired}" == "1" ]
   do
     if [ $count -eq 40 ]; then
       echo "-------- Failed to deploy the application within the time frame of ${count} minutes"
@@ -66,7 +66,7 @@ until desired=$(oc get dc/kogito-example -n ${namespace} | grep kogito-example |
 done
 
 echo "-------- Deployment seems to be finished"
-route=$(oc get route/kogito-example -n ${namespace} | grep http | awk '{ print $2 }')
+route=$(oc get route/kogito-example -n "${namespace}" | grep http | awk '{ print $2 }')
 
 echo "-------- Route is ${route}"
 response=$(curl "http://${route}/hello")
@@ -83,13 +83,13 @@ echo "------- Waiting a couple seconds to finish the clean up"
 sleep 5
 
 echo "------- Checking if the resources were actually cleaned"
-found=$(oc get dc/kogito-example -n ${namespace} 2> >(grep -m 1  -i notfound) | wc -l)
+found=$(oc get dc/kogito-example -n "${namespace}" 2> >(grep -m 1  -i notfound) | wc -l)
 if [ "$found" != "1" ]; then
   echo "Failed to clean the application the DC stills in the cluster!"
   exit 1
 fi
 
-found=$(oc get bc/kogito-example -n ${namespace} 2> >(grep -m 1  -i notfound) | wc -l)
+found=$(oc get bc/kogito-example -n "${namespace}" 2> >(grep -m 1  -i notfound) | wc -l)
 if [ "$found" != "1" ]; then
   echo "Failed to clean the application the BC stills in the cluster!"
   exit 1

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -27,7 +27,7 @@ if [ -z "$namespace" ]; then
 fi
 
 # creates the namespace
-oc create namespace ${namespace}
+oc create namespace "${namespace}"
 
 if [ -z "$tag" ]; then
   echo "-------- tag is empty, assuming default from the Operator"
@@ -41,9 +41,9 @@ else
   echo "-------- using local operator code for testing"
 
   # gives permissions
-  oc create -f deploy/role.yaml -n ${namespace}
-  oc create -f deploy/service_account.yaml -n ${namespace}
-  oc create -f deploy/role_binding.yaml -n ${namespace}
+  oc create -f deploy/role.yaml -n "${namespace}"
+  oc create -f deploy/service_account.yaml -n "${namespace}"
+  oc create -f deploy/role_binding.yaml -n "${namespace}"
 
   E2E_PARAMS="${E2E_PARAMS} --up-local"
 fi
@@ -51,7 +51,7 @@ fi
 echo "-------- Running e2e tests with namespace=${namespace}, tag=${tag}, maven_mirror=${maven_mirror} and image=${image}"
 
 # performs the test
-DEBUG=true KOGITO_IMAGE_TAG=${tag} MAVEN_MIRROR_URL=${maven_mirror} TESTS=${tests} operator-sdk test local ./test/e2e $E2E_PARAMS --namespace ${namespace} --debug --verbose --go-test-flags "-timeout 120m"
+DEBUG=true KOGITO_IMAGE_TAG=${tag} MAVEN_MIRROR_URL=${maven_mirror} TESTS=${tests} operator-sdk test local ./test/e2e "$E2E_PARAMS" --namespace "${namespace}" --debug --verbose --go-test-flags "-timeout 120m"
 
 # clean up
-oc delete namespace ${namespace}
+oc delete namespace "${namespace}"


### PR DESCRIPTION
[KOGITO-859](https://issues.jboss.org/browse/KOGITO-589)

Script ```hack/go-build-cli``` has bash-specific features such as function keyword and arrays. If shebang is #!/bin/sh and sh is a link to any shell different from bash (dash, for example), the script will fail. Making an explicit shebang #!/bin/bash resolves the issue.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [X] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster