### PR TITLE
[KOGITO-691] - Creating new tags when ImageStream already exists

### DIFF
--- a/deploy/olm-catalog/kogito-operator/0.7.0-rc4/kogito-operator.v0.7.0-rc4.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/0.7.0-rc4/kogito-operator.v0.7.0-rc4.clusterserviceversion.yaml
@@ -6,17 +6,6 @@ metadata:
       [
         {
           "apiVersion": "app.kiegroup.org/v1alpha1",
-          "kind": "KogitoInfra",
-          "metadata": {
-            "name": "kogito-infra"
-          },
-          "spec": {
-            "installInfinispan": false,
-            "installKafka": false
-          }
-        },
-        {
-          "apiVersion": "app.kiegroup.org/v1alpha1",
           "kind": "KogitoJobsService",
           "metadata": {
             "name": "jobs-service"
@@ -59,6 +48,17 @@ metadata:
             "memoryLimit": "",
             "memoryRequest": "",
             "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "app.kiegroup.org/v1alpha1",
+          "kind": "KogitoInfra",
+          "metadata": {
+            "name": "kogito-infra"
+          },
+          "spec": {
+            "installInfinispan": false,
+            "installKafka": false
           }
         }
       ]

--- a/pkg/client/openshift/imagestream.go
+++ b/pkg/client/openshift/imagestream.go
@@ -36,9 +36,16 @@ const (
 
 // ImageStreamInterface exposes OpenShift ImageStream operations
 type ImageStreamInterface interface {
+	// FetchDockerImage fetches a docker image based on a ImageStreamTag with the defined key (namespace and name).
+	// Returns nil if not found
 	FetchDockerImage(key types.NamespacedName) (*dockerv10.DockerImage, error)
+	// FetchTag fetches for a particular ImageStreamTag on OpenShift cluster.
+	// If tag is nil or empty, will search for "latest".
+	// Returns nil if the object was not found.
 	FetchTag(key types.NamespacedName, tag string) (*imgv1.ImageStreamTag, error)
+	// CreateTagIfNotExists will create a new ImageStreamTag if not exists
 	CreateTagIfNotExists(image *imgv1.ImageStreamTag) (bool, error)
+	// CreateImageStream will create a new ImageStream if not exists
 	CreateImageStream(is *imgv1.ImageStream) (bool, error)
 }
 
@@ -53,9 +60,6 @@ type imageStream struct {
 	client *client.Client
 }
 
-// FetchTag fetches for a particular imagestreamtag on OpenShift cluster.
-// If tag is nil or empty, will search for "latest".
-// Returns nil if the object was not found.
 func (i *imageStream) FetchTag(key types.NamespacedName, tag string) (*imgv1.ImageStreamTag, error) {
 	if len(tag) == 0 {
 		tag = ImageTagLatest
@@ -71,8 +75,6 @@ func (i *imageStream) FetchTag(key types.NamespacedName, tag string) (*imgv1.Ima
 	return isTag, err
 }
 
-// FetchDockerImage fetches a docker image based on a ImageStreamTag with the defined key (namespace and name).
-// Returns nil if not found
 func (i *imageStream) FetchDockerImage(key types.NamespacedName) (*dockerv10.DockerImage, error) {
 	dockerImage := &dockerv10.DockerImage{}
 	isTag, err := i.FetchTag(key, "")
@@ -95,7 +97,6 @@ func (i *imageStream) FetchDockerImage(key types.NamespacedName) (*dockerv10.Doc
 	return nil, nil
 }
 
-// CreateTagIfNotExists will create a new ImageStreamTag if not exists
 func (i *imageStream) CreateTagIfNotExists(is *imgv1.ImageStreamTag) (bool, error) {
 	is, err := i.client.ImageCli.ImageStreamTags(is.Namespace).Create(is)
 	if err != nil && !errors.IsAlreadyExists(err) {
@@ -109,7 +110,6 @@ func (i *imageStream) CreateTagIfNotExists(is *imgv1.ImageStreamTag) (bool, erro
 	return true, nil
 }
 
-// CreateImageStream will create a new ImageStream if not exists
 func (i *imageStream) CreateImageStream(is *imgv1.ImageStream) (bool, error) {
 	is, err := i.client.ImageCli.ImageStreams(is.Namespace).Create(is)
 	if err != nil && !errors.IsAlreadyExists(err) {

--- a/pkg/controller/kogitoapp/resource/kogito_imagestream_test.go
+++ b/pkg/controller/kogitoapp/resource/kogito_imagestream_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestKogitoImageStreamGeneration(t *testing.T) {
 
-	itemsTest := KogitoImageStream("test", version.Version, "", false)
+	itemsTest := CreateKogitoImageStream("test", version.Version, "", false)
 	assert.Equal(t, 6, len(itemsTest.Items))
 
 	for _, item := range itemsTest.Items {
@@ -96,21 +96,21 @@ func TestKogitoImageStreamGeneration(t *testing.T) {
 }
 
 func TestQuarkusKogitoImageStreamGenerationNonNative(t *testing.T) {
-	itemsTest := KogitoImageStream("quarkus", version.Version, v1alpha1.QuarkusRuntimeType, false)
+	itemsTest := CreateKogitoImageStream("quarkus", version.Version, v1alpha1.QuarkusRuntimeType, false)
 	assert.Equal(t, 2, len(itemsTest.Items))
 	assert.True(t, containsIsName(KogitoQuarkusJVMUbi8Image, itemsTest.Items))
 	assert.True(t, containsIsName(KogitoQuarkusUbi8s2iImage, itemsTest.Items))
 }
 
 func TestQuarkusKogitoImageStreamGenerationNative(t *testing.T) {
-	itemsTest := KogitoImageStream("quarkus", version.Version, v1alpha1.QuarkusRuntimeType, true)
+	itemsTest := CreateKogitoImageStream("quarkus", version.Version, v1alpha1.QuarkusRuntimeType, true)
 	assert.Equal(t, 2, len(itemsTest.Items))
 	assert.True(t, containsIsName(KogitoQuarkusUbi8s2iImage, itemsTest.Items))
 	assert.True(t, containsIsName(KogitoQuarkusUbi8Image, itemsTest.Items))
 }
 
 func TestSpringbootKogitoImageStreamGenerationNative(t *testing.T) {
-	itemsTest := KogitoImageStream("springboot", version.Version, v1alpha1.SpringbootRuntimeType, false)
+	itemsTest := CreateKogitoImageStream("springboot", version.Version, v1alpha1.SpringbootRuntimeType, false)
 	assert.Equal(t, 2, len(itemsTest.Items))
 	assert.True(t, containsIsName(KogitoSpringbootUbi8Image, itemsTest.Items))
 	assert.True(t, containsIsName(KogitoSpringbootUbi8s2iImage, itemsTest.Items))

--- a/pkg/controller/kogitoapp/resource/requested_resources.go
+++ b/pkg/controller/kogitoapp/resource/requested_resources.go
@@ -90,10 +90,10 @@ func protoBufConfigMap(chain *builderChain) *builderChain {
 }
 
 func imageStreamBuilder(chain *builderChain) *builderChain {
-	isS2I := newImageStreamTag(chain.KogitoApp, chain.Resources.BuildConfigS2I.Name)
+	isS2I := newImageStream(chain.KogitoApp, chain.Resources.BuildConfigS2I.Name)
 	chain.Resources.ImageStreamS2I = isS2I
 
-	isRuntime := newImageStreamTag(chain.KogitoApp, chain.Resources.BuildConfigRuntime.Name)
+	isRuntime := newImageStream(chain.KogitoApp, chain.Resources.BuildConfigRuntime.Name)
 	chain.Resources.ImageStreamRuntime = isRuntime
 
 	return chain

--- a/pkg/framework/comparator.go
+++ b/pkg/framework/comparator.go
@@ -154,10 +154,6 @@ func CreateBuildConfigComparator() func(deployed resource.KubernetesResource, re
 		if !containAllLabels(bcDeployed, bcRequested) {
 			return false
 		}
-		if bcDeployed.Spec.Strategy.SourceStrategy != nil {
-			//This value is generated based on image stream being found in current or openshift project:
-			bcDeployed.Spec.Strategy.SourceStrategy.From.Namespace = bcRequested.Spec.Strategy.SourceStrategy.From.Namespace
-		}
 		if len(bcDeployed.Spec.Triggers) > 0 && len(bcRequested.Spec.Triggers) == 0 {
 			//Triggers are generated based on provided github repo
 			bcDeployed.Spec.Triggers = bcRequested.Spec.Triggers


### PR DESCRIPTION
See:
https://issues.redhat.com/browse/KOGITO-691

In this PR we add the possibility to have multiple image tags for the same image stream.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster