### PR TITLE
[KOGITO-1255] - Handling Deployment Images like a boss 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/kiegroup/kogito-cloud-operator
 
 require (
-	github.com/RHsyseng/operator-utils v0.0.0-20200108204558-82090ef57586
+	github.com/RHsyseng/operator-utils v0.0.0-20200304191317-2425bf382482
 	github.com/coreos/prometheus-operator v0.34.0
 	github.com/cucumber/godog v0.8.1
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/RHsyseng/operator-utils v0.0.0-20200108204558-82090ef57586 h1:bHfsHIAh0nbiGzDWAvpRBJrNCjNmhqHlNUklpHds52w=
-github.com/RHsyseng/operator-utils v0.0.0-20200108204558-82090ef57586/go.mod h1:E+hCtYz+9UsXfAGnRjX2LGuaa5gSGNKHCVTmGZR79vY=
+github.com/RHsyseng/operator-utils v0.0.0-20200304191317-2425bf382482 h1:fKhuv/tta/VrnwRQb8r8CS8o+zlIR88H8LFkkTG5+uE=
+github.com/RHsyseng/operator-utils v0.0.0-20200304191317-2425bf382482/go.mod h1:E+hCtYz+9UsXfAGnRjX2LGuaa5gSGNKHCVTmGZR79vY=
 github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkFW6gg=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=

--- a/pkg/controller/kogitodataindex/kogitodataindex_controller_test.go
+++ b/pkg/controller/kogitodataindex/kogitodataindex_controller_test.go
@@ -123,8 +123,8 @@ func TestReconcileKogitoDataIndex_UpdateHTTPPort(t *testing.T) {
 			},
 		},
 	}
-
-	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{instance}, nil, nil)
+	is, tag := test.GetImageStreams(infrastructure.DefaultDataIndexImageName, instance.Namespace, instance.Name)
+	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{instance, is}, []runtime.Object{tag}, nil)
 	r := &ReconcileKogitoDataIndex{
 		client: cli,
 		scheme: meta.GetRegisteredSchema(),

--- a/pkg/infrastructure/services/deployment.go
+++ b/pkg/infrastructure/services/deployment.go
@@ -39,7 +39,7 @@ var defaultProbe = &corev1.Probe{
 	FailureThreshold: int32(3),
 }
 
-func createRequiredDeployment(service v1alpha1.KogitoService, image *imageHandler, definition ServiceDefinition) *appsv1.Deployment {
+func createRequiredDeployment(service v1alpha1.KogitoService, image string, definition ServiceDefinition) *appsv1.Deployment {
 	if definition.SingleReplica && service.GetSpec().GetReplicas() > singleReplica {
 		service.GetSpec().SetReplicas(singleReplica)
 		log.Warnf("%s can't scale vertically, only one replica is allowed.", service.GetName())
@@ -69,18 +69,13 @@ func createRequiredDeployment(service v1alpha1.KogitoService, image *imageHandle
 							LivenessProbe:   defaultProbe,
 							ReadinessProbe:  defaultProbe,
 							ImagePullPolicy: corev1.PullAlways,
-							Image:           image.resolveImage(),
+							Image:           image,
 						},
 					},
 				},
 			},
 			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType},
 		},
-	}
-
-	if image.hasImageStream() {
-		key, value := framework.ResolveImageStreamTriggerAnnotation(image.resolveImageNameTag(), service.GetName())
-		deployment.Annotations = map[string]string{key: value}
 	}
 
 	return deployment

--- a/pkg/infrastructure/services/image_test.go
+++ b/pkg/infrastructure/services/image_test.go
@@ -1,0 +1,98 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+)
+
+func Test_imageHandler_resolveImageOnOpenShiftWithImageStreamCreated(t *testing.T) {
+	instance := &v1alpha1.KogitoJobsService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-data-index",
+			Namespace: t.Name(),
+		},
+		Spec: v1alpha1.KogitoJobsServiceSpec{
+			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{Replicas: 1},
+			InfinispanMeta: v1alpha1.InfinispanMeta{
+				InfinispanProperties: v1alpha1.InfinispanConnectionProperties{
+					UseKogitoInfra: false,
+					URI:            "another-uri:11222",
+				},
+			},
+		},
+	}
+	is, tag := test.GetImageStreams(infrastructure.DefaultJobsServiceImageName, instance.Namespace, instance.Name)
+	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{instance, is}, []runtime.Object{tag}, nil)
+	imageHandler := newImageHandler(instance, infrastructure.DefaultJobsServiceImageName, cli)
+	image, err := imageHandler.resolveImage()
+	assert.NoError(t, err)
+	// since we have imagestream and tag, we should see them here
+	assert.Contains(t, image, infrastructure.DefaultJobsServiceImageName)
+}
+
+func Test_imageHandler_resolveImageOnOpenShiftNoImageStreamCreated(t *testing.T) {
+	instance := &v1alpha1.KogitoJobsService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-data-index",
+			Namespace: t.Name(),
+		},
+		Spec: v1alpha1.KogitoJobsServiceSpec{
+			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{Replicas: 1},
+			InfinispanMeta: v1alpha1.InfinispanMeta{
+				InfinispanProperties: v1alpha1.InfinispanConnectionProperties{
+					UseKogitoInfra: false,
+					URI:            "another-uri:11222",
+				},
+			},
+		},
+	}
+	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{instance}, nil, nil)
+	imageHandler := newImageHandler(instance, infrastructure.DefaultJobsServiceImageName, cli)
+	image, err := imageHandler.resolveImage()
+	assert.NoError(t, err)
+	// on OpenShift and no ImageStream? Bye!
+	assert.Empty(t, image)
+}
+
+func Test_imageHandler_resolveImageOnKubernetes(t *testing.T) {
+	instance := &v1alpha1.KogitoJobsService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-data-index",
+			Namespace: t.Name(),
+		},
+		Spec: v1alpha1.KogitoJobsServiceSpec{
+			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{Replicas: 1},
+			InfinispanMeta: v1alpha1.InfinispanMeta{
+				InfinispanProperties: v1alpha1.InfinispanConnectionProperties{
+					UseKogitoInfra: false,
+					URI:            "another-uri:11222",
+				},
+			},
+		},
+	}
+	cli := test.CreateFakeClient([]runtime.Object{instance}, nil, nil)
+	imageHandler := newImageHandler(instance, infrastructure.DefaultJobsServiceImageName, cli)
+	image, err := imageHandler.resolveImage()
+	assert.NoError(t, err)
+	// we should always have an image available on Kubernetes
+	assert.Contains(t, image, infrastructure.DefaultJobsServiceImageName)
+}

--- a/pkg/infrastructure/services/resources_test.go
+++ b/pkg/infrastructure/services/resources_test.go
@@ -1,0 +1,102 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
+	imgv1 "github.com/openshift/api/image/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+)
+
+func Test_serviceDeployer_createRequiredResources_OnOCPImageStreamCreated(t *testing.T) {
+	instance := &v1alpha1.KogitoJobsService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      infrastructure.DefaultJobsServiceName,
+			Namespace: t.Name(),
+		},
+		Spec: v1alpha1.KogitoJobsServiceSpec{
+			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{Replicas: 1},
+			InfinispanMeta: v1alpha1.InfinispanMeta{
+				InfinispanProperties: v1alpha1.InfinispanConnectionProperties{
+					UseKogitoInfra: false,
+					URI:            "another-uri:11222",
+				},
+			},
+		},
+	}
+	is, tag := test.GetImageStreams(infrastructure.DefaultJobsServiceImageName, instance.Namespace, instance.Name)
+	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{instance, is}, []runtime.Object{tag}, nil)
+	deployer := serviceDeployer{
+		client:       cli,
+		scheme:       meta.GetRegisteredSchema(),
+		instanceList: &v1alpha1.KogitoJobsServiceList{},
+		definition: ServiceDefinition{
+			DefaultImageName: infrastructure.DefaultJobsServiceImageName,
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: infrastructure.DefaultJobsServiceName, Namespace: t.Name()},
+			},
+		},
+	}
+	resources, err := deployer.createRequiredResources(instance)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resources)
+	// we have the Image Stream, so other resources should have been created
+	assert.True(t, len(resources) > 1)
+}
+
+func Test_serviceDeployer_createRequiredResources_OnOCPNoImageStreamCreated(t *testing.T) {
+	instance := &v1alpha1.KogitoJobsService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      infrastructure.DefaultJobsServiceName,
+			Namespace: t.Name(),
+		},
+		Spec: v1alpha1.KogitoJobsServiceSpec{
+			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{Replicas: 1},
+			InfinispanMeta: v1alpha1.InfinispanMeta{
+				InfinispanProperties: v1alpha1.InfinispanConnectionProperties{
+					UseKogitoInfra: false,
+					URI:            "another-uri:11222",
+				},
+			},
+		},
+	}
+	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{instance}, nil, nil)
+	deployer := serviceDeployer{
+		client:       cli,
+		scheme:       meta.GetRegisteredSchema(),
+		instanceList: &v1alpha1.KogitoJobsServiceList{},
+		definition: ServiceDefinition{
+			DefaultImageName: infrastructure.DefaultJobsServiceImageName,
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: infrastructure.DefaultJobsServiceName, Namespace: t.Name()},
+			},
+		},
+	}
+	resources, err := deployer.createRequiredResources(instance)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resources)
+	// we have the Image Stream, so other resources should have been created
+	assert.True(t, len(resources) == 1)
+	assert.Equal(t, resources[reflect.TypeOf(imgv1.ImageStream{})][0].GetName(), infrastructure.DefaultJobsServiceImageName)
+}

--- a/pkg/test/image.go
+++ b/pkg/test/image.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"github.com/kiegroup/kogito-cloud-operator/version"
+	v1 "github.com/openshift/api/image/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetImageStreams creates and gets an ImageStream and its ImageStreamTag for mocking purposes
+func GetImageStreams(imageName, namespace, ownerName string) (*v1.ImageStream, *v1.ImageStreamTag) {
+	image := fmt.Sprintf("quay.io/kiegroup/%s:%s", imageName, version.Version)
+	is := &v1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            imageName,
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{{Name: ownerName}},
+		},
+		Spec: v1.ImageStreamSpec{
+			LookupPolicy: v1.ImageLookupPolicy{Local: true},
+			Tags: []v1.TagReference{
+				{
+					Name: version.Version,
+					From: &corev1.ObjectReference{
+						Kind: "DockerImage",
+						Name: image,
+					},
+					ReferencePolicy: v1.TagReferencePolicy{Type: v1.LocalTagReferencePolicy},
+				},
+			},
+		},
+	}
+	tag := &v1.ImageStreamTag{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s:%s", imageName, version.Version), Namespace: namespace},
+		Image: v1.Image{
+			DockerImageReference: image,
+		},
+	}
+	return is, tag
+}


### PR DESCRIPTION
Many thanks for submiting your Pull Request :heart:! 

See:
https://issues.redhat.com/browse/KOGITO-1255

In this PR we reinvented the way we add images to Deployment resources. Now the Operator will wait for the ImageStream to be ready to create the Deployment resource. In case you change the image, we just hold the old value until the OpenShift triggers us again.

Bonus: we fixed the annoying sort bug that made a lot of reconciliation updates until the environment variables were in the order it wants. This one is from the operator-utils, that's why we changed the `go.mod`file.

I'll rebase this PR once we merge https://github.com/kiegroup/kogito-cloud-operator/pull/196

I've decided to submit this one to move the clutter before starting working on the binary builds.

Would be awesome to have it for 0.8.0.

Have fun!

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster