### PR TITLE
[KOGITO-839] Adding Istio annotation to KogitoApp generated pods

### DIFF
--- a/cmd/kogito/command/deploy/deploy_service.go
+++ b/cmd/kogito/command/deploy/deploy_service.go
@@ -59,6 +59,7 @@ type deployFlags struct {
 	installKafka      string
 	imageVersion      string
 	mavenMirrorURL    string
+	enableIstio       bool
 }
 
 type deployCommand struct {
@@ -157,6 +158,7 @@ func (i *deployCommand) InitHook() {
 	i.command.Flags().StringVar(&i.flags.installKafka, "install-kafka", defaultInstallKafka, "Kafka installation mode: \"Always\" or \"Never\". \"Always\" will use the Strimzi Operator to install a Kafka cluster. The environment variable 'KAFKA_BOOTSTRAP_SERVERS' will be available for the service during runtime.")
 	i.command.Flags().StringVar(&i.flags.imageVersion, "image-version", "", "Image version for standard Kogito build images. Ignored if a custom image is set for image-s2i or image-runtime.")
 	i.command.Flags().StringVar(&i.flags.mavenMirrorURL, "maven-mirror-url", "", "Internal Maven Mirror to be used during source-to-image builds to considerably increase build speed, e.g: https://my.internal.nexus/content/group/public")
+	i.command.Flags().BoolVar(&i.flags.enableIstio, "enable-istio", false, "Enable Istio integration by annotating the Kogito service pods with the right value for Istio controller to inject sidecars on it. Defaults to false")
 }
 
 func (i *deployCommand) Exec(cmd *cobra.Command, args []string) error {
@@ -227,7 +229,8 @@ func (i *deployCommand) Exec(cmd *cobra.Command, args []string) error {
 				Limits:   shared.FromStringArrayToControllerResourceMap(i.flags.Limits),
 				Requests: shared.FromStringArrayToControllerResourceMap(i.flags.Requests),
 			},
-			Infra: v1alpha1.KogitoAppInfra{InstallInfinispan: v1alpha1.KogitoAppInfraInstallInfinispanType(i.flags.installInfinispan), InstallKafka: v1alpha1.KogitoAppInfraInstallKafkaType(i.flags.installKafka)},
+			Infra:       v1alpha1.KogitoAppInfra{InstallInfinispan: v1alpha1.KogitoAppInfraInstallInfinispanType(i.flags.installInfinispan), InstallKafka: v1alpha1.KogitoAppInfraInstallKafkaType(i.flags.installKafka)},
+			EnableIstio: i.flags.enableIstio,
 		},
 		Status: v1alpha1.KogitoAppStatus{
 			ConditionsMeta: v1alpha1.ConditionsMeta{Conditions: make([]v1alpha1.Condition, 0)},

--- a/deploy/crds/app.kiegroup.org_kogitoapps_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitoapps_crd.yaml
@@ -151,6 +151,11 @@ spec:
               required:
               - gitSource
               type: object
+            enableIstio:
+              description: Annotates the pods managed by the operator with the required
+                metadata for Istio to setup its sidecars, enabling the mesh. Defaults
+                to false.
+              type: boolean
             env:
               description: 'Environment variables for the runtime service Default
                 value: nil'
@@ -204,8 +209,8 @@ spec:
               minimum: 0
               type: integer
             resources:
-              description: Resources Data to define Resources needed for each deployed
-                pod
+              description: 'The resources for the deployed pods, like memory and cpu
+                Default value: nil'
               properties:
                 limits:
                   items:

--- a/deploy/olm-catalog/kogito-operator/0.8.0/app.kiegroup.org_kogitoapps_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/0.8.0/app.kiegroup.org_kogitoapps_crd.yaml
@@ -151,6 +151,11 @@ spec:
               required:
               - gitSource
               type: object
+            enableIstio:
+              description: Annotates the pods managed by the operator with the required
+                metadata for Istio to setup its sidecars, enabling the mesh. Defaults
+                to false.
+              type: boolean
             env:
               description: 'Environment variables for the runtime service Default
                 value: nil'
@@ -204,8 +209,8 @@ spec:
               minimum: 0
               type: integer
             resources:
-              description: Resources Data to define Resources needed for each deployed
-                pod
+              description: 'The resources for the deployed pods, like memory and cpu
+                Default value: nil'
               properties:
                 limits:
                   items:

--- a/deploy/olm-catalog/kogito-operator/0.8.0/kogito-operator.v0.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/0.8.0/kogito-operator.v0.8.0.clusterserviceversion.yaml
@@ -133,6 +133,13 @@ spec:
         path: build.native
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Annotates the pods managed by the operator with the required
+          metadata for Istio to setup its sidecars, enabling the mesh. Defaults to
+          false.
+        displayName: Enable Istio
+        path: enableIstio
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: 'Environment variables for the runtime service Default value:
           nil'
         displayName: Environment Variables

--- a/pkg/apis/app/v1alpha1/kogitoapp_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoapp_types.go
@@ -50,7 +50,6 @@ type KogitoAppSpec struct {
 
 	// The resources for the deployed pods, like memory and cpu
 	// Default value: nil
-
 	Resources Resources `json:"resources,omitempty"`
 
 	// S2I Build configuration
@@ -63,6 +62,12 @@ type KogitoAppSpec struct {
 
 	// Infrastructure definition
 	Infra KogitoAppInfra `json:"infra,omitempty"`
+
+	// Annotates the pods managed by the operator with the required metadata for Istio to setup its sidecars, enabling the mesh. Defaults to false.
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Enable Istio"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	EnableIstio bool `json:"enableIstio,omitempty"`
 }
 
 // Resources Data to define Resources needed for each deployed pod

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -674,7 +674,8 @@ func schema_pkg_apis_app_v1alpha1_KogitoAppSpec(ref common.ReferenceCallback) co
 					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Resources"),
+							Description: "The resources for the deployed pods, like memory and cpu Default value: nil",
+							Ref:         ref("github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Resources"),
 						},
 					},
 					"build": {
@@ -693,6 +694,13 @@ func schema_pkg_apis_app_v1alpha1_KogitoAppSpec(ref common.ReferenceCallback) co
 						SchemaProps: spec.SchemaProps{
 							Description: "Infrastructure definition",
 							Ref:         ref("github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.KogitoAppInfra"),
+						},
+					},
+					"enableIstio": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Annotates the pods managed by the operator with the required metadata for Istio to setup its sidecars, enabling the mesh. Defaults to false.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/controller/kogitoapp/resource/deployment_config.go
+++ b/pkg/controller/kogitoapp/resource/deployment_config.go
@@ -163,6 +163,11 @@ func newDeploymentConfig(kogitoApp *v1alpha1.KogitoApp, runnerBC *buildv1.BuildC
 	addDefaultLabels(&dc.Spec.Selector, kogitoApp)
 	framework.MergeImageMetadataWithDeploymentConfig(dc, dockerImage)
 	framework.DiscoverPortsAndProbesFromImage(dc, dockerImage)
+
+	if kogitoApp.Spec.EnableIstio {
+		framework.AddIstioInjectSidecarAnnotation(&dc.Spec.Template.ObjectMeta)
+	}
+
 	setReplicas(kogitoApp, dc)
 
 	return dc, nil

--- a/pkg/framework/istio.go
+++ b/pkg/framework/istio.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+const (
+	istioSidecarInjectAnnotation = "sidecar.istio.io/inject"
+)
+
+// AddIstioInjectSidecarAnnotation adds the annotation to be read by the Istio operator to setup sidecars in the given Pod
+func AddIstioInjectSidecarAnnotation(objectMeta *metav1.ObjectMeta) {
+	if objectMeta == nil {
+		return
+	}
+	if objectMeta.Annotations == nil {
+		objectMeta.Annotations = map[string]string{}
+	}
+	objectMeta.Annotations[istioSidecarInjectAnnotation] = "true"
+}


### PR DESCRIPTION
See:
https://issues.redhat.com/browse/KOGITO-839

In this PR we added the possibility to have istio annotations. Needs more testing, specially with the full Istio infrastructure.

Here's the image:
https://quay.io/repository/ricardozanini/kogito-cloud-operator?tab=tags (0.8.0)

@kmacedovarela
To test it, the operator must be installed via YAML files and the `kogitoApp` CRD applied. I'll be on PTO next week. Could you please try to test it? If you run into problems, please ask @radtriste that he will help you :)

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster