### PR TITLE
[KOGITO-677] - Add Infinispan credentials as envfrom secret

### DIFF
--- a/pkg/controller/kogitoapp/resource/deployment_config.go
+++ b/pkg/controller/kogitoapp/resource/deployment_config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/controller/kogitoapp/shared"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/controller/kogitoinfra/infinispan"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/resource"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/util"
@@ -136,7 +137,7 @@ func SetInfinispanEnvVars(cli *client.Client, kogitoInfra *v1alpha1.KogitoInfra,
 		if err != nil {
 			return err
 		}
-		user, password, err := infrastructure.GetInfinispanCredentials(cli, kogitoInfra)
+		secret, err := infrastructure.GetInfinispanCredentialsSecret(cli, kogitoInfra)
 		if err != nil {
 			return err
 		}
@@ -148,9 +149,9 @@ func SetInfinispanEnvVars(cli *client.Client, kogitoInfra *v1alpha1.KogitoInfra,
 				vars = envVarInfinispanSpring
 			}
 			util.SetEnvVar(vars[envVarInfinispanServerList], uri, &dc.Spec.Template.Spec.Containers[0])
-			util.SetEnvVar(vars[envVarInfinispanUser], user, &dc.Spec.Template.Spec.Containers[0])
-			util.SetEnvVar(vars[envVarInfinispanPassword], password, &dc.Spec.Template.Spec.Containers[0])
 			util.SetEnvVar(vars[envVarInfinispanSaslMechanism], string(defaultInfinispanSaslMechanism), &dc.Spec.Template.Spec.Containers[0])
+			util.SetEnvVarFromSecret(vars[envVarInfinispanUser], infinispan.SecretUsernameKey, secret, &dc.Spec.Template.Spec.Containers[0])
+			util.SetEnvVarFromSecret(vars[envVarInfinispanPassword], infinispan.SecretPasswordKey, secret, &dc.Spec.Template.Spec.Containers[0])
 		}
 	}
 	return nil

--- a/pkg/controller/kogitodataindex/resource/manage_resources.go
+++ b/pkg/controller/kogitodataindex/resource/manage_resources.go
@@ -161,7 +161,7 @@ func ensureInfinispan(instance *v1alpha1.KogitoDataIndex, statefulset *appsv1.St
 		}
 	}
 
-	infinispanEnvs := fromInfinispanToStringMap(instance.Spec.Infinispan, secret)
+	infinispanEnvs := fromInfinispanToStringMap(instance.Spec.Infinispan)
 	currentInfinispan := getInfinispanVars(statefulset.Spec.Template.Spec.Containers[0])
 
 	if util.EnvVarCheck(currentInfinispan, util.FromMapToEnvVar(infinispanEnvs)) {

--- a/pkg/controller/kogitodataindex/resource/statefulset.go
+++ b/pkg/controller/kogitodataindex/resource/statefulset.go
@@ -34,7 +34,7 @@ func newStatefulset(instance *v1alpha1.KogitoDataIndex, cm *corev1.ConfigMap, se
 	envs := instance.Spec.Env
 	// defaults
 	envs = util.AppendStringMap(envs, defaultEnvs)
-	envs = util.AppendStringMap(envs, fromInfinispanToStringMap(instance.Spec.Infinispan, secret))
+	envs = util.AppendStringMap(envs, fromInfinispanToStringMap(instance.Spec.Infinispan))
 	envs = util.AppendStringMap(envs, fromKafkaToStringMap(instance.Spec.Kafka))
 
 	if instance.Spec.Replicas == 0 {
@@ -98,6 +98,7 @@ func newStatefulset(instance *v1alpha1.KogitoDataIndex, cm *corev1.ConfigMap, se
 		},
 	}
 
+	setInfinispanCredentialsSecret(instance.Spec.Infinispan, secret, &statefulset.Spec.Template.Spec.Containers[0])
 	meta.SetGroupVersionKind(&statefulset.TypeMeta, meta.KindStatefulSet)
 	addDefaultMetadata(&statefulset.ObjectMeta, instance)
 	addDefaultMetadata(&statefulset.Spec.Template.ObjectMeta, instance)

--- a/pkg/infrastructure/infinispan.go
+++ b/pkg/infrastructure/infinispan.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
-	"github.com/kiegroup/kogito-cloud-operator/pkg/controller/kogitoinfra/infinispan"
 	"k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,27 +80,15 @@ func GetInfinispanServiceURI(cli *client.Client, infra *v1alpha1.KogitoInfra) (u
 	return "", nil
 }
 
-// GetInfinispanCredentials fetches the Infinispan secret credentials managed by the given KogitoInfra and returns the credentials stored
-func GetInfinispanCredentials(cli *client.Client, infra *v1alpha1.KogitoInfra) (user, password string, err error) {
-	user = ""
-	password = ""
+// GetInfinispanCredentialsSecret will fetch for the secret created to hold Infinispan credentials
+func GetInfinispanCredentialsSecret(cli *client.Client, infra *v1alpha1.KogitoInfra) (secret *corev1.Secret, err error) {
 	err = nil
 	if &infra == nil || &infra.Status == nil || &infra.Status.Infinispan == nil {
 		return
 	}
-
-	secret := &corev1.Secret{
+	secret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: infra.Status.Infinispan.CredentialSecret, Namespace: infra.Namespace},
 	}
-	exists := false
-	if exists, err = kubernetes.ResourceC(cli).Fetch(secret); err != nil {
-		return
-	}
-
-	if exists {
-		user = string(secret.Data[infinispan.SecretUsernameKey])
-		password = string(secret.Data[infinispan.SecretPasswordKey])
-	}
-
+	_, err = kubernetes.ResourceC(cli).Fetch(secret)
 	return
 }

--- a/pkg/util/env_var.go
+++ b/pkg/util/env_var.go
@@ -132,6 +132,26 @@ func SetEnvVar(key, value string, container *corev1.Container) {
 	container.Env = append(container.Env, corev1.EnvVar{Name: key, Value: value})
 }
 
+// SetEnvVarFromSecret will set the Environment Variable from a Secret
+func SetEnvVarFromSecret(key, secretKey string, secret *corev1.Secret, container *corev1.Container) {
+	if container == nil || secret == nil {
+		return
+	}
+	valueFrom := &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secret.Name},
+			Key:                  secretKey,
+		},
+	}
+	for i, env := range container.Env {
+		if env.Name == key {
+			container.Env[i].ValueFrom = valueFrom
+			return
+		}
+	}
+	container.Env = append(container.Env, corev1.EnvVar{Name: key, ValueFrom: valueFrom})
+}
+
 // EnvVarCheck checks whether the src and dst []EnvVar have the same values
 func EnvVarCheck(dst, src []corev1.EnvVar) bool {
 	for _, denv := range dst {


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-677

In this PR we keep the Infinispan credentials in the secret.

TODO:
- [x] Unit tests for KogitoApp controller
- [x] Support on DataIndex

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster