### PR TITLE
KOGITO-490: Kogito CLI: Add `kogito project` to display which project has been configured.

### DIFF
--- a/cmd/kogito/command/project/display_project.go
+++ b/cmd/kogito/command/project/display_project.go
@@ -1,0 +1,75 @@
+// Copyright 2019 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
+
+	"github.com/spf13/cobra"
+)
+
+type displayProjectFlags struct {
+}
+
+type displayProjectCommand struct {
+	context.CommandContext
+	flags   displayProjectFlags
+	command *cobra.Command
+	Parent  *cobra.Command
+}
+
+func newDisplayProjectCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+	cmd := displayProjectCommand{
+		CommandContext: *ctx,
+		Parent:         parent,
+	}
+	cmd.RegisterHook()
+	cmd.InitHook()
+	return &cmd
+}
+
+func (i *displayProjectCommand) Command() *cobra.Command {
+	return i.command
+}
+
+func (i *displayProjectCommand) RegisterHook() {
+	i.command = &cobra.Command{
+		Use:     "project",
+		Aliases: []string{"ns"},
+		Short:   "Display the current used project",
+		Long:    `project will print the Kubernetes Namespace where the Kogito services will be deployed. It's the Namespace/Project on Kubernetes/OpenShift world.`,
+		RunE:    i.Exec,
+		PreRun:  i.CommonPreRun,
+		PostRun: i.CommonPostRun,
+		Args:    func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
+
+func (i *displayProjectCommand) InitHook() {
+	i.flags = displayProjectFlags{}
+	i.Parent.AddCommand(i.command)
+}
+
+func (i *displayProjectCommand) Exec(cmd *cobra.Command, args []string) error {
+	log := context.GetDefaultLogger()
+	config := context.ReadConfig()
+	if config.Namespace != "" {
+		log.Infof("Using project '%s'", config.Namespace)
+	} else {
+		log.Infof("No project configured yet...")
+	}
+
+	return nil
+}

--- a/cmd/kogito/command/project/display_project_test.go
+++ b/cmd/kogito/command/project/display_project_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/test"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDisplayProjectCmd_WhenTheresNoConfigAndNoNamespace(t *testing.T) {
+	path := test.GetTestConfigFilePath()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		err := os.Remove(path)
+		assert.NoError(t, err)
+	} else {
+		err := os.MkdirAll(test.GetTestConfigPath(), os.ModePerm)
+		assert.NoError(t, err)
+	}
+
+	// open
+	file, err := os.Create(path)
+	defer file.Close()
+	assert.NoError(t, err)
+	test.SetupCliTest(strings.Join([]string{"project"}, " "), context.CommandFactory{BuildCommands: BuildCommands})
+	o, _, err := test.ExecuteCli()
+	assert.NoError(t, err)
+	assert.Contains(t, o, "No project configured")
+}
+
+func TestDisplayProjectCmd_WhenThereIsTheNamespace(t *testing.T) {
+	config := context.ReadConfig()
+	ns := uuid.New().String()
+	config.Namespace = ns
+	config.Save()
+
+	nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+	test.SetupCliTest(strings.Join([]string{"project", ns}, " "), context.CommandFactory{BuildCommands: BuildCommands}, nsObj)
+	o, _, err := test.ExecuteCli()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, o)
+	assert.Contains(t, o, ns)
+}

--- a/cmd/kogito/command/project/factory.go
+++ b/cmd/kogito/command/project/factory.go
@@ -25,5 +25,6 @@ func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) []co
 		newDeleteProjectCommand(ctx, rootCommand),
 		newNewProjectCommand(ctx, rootCommand),
 		newUseProjectCommand(ctx, rootCommand),
+		newDisplayProjectCommand(ctx, rootCommand),
 	}
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/KOGITO-490

`kogito project` now displays the current used project.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster