### PR TITLE
[KOGITO-1408] Install missing dependent crd before start of test

### DIFF
--- a/test/framework/kubernetes.go
+++ b/test/framework/kubernetes.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -184,4 +185,14 @@ func checkAllPodsContainingTextInLog(namespace string, pods *corev1.PodList, con
 func isPodContainingTextInLog(namespace string, pod *corev1.Pod, containerName, text string) (bool, error) {
 	log, err := kubernetes.PodC(kubeClient).GetLogs(namespace, pod.GetName(), containerName)
 	return strings.Contains(log, text), err
+}
+
+// IsCrdAvailable returns whether the crd is available on cluster
+func IsCrdAvailable(crdName string) (bool, error) {
+	crdEntity := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+	}
+	return kubernetes.ResourceC(kubeClient).Fetch(crdEntity)
 }

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -29,9 +29,9 @@ import (
 )
 
 // GenerateNamespaceName generates a namespace name, taking configuration into account (local or not)
-func GenerateNamespaceName() string {
+func GenerateNamespaceName(prefix string) string {
 	rand.Seed(time.Now().UnixNano())
-	ns := fmt.Sprintf("cucumber-%s", RandSeq(4))
+	ns := fmt.Sprintf("%s-%s", prefix, RandSeq(4))
 	if IsConfigLocalTests() {
 		username := getEnvUsername()
 		ns = fmt.Sprintf("%s-local-%s", username, ns)

--- a/test/steps/data.go
+++ b/test/steps/data.go
@@ -46,7 +46,7 @@ func (data *Data) RegisterAllSteps(s *godog.Suite) {
 // BeforeScenario configure the data before a scenario is launched
 func (data *Data) BeforeScenario(s interface{}) {
 	data.StartTime = time.Now()
-	data.Namespace = framework.GenerateNamespaceName()
+	data.Namespace = framework.GenerateNamespaceName("cucumber")
 
 	framework.GetLogger(data.Namespace).Info(fmt.Sprintf("Scenario %s", framework.GetScenarioName(s)))
 	go framework.StartPodLogCollector(data.Namespace)


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-1408

Workaround int tests until KOGITO-1376 is implemented, as we would like the kogito pipelines to run correctly.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster