### PR TITLE
[KOGITO-993] Removing annoying symlinks from protobuf configMaps

### DIFF
--- a/pkg/infrastructure/services/kafka.go
+++ b/pkg/infrastructure/services/kafka.go
@@ -20,20 +20,11 @@ import (
 	kafkabetav1 "github.com/kiegroup/kogito-cloud-operator/pkg/apis/kafka/v1beta1"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 )
 
 const (
-	kafkaClusterLabel string = "strimzi.io/cluster"
-
 	kafkaURINotFoundError string = "there's no Kafka instance URI found in the namespace and Kafka external URI is not specified, cannot deploy Data Index service"
-	kafkaNotExist         string = "there is no Kafka instance found in the namespace, cannot deploy Kafka Topics"
-
-	kafkaTopicConfigRetentionKey   string = "retention.ms"
-	kafkaTopicConfigSegmentKey     string = "segment.bytes"
-	kafkaTopicConfigRetentionValue string = "604800000"
-	kafkaTopicConfigSegmentValue   string = "1073741824"
 
 	quarkusTopicBootstrapEnvVar = "MP_MESSAGING_%s_%s_BOOTSTRAP_SERVERS"
 	quarkusBootstrapEnvVar      = "QUARKUS_KAFKA_BOOTSTRAP_SERVERS"
@@ -62,45 +53,9 @@ func getKafkaServerURI(kafkaProp v1alpha1.KafkaConnectionProperties, namespace s
 	return "", fmt.Errorf(kafkaURINotFoundError)
 }
 
-func getKafkaServerReplicas(kafkaProp v1alpha1.KafkaConnectionProperties, namespace string, client *client.Client) (string, int32, error) {
-	if len(kafkaProp.ExternalURI) <= 0 {
-		if kafka, err := getKafkaInstance(kafkaProp, namespace, client); err != nil {
-			return "", 0, err
-		} else if kafka != nil {
-			if replicas := infrastructure.ResolveKafkaServerReplicas(kafka); replicas > 0 {
-				return kafka.Name, replicas, nil
-			}
-		}
-
-		return "", 0, fmt.Errorf(kafkaNotExist)
-	}
-
-	return "", 0, nil
-}
-
 func getKafkaInstance(kafka v1alpha1.KafkaConnectionProperties, namespace string, client *client.Client) (*kafkabetav1.Kafka, error) {
 	if len(kafka.Instance) > 0 {
 		return infrastructure.GetKafkaInstanceWithName(kafka.Instance, namespace, client)
 	}
 	return nil, nil
-}
-
-func newKafkaTopic(topicName string, kafkaName string, kafkaReplicas int32, namespace string) *kafkabetav1.KafkaTopic {
-	return &kafkabetav1.KafkaTopic{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      topicName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				kafkaClusterLabel: kafkaName,
-			},
-		},
-		Spec: kafkabetav1.KafkaTopicSpec{
-			Replicas:   kafkaReplicas,
-			Partitions: 10,
-			Config: map[string]string{
-				kafkaTopicConfigRetentionKey: kafkaTopicConfigRetentionValue,
-				kafkaTopicConfigSegmentKey:   kafkaTopicConfigSegmentValue,
-			},
-		},
-	}
 }

--- a/pkg/infrastructure/services/resources.go
+++ b/pkg/infrastructure/services/resources.go
@@ -54,14 +54,6 @@ func (s *serviceDeployer) createRequiredResources(instance v1alpha1.KogitoServic
 	}
 
 	if s.definition.kafkaAware {
-		if instance.GetSpec().(v1alpha1.KafkaAware).GetKafkaProperties().UseKogitoInfra &&
-			infrastructure.IsStrimziAvailable(s.client) {
-			if topics, err := s.createKafkaTopics(instance); err != nil {
-				return nil, err
-			} else if topics != nil {
-				resources[reflect.TypeOf(kafkabetav1.KafkaTopic{})] = topics
-			}
-		}
 		if err = s.applyKafkaConfigurations(deployment, instance); err != nil {
 			return
 		}
@@ -112,25 +104,6 @@ func (s *serviceDeployer) applyKafkaConfigurations(deployment *appsv1.Deployment
 	}
 
 	return nil
-}
-
-func (s *serviceDeployer) createKafkaTopics(instance v1alpha1.KogitoService) (topics []resource.KubernetesResource, err error) {
-	if !infrastructure.IsStrimziAvailable(s.client) {
-		return
-	}
-	kafkaName, kafkaReplicas, err := getKafkaServerReplicas(*instance.GetSpec().(v1alpha1.KafkaAware).GetKafkaProperties(), s.getNamespace(), s.client)
-	if err != nil {
-		return
-	} else if len(kafkaName) <= 0 || kafkaReplicas <= 0 {
-		return
-	}
-
-	for _, topic := range s.definition.KafkaTopics {
-		kafkaTopic := newKafkaTopic(topic.TopicName, kafkaName, kafkaReplicas, s.getNamespace())
-		topics = append(topics, kafkaTopic)
-	}
-
-	return
 }
 
 // getDeployedResources gets the deployed resources in the cluster owned by the given instance


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See:
https://issues.redhat.com/browse/KOGITO-993

In this PR we change the way the ConfigMap is mounted in Data Index to avoid symlinks, messing with the Data Index watcher.

Instead of having the protobuf environment variables to be added via Arrays (which doesn't have a required order), we are adding then in a sorted way to avoid this bug: 
https://github.com/RHsyseng/operator-utils/pull/44

I also removed the creation of KafkaTopics by the operator since now Strimzi is auto creating and managing those by itself. The user will be able to change and adjust them accordingly via Strimzi. Was causing a side effect in the ConfigMap tests with Data Index.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster