### PR TITLE
[KOGITO-703] Installs Kogito Operator if available in the OperatorHub

### DIFF
--- a/cmd/kogito/command/shared/operatorhub.go
+++ b/cmd/kogito/command/shared/operatorhub.go
@@ -15,17 +15,21 @@
 package shared
 
 import (
+	"fmt"
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/util"
+	olmapiv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 )
 
 const (
 	defaultOperatorPackageName   = "kogito-operator"
+	defaultOperatorChannelName   = "alpha"
 	communityOperatorSource      = "community-operators"
 	operatorMarketplaceNamespace = "openshift-marketplace"
 )
@@ -35,7 +39,7 @@ func isOperatorAvailableInOperatorHub(kubeCli *client.Client) (bool, error) {
 	log := context.GetDefaultLogger()
 	log.Debug("Trying to find if Kogito Operator is available in the OperatorHub")
 	operatorSource := &v1.OperatorSource{
-		ObjectMeta: v12.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      communityOperatorSource,
 			Namespace: operatorMarketplaceNamespace,
 		},
@@ -53,4 +57,77 @@ func isOperatorAvailableInOperatorHub(kubeCli *client.Client) (bool, error) {
 	}
 
 	return strings.Contains(operatorSource.Status.Packages, defaultOperatorPackageName), nil
+}
+
+// installOperatorWithOperatorHub installs the Kogito Operator via OperatorHub custom resources, works for OCP 4.x
+// checks if a subscription to the given Kogito Operator package already exists. Doesn't create if one is in place.
+// see: https://docs.openshift.com/container-platform/4.2/operators/olm-adding-operators-to-cluster.html#olm-installing-operator-from-operatorhub-using-cli_olm-adding-operators-to-a-cluster
+func installOperatorWithOperatorHub(namespace string, cli *client.Client) error {
+	log := context.GetDefaultLogger()
+	log.Debug("Trying to install Kogito Operator via Subscription to the OperatorHub")
+	if err := createOperatorGroupIfNotExists(namespace, cli); err != nil {
+		return err
+	}
+
+	subs := &olmapiv1alpha1.SubscriptionList{}
+	if err := kubernetes.ResourceC(cli).ListWithNamespace(namespace, subs); err != nil {
+		return err
+	}
+
+	for _, sub := range subs.Items {
+		if sub.Spec.Package == defaultOperatorPackageName &&
+			sub.Spec.CatalogSource == communityOperatorSource {
+			log.Warnf("Found subscription %s with package %s and catalog source %s. Won't create a new one",
+				sub.Name, sub.Spec.Package, sub.Spec.CatalogSource)
+			return nil
+		}
+	}
+
+	subscription := &olmapiv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultOperatorPackageName,
+			Namespace: namespace,
+		},
+		Spec: &olmapiv1alpha1.SubscriptionSpec{
+			Package:                defaultOperatorPackageName,
+			CatalogSource:          communityOperatorSource,
+			CatalogSourceNamespace: operatorMarketplaceNamespace,
+			Channel:                defaultOperatorChannelName,
+		},
+	}
+	log.Debug("About to create a new subscription for the Kogito Operator")
+	if err := kubernetes.ResourceC(cli).Create(subscription); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createOperatorGroupIfNotExists creates a new OperatorGroup for `SingleNamespace` installations mode.
+// Only creates it if we don't have one in the given namespace that targets the given namespace.
+func createOperatorGroupIfNotExists(namespace string, cli *client.Client) error {
+	groups := &olmapiv1.OperatorGroupList{}
+	if err := kubernetes.ResourceC(cli).ListWithNamespace(namespace, groups); err != nil {
+		return err
+	}
+
+	// inspect target namespace in the groups
+	for _, group := range groups.Items {
+		for _, ns := range group.Spec.TargetNamespaces {
+			if ns == namespace {
+				return nil
+			}
+		}
+	}
+
+	// we don't have a group, let's create a new one
+	groupName := fmt.Sprintf("%s-%s", namespace, util.RandomSuffix())
+	group := &olmapiv1.OperatorGroup{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: groupName},
+		Spec:       olmapiv1.OperatorGroupSpec{TargetNamespaces: []string{namespace}},
+	}
+	if err := kubernetes.ResourceC(cli).Create(group); err != nil {
+		return err
+	}
+	return nil
 }

--- a/deploy/olm-catalog/kogito-operator/0.7.0-rc1/kogito-operator.v0.7.0-rc1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/0.7.0-rc1/kogito-operator.v0.7.0-rc1.clusterserviceversion.yaml
@@ -6,21 +6,6 @@ metadata:
       [
         {
           "apiVersion": "app.kiegroup.org/v1alpha1",
-          "kind": "KogitoApp",
-          "metadata": {
-            "name": "example-quarkus"
-          },
-          "spec": {
-            "build": {
-              "gitSource": {
-                "contextDir": "jbpm-quarkus-example",
-                "uri": "https://github.com/kiegroup/kogito-examples"
-              }
-            }
-          }
-        },
-        {
-          "apiVersion": "app.kiegroup.org/v1alpha1",
           "kind": "KogitoDataIndex",
           "metadata": {
             "name": "kogito-data-index"
@@ -49,6 +34,21 @@ metadata:
           "spec": {
             "installInfinispan": false,
             "installKafka": false
+          }
+        },
+        {
+          "apiVersion": "app.kiegroup.org/v1alpha1",
+          "kind": "KogitoApp",
+          "metadata": {
+            "name": "example-quarkus"
+          },
+          "spec": {
+            "build": {
+              "gitSource": {
+                "contextDir": "jbpm-quarkus-example",
+                "uri": "https://github.com/kiegroup/kogito-examples"
+              }
+            }
           }
         }
       ]

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,6 +17,8 @@ package client
 import (
 	"fmt"
 	appsv1 "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	olmapiv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"strings"
@@ -229,6 +231,8 @@ func newControllerCliOptions() controllercli.Options {
 	mapper.Add(rbac.SchemeGroupVersion.WithKind(meta.KindRole.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
 	mapper.Add(rbac.SchemeGroupVersion.WithKind(meta.KindRoleBinding.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
 	mapper.Add(operatormkt.SchemeGroupVersion.WithKind(meta.KindOperatorSource.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
+	mapper.Add(olmapiv1.SchemeGroupVersion.WithKind(meta.KindOperatorGroup.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
+	mapper.Add(olmapiv1alpha1.SchemeGroupVersion.WithKind(meta.KindSubscription.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
 
 	// the kube client is having problems with plural: kogitodataindexs :(
 	mapper.AddSpecific(v1alpha1.SchemeGroupVersion.WithKind(meta.KindKogitoDataIndex.Name),

--- a/pkg/client/meta/meta.go
+++ b/pkg/client/meta/meta.go
@@ -94,6 +94,10 @@ var (
 	KindOperatorSource = DefinitionKind{"OperatorSource", false, operatormkt.SchemeGroupVersion}
 	// KindServiceMonitor ...
 	KindServiceMonitor = DefinitionKind{"ServiceMonitor", false, monv1.SchemeGroupVersion}
+	// KindOperatorGroup ...
+	KindOperatorGroup = DefinitionKind{"OperatorGroup", false, olmapiv1.SchemeGroupVersion}
+	// KindSubscription ...
+	KindSubscription = DefinitionKind{"Subscription", false, olmapiv1alpha1.SchemeGroupVersion}
 )
 
 // SetGroupVersionKind sets the group, version and kind for the resource
@@ -123,12 +127,16 @@ func GetRegisteredSchema() *runtime.Scheme {
 	s.AddKnownTypes(routev1.GroupVersion, &routev1.Route{}, &routev1.RouteList{})
 	s.AddKnownTypes(imgv1.GroupVersion, &imgv1.ImageStreamTag{}, &imgv1.ImageStream{}, &imgv1.ImageStreamList{})
 	s.AddKnownTypes(operatormkt.SchemeGroupVersion, &operatormkt.OperatorSource{}, &operatormkt.OperatorSourceList{})
+	s.AddKnownTypes(olmapiv1.SchemeGroupVersion, &olmapiv1.OperatorGroup{}, &olmapiv1.OperatorGroupList{})
+	s.AddKnownTypes(olmapiv1alpha1.SchemeGroupVersion, &olmapiv1alpha1.Subscription{}, &olmapiv1alpha1.SubscriptionList{})
+
 	// After upgrading to Operator SDK 0.11.0 we need to add CreateOptions to our own schema. See: https://issues.jboss.org/browse/KOGITO-493
-	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &metav1.CreateOptions{})
+	metav1.AddToGroupVersion(s, v1alpha1.SchemeGroupVersion)
 	// https://issues.jboss.org/browse/KOGITO-617
-	s.AddKnownTypes(apiextensionsv1beta1.SchemeGroupVersion, &metav1.CreateOptions{})
-	s.AddKnownTypes(operatormkt.SchemeGroupVersion, &metav1.CreateOptions{})
-	s.AddKnownTypes(olmapiv1.SchemeGroupVersion, &olmapiv1.OperatorGroup{})
-	s.AddKnownTypes(olmapiv1alpha1.SchemeGroupVersion, &olmapiv1alpha1.Subscription{})
+	metav1.AddToGroupVersion(s, apiextensionsv1beta1.SchemeGroupVersion)
+	metav1.AddToGroupVersion(s, operatormkt.SchemeGroupVersion)
+	metav1.AddToGroupVersion(s, olmapiv1.SchemeGroupVersion)
+	metav1.AddToGroupVersion(s, olmapiv1alpha1.SchemeGroupVersion)
+
 	return s
 }

--- a/pkg/util/hash.go
+++ b/pkg/util/hash.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"crypto/md5"
 	"fmt"
+	"math/rand"
+	"strconv"
 )
 
 // GenerateMD5Hash will generate a MD5 hash from the given map
@@ -30,4 +32,9 @@ func GenerateMD5Hash(source map[string]string) string {
 		fmt.Fprintf(b, "%s=\"%s\"\n", k, v)
 	}
 	return fmt.Sprintf("%x", md5.Sum(b.Bytes()))
+}
+
+// RandomSuffix generates a random suffix to be used in names for kubernetes objects
+func RandomSuffix() string {
+	return strconv.Itoa(rand.Intn(10000))
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -481,12 +481,12 @@ k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/third_party/forked/golang/reflect
+k8s.io/apimachinery/pkg/util/clock
 k8s.io/apimachinery/pkg/runtime/serializer/json
 k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer
 k8s.io/apimachinery/pkg/runtime/serializer/versioning
 k8s.io/apimachinery/pkg/util/cache
-k8s.io/apimachinery/pkg/util/clock
 k8s.io/apimachinery/pkg/util/diff
 k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/pkg/util/mergepatch
@@ -502,6 +502,7 @@ k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/testing
+k8s.io/client-go/tools/record
 k8s.io/client-go/dynamic
 k8s.io/client-go/kubernetes
 k8s.io/client-go/tools/cache
@@ -520,12 +521,13 @@ k8s.io/client-go/util/cert
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/tools/leaderelection
 k8s.io/client-go/tools/leaderelection/resourcelock
-k8s.io/client-go/tools/record
 k8s.io/client-go/tools/auth
 k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/workqueue
 k8s.io/client-go/discovery/cached
+k8s.io/client-go/tools/record/util
+k8s.io/client-go/tools/reference
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1
 k8s.io/client-go/kubernetes/typed/apps/v1
 k8s.io/client-go/kubernetes/typed/apps/v1beta1
@@ -570,8 +572,6 @@ k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1
 k8s.io/client-go/pkg/apis/clientauthentication/v1beta1
 k8s.io/client-go/util/connrotation
 k8s.io/client-go/util/keyutil
-k8s.io/client-go/tools/record/util
-k8s.io/client-go/tools/reference
 k8s.io/client-go/tools/clientcmd/api/v1
 k8s.io/client-go/discovery/cached/memory
 k8s.io/client-go/third_party/forked/golang/template


### PR DESCRIPTION
See:
https://issues.redhat.com/browse/KOGITO-703

Instead of given the annoying WARN that the Operator is available in the hub, installs it via Hb Subscription.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster