### PR TITLE
[KOGITO-1206] Bump events after scenario run

### DIFF
--- a/pkg/client/kubernetes/event.go
+++ b/pkg/client/kubernetes/event.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	v1beta1 "k8s.io/api/events/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
+)
+
+// EventInterface has functions that interacts with pod object in the Kubernetes cluster
+type EventInterface interface {
+	// Retrieve all events from a namespace
+	GetEvents(namespace string) (*v1beta1.EventList, error)
+}
+
+type event struct {
+	client *client.Client
+}
+
+func newEvent(c *client.Client) EventInterface {
+	client.MustEnsureClient(c)
+	return &event{
+		client: c,
+	}
+}
+
+func (event *event) GetEvents(namespace string) (*v1beta1.EventList, error) {
+	opts := metav1.ListOptions{}
+	return event.client.KubernetesExtensionCli.EventsV1beta1().Events(namespace).List(opts)
+}

--- a/pkg/client/kubernetes/kubernetes.go
+++ b/pkg/client/kubernetes/kubernetes.go
@@ -50,3 +50,13 @@ func Pod() PodInterface {
 func PodC(c *client.Client) PodInterface {
 	return newPod(c)
 }
+
+// Event will fetch the inner API for Kubernetes event resource with a default client
+func Event() EventInterface {
+	return newEvent(&client.Client{})
+}
+
+// EventC will use a defined client to fetch the Kubernetes event resources
+func EventC(c *client.Client) EventInterface {
+	return newEvent(c)
+}

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -101,4 +102,45 @@ func GetScenarioName(s interface{}) string {
 		return scenario.Name
 	}
 	return s.(*gherkin.ScenarioOutline).Name
+}
+
+// PrintDataMap prints a formatted dataMap using the given writer
+func PrintDataMap(keys []string, dataMaps []map[string]string, writer io.StringWriter) {
+	// Get size of strings to be written, to be able to format correctly
+	maxStringSizeMap := make(map[string]int)
+	for _, key := range keys {
+		maxSize := len(key)
+		for _, dataMap := range dataMaps {
+			if len(dataMap[key]) > maxSize {
+				maxSize = len(dataMap[key])
+			}
+		}
+		maxStringSizeMap[key] = maxSize
+	}
+
+	// Write headers
+	for _, header := range keys {
+		writer.WriteString(header)
+		writer.WriteString(getWhitespaceStr(maxStringSizeMap[header] - len(header) + 1))
+		writer.WriteString(" | ")
+	}
+	writer.WriteString("\n")
+
+	// Write events
+	for _, dataMap := range dataMaps {
+		for _, key := range eventKeys {
+			writer.WriteString(dataMap[key])
+			writer.WriteString(getWhitespaceStr(maxStringSizeMap[key] - len(dataMap[key]) + 1))
+			writer.WriteString(" | ")
+		}
+		writer.WriteString("\n")
+	}
+}
+
+func getWhitespaceStr(size int) string {
+	whiteSpaceStr := ""
+	for i := 0; i < size; i++ {
+		whiteSpaceStr += " "
+	}
+	return whiteSpaceStr
 }

--- a/test/steps/data.go
+++ b/test/steps/data.go
@@ -56,6 +56,7 @@ func (data *Data) BeforeScenario(s interface{}) {
 func (data *Data) AfterScenario(s interface{}, err error) {
 	framework.StopPodLogCollector(data.Namespace)
 	framework.FlushLogger(data.Namespace)
+	framework.BumpEvents(data.Namespace)
 
 	logScenarioDuration(data, s)
 	handleScenarioResult(data, s, err)


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-1206

Example output:
```
LAST_SEEN            | FIRST_SEEN           | COUNT  | NAME                                               | KIND  | SUBOBJECT                               | TYPE    | REASON             | ACTION   | SOURCE             | MESSAGE                                                                                                               | 
2020-02-20 13:06:54  | 2020-02-20 13:06:54  | 0      | kogito-operator-564f4659db-5xkrd.15f51ae4ee7eaef0  | -     | -                                       | Normal  | Scheduled          | Binding  | default-scheduler  | Successfully assigned tradisso-local-cucumber-pchy/kogito-operator-564f4659db-5xkrd to playground-lmlv7-worker-9mhtv  | 
0001-01-01 00:00:00  | 0001-01-01 00:00:00  | 1      | kogito-operator-564f4659db-5xkrd.15f51ae7e62a3946  | -     | spec.containers{kogito-cloud-operator}  | Normal  | Pulling            | -        | -                  | Pulling image "quay.io/tradisso/kogito-cloud-operator:0.8.0"                                                          | 
0001-01-01 00:00:00  | 0001-01-01 00:00:00  | 1      | kogito-operator-564f4659db-5xkrd.15f51ae82cb87638  | -     | spec.containers{kogito-cloud-operator}  | Normal  | Pulled             | -        | -                  | Successfully pulled image "quay.io/tradisso/kogito-cloud-operator:0.8.0"                                              | 
0001-01-01 00:00:00  | 0001-01-01 00:00:00  | 1      | kogito-operator-564f4659db-5xkrd.15f51ae835a94b52  | -     | spec.containers{kogito-cloud-operator}  | Normal  | Created            | -        | -                  | Created container kogito-cloud-operator                                                                               | 
0001-01-01 00:00:00  | 0001-01-01 00:00:00  | 1      | kogito-operator-564f4659db-5xkrd.15f51ae837255dd3  | -     | spec.containers{kogito-cloud-operator}  | Normal  | Started            | -        | -                  | Started container kogito-cloud-operator                                                                               | 
0001-01-01 00:00:00  | 0001-01-01 00:00:00  | 1      | kogito-operator-564f4659db.15f51ae4ede9c85a        | -     | -                                       | Normal  | SuccessfulCreate   | -        | -                  | Created pod: kogito-operator-564f4659db-5xkrd                                                                         | 
0001-01-01 00:00:00  | 0001-01-01 00:00:00  | 1      | kogito-operator.15f51ae4ec925ec2                   | -     | -                                       | Normal  | ScalingReplicaSet  | -        | -                  | Scaled up replica set kogito-operator-564f4659db to 1                                                                 | 
```

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster