### PR TITLE
[KOGITO-1439] Cucumber tests: Set CLI or CR tests via test option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ smoke=false
 load_factor=1
 local=false
 ci=
+cr_deployment_only=false
 # operator information
 operator_image=
 operator_tag=
@@ -109,6 +110,7 @@ run-tests:
 	&& if [ "$${debug}" = "true" ]; then opts+=("--debug"); fi \
 	&& if [ "$${smoke}" = "true" ]; then opts+=("--smoke"); fi \
 	&& if [ "$${local}" = "true" ]; then opts+=("--local"); fi \
+	&& if [ "$${cr_deployment_only}" = "true" ]; then opts+=("--cr_deployment_only"); fi \
 	&& if [ "$${show_scenarios}" = "true" ]; then opts+=("--show_scenarios"); fi \
 	&& if [ "$${dry_run}" = "true" ]; then opts+=("--dry_run"); fi \
 	&& if [ "$${keep_namespace}" = "true" ]; then opts+=("--keep_namespace"); fi \

--- a/README.md
+++ b/README.md
@@ -972,6 +972,7 @@ You can set those optional keys:
 - `local` to be set to true if running tests in local.  
   *Default is false.*
 - `ci` to be set if running tests with CI. Give CI name. 
+- `cr_deployment_only` to be set if you don't have a CLI built. Default will deploy applications via the CLI.
 - `operator_image` is the Operator image full name.  
   *Default: operator_image=quay.io/kiegroup/kogito-cloud-operator*.
 - `operator_tag` is the Operator image tag.  

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -52,6 +52,7 @@ function usage(){
   printf "\n--load_factor {INT_VALUE}\n\tSet the tests load factor. Useful for the tests to take into account that the cluster can be overloaded, for example for the calculation of timouts. Default value is 1."
   printf "\n--local\n\tSpecify whether you run test in local."
   printf "\n--ci {CI_NAME}\n\tSpecify whether you run test with ci, give also the name of the CI."
+  printf "\n--cr_deployment_only\n\tUse this option if you have no CLI to test against. It will use only direct CR deployments."
 
   # operator information
   printf "\n--operator_image {NAME}\n\tOperator image name. Default is 'quay.io/kiegroup' one."
@@ -204,6 +205,10 @@ case $1 in
   --ci)
     shift
     if addParamKeyValueIfAccepted "--tests.ci" ${1}; then shift; fi
+  ;;
+  --cr_deployment_only)
+    addParam "--tests.cr-deployment-only"
+    shift
   ;;
 
   # operator information

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package framework
+package config
 
 import (
 	"flag"
@@ -24,10 +24,11 @@ import (
 // TestConfig contains the information about the tests environment
 type TestConfig struct {
 	// tests configuration
-	smoke      bool
-	loadFactor int
-	localTests bool
-	ciName     string
+	smoke            bool
+	loadFactor       int
+	localTests       bool
+	ciName           string
+	crDeploymentOnly bool
 
 	// operator information
 	operatorImageName string
@@ -76,8 +77,8 @@ var (
 	env = TestConfig{}
 )
 
-// BindTestsConfigFlags binds BDD tests env flags to given flag set
-func BindTestsConfigFlags(set *flag.FlagSet) {
+// BindFlags binds BDD tests env flags to given flag set
+func BindFlags(set *flag.FlagSet) {
 	prefix := "tests."
 	developmentOptionsPrefix := prefix + "dev."
 
@@ -86,6 +87,7 @@ func BindTestsConfigFlags(set *flag.FlagSet) {
 	set.IntVar(&env.loadFactor, prefix+"load-factor", defaultLoadFactor, "Set the tests load factor. Useful for the tests to take into account that the cluster can be overloaded, for example for the calculation of timeouts. Default value is 1.")
 	set.BoolVar(&env.localTests, prefix+"local", false, "If tests are launch on local machine")
 	set.StringVar(&env.ciName, prefix+"ci", "", "If tests are launch on ci machine, give the CI name")
+	set.BoolVar(&env.crDeploymentOnly, prefix+"cr-deployment-only", false, "Use this option if you have no CLI to test against. It will use only direct CR deployments.")
 
 	// operator information
 	set.StringVar(&env.operatorImageName, prefix+"operator-image-name", defaultOperatorImageName, "Operator image name")
@@ -119,119 +121,124 @@ func BindTestsConfigFlags(set *flag.FlagSet) {
 
 // tests configuration
 
-// IsConfigSmokeTests return whether tests are executed in local
-func IsConfigSmokeTests() bool {
+// IsSmokeTests return whether tests are executed in local
+func IsSmokeTests() bool {
 	return env.smoke
 }
 
-// GetConfigLoadFactor return the load factor of the cluster
-func GetConfigLoadFactor() int {
+// GetLoadFactor return the load factor of the cluster
+func GetLoadFactor() int {
 	return env.loadFactor
 }
 
-// IsConfigLocalTests return whether tests are executed in local
-func IsConfigLocalTests() bool {
+// IsLocalTests return whether tests are executed in local
+func IsLocalTests() bool {
 	return env.localTests
 }
 
-// GetConfigCiName return the CI name that executes the tests, if any
-func GetConfigCiName() string {
+// GetCiName return the CI name that executes the tests, if any
+func GetCiName() string {
 	return env.ciName
+}
+
+// IsCrDeploymentOnly returns whether the deployment should be done only with CR
+func IsCrDeploymentOnly() bool {
+	return env.crDeploymentOnly
 }
 
 // operator information
 
-// GetConfigOperatorImageName return the image name for the operator
-func GetConfigOperatorImageName() string {
+// GetOperatorImageName return the image name for the operator
+func GetOperatorImageName() string {
 	return env.operatorImageName
 }
 
-// GetConfigOperatorImageTag return the image tag for the operator
-func GetConfigOperatorImageTag() string {
+// GetOperatorImageTag return the image tag for the operator
+func GetOperatorImageTag() string {
 	return env.operatorImageTag
 }
 
 // files/binaries
 
-// GetConfigOperatorDeployURI return the uri for deployment folder
-func GetConfigOperatorDeployURI() string {
+// GetOperatorDeployURI return the uri for deployment folder
+func GetOperatorDeployURI() string {
 	return env.operatorDeployURI
 }
 
-// GetConfigOperatorCliPath return the path to the kogito CLI binary
-func GetConfigOperatorCliPath() (string, error) {
+// GetOperatorCliPath return the path to the kogito CLI binary
+func GetOperatorCliPath() (string, error) {
 	return filepath.Abs(env.cliPath)
 }
 
 // runtime
 
-// GetConfigServicesImageVersion return the version for the services images
-func GetConfigServicesImageVersion() string {
+// GetServicesImageVersion return the version for the services images
+func GetServicesImageVersion() string {
 	return env.servicesImageVersion
 }
 
-// GetConfigDataIndexImageTag return the Kogito Data Index image tag
-func GetConfigDataIndexImageTag() string {
+// GetDataIndexImageTag return the Kogito Data Index image tag
+func GetDataIndexImageTag() string {
 	return env.dataIndexImageTag
 }
 
-// GetConfigJobsServiceImageTag return the Kogito Jobs Service image tag
-func GetConfigJobsServiceImageTag() string {
+// GetJobsServiceImageTag return the Kogito Jobs Service image tag
+func GetJobsServiceImageTag() string {
 	return env.jobsServiceImageTag
 }
 
 // build
 
-// GetConfigMavenMirrorURL return the maven mirror url used for building applications
-func GetConfigMavenMirrorURL() string {
+// GetMavenMirrorURL return the maven mirror url used for building applications
+func GetMavenMirrorURL() string {
 	return env.mavenMirrorURL
 }
 
-// GetConfigBuildImageVersion return the version for the build images
-func GetConfigBuildImageVersion() string {
+// GetBuildImageVersion return the version for the build images
+func GetBuildImageVersion() string {
 	return env.buildImageVersion
 }
 
-// GetConfigBuildS2IImageStreamTag return the tag for the s2i build image
-func GetConfigBuildS2IImageStreamTag() string {
+// GetBuildS2IImageStreamTag return the tag for the s2i build image
+func GetBuildS2IImageStreamTag() string {
 	return env.buildS2iImageTag
 }
 
-// GetConfigBuildRuntimeImageStreamTag return the tag for the runtime build image
-func GetConfigBuildRuntimeImageStreamTag() string {
+// GetBuildRuntimeImageStreamTag return the tag for the runtime build image
+func GetBuildRuntimeImageStreamTag() string {
 	return env.buildRuntimeImageTag
 }
 
 // examples repository
 
-// GetConfigExamplesRepositoryURI return the uri for the examples repository
-func GetConfigExamplesRepositoryURI() string {
+// GetExamplesRepositoryURI return the uri for the examples repository
+func GetExamplesRepositoryURI() string {
 	return env.examplesRepositoryURI
 }
 
-// GetConfigExamplesRepositoryRef return the branch for the examples repository
-func GetConfigExamplesRepositoryRef() string {
+// GetExamplesRepositoryRef return the branch for the examples repository
+func GetExamplesRepositoryRef() string {
 	return env.examplesRepositoryRef
 }
 
 // dev options
 
-// IsConfigShowScenarios return whether we should display scenarios
-func IsConfigShowScenarios() bool {
+// IsShowScenarios return whether we should display scenarios
+func IsShowScenarios() bool {
 	return env.showScenarios
 }
 
-// IsConfigDryRun return whether we should do a dry run
-func IsConfigDryRun() bool {
+// IsDryRun return whether we should do a dry run
+func IsDryRun() bool {
 	return env.dryRun
 }
 
-// IsConfigKeepNamespace return whether we should keep namespace after scenario run
-func IsConfigKeepNamespace() bool {
+// IsKeepNamespace return whether we should keep namespace after scenario run
+func IsKeepNamespace() bool {
 	return env.keepNamespace
 }
 
-// GetConfigNamespaceName return namespace name if it was defined
-func GetConfigNamespaceName() string {
+// GetNamespaceName return namespace name if it was defined
+func GetNamespaceName() string {
 	return env.namespaceName
 }

--- a/test/features/deploy_quarkus_service.feature
+++ b/test/features/deploy_quarkus_service.feature
@@ -7,7 +7,7 @@ Feature: Deploy quarkus service
   Scenario Outline: Deploy drools-quarkus-example service without persistence
     Given Kogito Operator is deployed
     
-    When "<installer>" deploy quarkus example service "ruleunit-quarkus-example" with native "<native>"
+    When Deploy quarkus example service "ruleunit-quarkus-example" with native <native>
 
     Then Kogito application "ruleunit-quarkus-example" has 1 pods running within <minutes> minutes
     And HTTP POST request on service "ruleunit-quarkus-example" is successful within 2 minutes with path "find-approved" and body:
@@ -41,36 +41,23 @@ Feature: Deploy quarkus service
           }]
         }
       """
-    
-    @cr
-    Examples: CR Non Native
-      | installer | native | minutes |
-      | CR        | false  | 10      |
 
-    @cr
+    @smoke  
+    Examples: Non Native
+      | native   | minutes |
+      | disabled | 10      |
+
     @native
-    Examples: CR Native
-      | installer | native | minutes |
-      | CR        | true   | 20      |
-
-    @smoke
-    @cli
-    Examples: CLI Non Native
-      | installer | native | minutes |
-      | CLI       | false  | 10      |
-
-    @cli
-    @native
-    Examples: CLI Native
-      | installer | native | minutes |
-      | CLI       | true   | 20      |
+    Examples: Native
+      | native  | minutes |
+      | enabled | 20      |
 
 #####
 
   @persistence
   Scenario Outline: Deploy jbpm-quarkus-example service with persistence
     Given Kogito Operator is deployed with Infinispan operator
-    And "<installer>" deploy quarkus example service "jbpm-quarkus-example" with native "<native>" and persistence
+    And Deploy quarkus example service "jbpm-quarkus-example" with native <native> and persistence
     And Kogito application "jbpm-quarkus-example" has 1 pods running within <minutes> minutes
     And HTTP GET request on service "jbpm-quarkus-example" with path "orders" is successful within 3 minutes
     And HTTP POST request on service "jbpm-quarkus-example" with path "orders" and body:
@@ -90,38 +77,24 @@ Feature: Deploy quarkus service
     
     Then HTTP GET request on service "jbpm-quarkus-example" with path "orders" should return an array of size 1 within 2 minutes
     
-    @cr
-    Examples: CR Non Native
-      | installer | native | minutes |
-      | CR        | false  | 10      |
+    Examples: Non Native
+      | native   | minutes |
+      | disabled | 10      |
 
-    @cr
     @native
-    Examples: CR Native
-      | installer | native | minutes |
-      | CR        | true   | 20      |
-
-    @cli
-    Examples: CLI Non Native
-      | installer | native | minutes |
-      | CLI       | false  | 10      |
-
-    @cli
-    @native
-    Examples: CLI Native
-      | installer | native | minutes |
-      | CLI       | true   | 20      |
+    Examples: Native
+      | native  | minutes |
+      | enabled | 20      |
 
 #####
 
   # Disabled as long as https://issues.redhat.com/browse/KOGITO-1163 and https://issues.redhat.com/browse/KOGITO-1166 is not solved
   @disabled
-  @cr
   @jobsservice
   Scenario Outline: Deploy timer-quarkus-example service with Jobs service
     Given Kogito Operator is deployed
-    And "CR" install Kogito Jobs Service with 1 replicas
-    And "CR" deploy quarkus example service "timer-quarkus-example" with native "<native>"
+    And Install Kogito Jobs Service with 1 replicas
+    And Deploy quarkus example service "timer-quarkus-example" with native <native>
     And Kogito application "timer-quarkus-example" has 1 pods running within <minutes> minutes
 
     When HTTP POST request on service "timer-quarkus-example" is successful within 2 minutes with path "timer" and body:
@@ -134,12 +107,12 @@ Feature: Deploy quarkus service
     And Kogito application "timer-quarkus-example" log contains text "After timer" within 1 minutes
 
     Examples: Non Native
-      | native | minutes |
-      | false  | 10      |
+      | native   | minutes |
+      | disabled | 10      |
 
     # Disabled as long as https://issues.redhat.com/browse/KOGITO-1179 is not solved
     @disabled
     @native
     Examples: Native
-      | native | minutes |
-      | true   | 20      |
+      | native  | minutes |
+      | enabled | 20      |

--- a/test/features/deploy_springboot_service.feature
+++ b/test/features/deploy_springboot_service.feature
@@ -4,33 +4,23 @@ Feature: Deploy spring boot service
   Background:
     Given Namespace is created
 
-  Scenario Outline: Deploy jbpm-springboot-example service without persistence
+  @smoke
+  Scenario: Deploy jbpm-springboot-example service without persistence
     Given Kogito Operator is deployed
     
-    When "<installer>" deploy spring boot example service "jbpm-springboot-example"
+    When Deploy spring boot example service "jbpm-springboot-example"
 
     Then Kogito application "jbpm-springboot-example" has 1 pods running within 10 minutes
     And HTTP GET request on service "jbpm-springboot-example" with path "orders" is successful within 2 minutes
-
-    @cr
-    Examples: CR
-      | installer |
-      | CR        |
-
-    @smoke
-    @cli
-    Examples: CLI
-      | installer |
-      | CLI       |
 
 #####
 
   # Disabled because of https://issues.redhat.com/browse/KOGITO-948
   @disabled
   @persistence
-  Scenario Outline: Deploy jbpm-springboot-example service with persistence
+  Scenario: Deploy jbpm-springboot-example service with persistence
     Given Kogito Operator is deployed with Infinispan operator
-    And "<installer>" deploy spring boot example service "jbpm-springboot-example" with persistence
+    And Deploy spring boot example service "jbpm-springboot-example" with persistence
     And Kogito application "jbpm-springboot-example" has 1 pods running within 10 minutes
     And HTTP GET request on service "jbpm-springboot-example" with path "orders" is successful within 3 minutes
     And HTTP POST request on service "jbpm-springboot-example" with path "orders" and body:
@@ -50,25 +40,15 @@ Feature: Deploy spring boot service
     
     Then HTTP GET request on service "jbpm-springboot-example" with path "orders" should return an array of size 1 within 2 minutes
 
-    @cr
-    Examples: CR
-      | installer |
-      | CR        |
-
-    @cli
-    Examples: CLI
-      | installer |
-      | CLI       |
 #####
 
   # Disabled as long as https://issues.redhat.com/browse/KOGITO-1163 and https://issues.redhat.com/browse/KOGITO-1166 is not solved
   @disabled
-  @cr
   @jobsservice
-  Scenario: CR deploy timer-springboot-example service with Jobs service
+  Scenario: Deploy timer-springboot-example service with Jobs service
     Given Kogito Operator is deployed
-    And "CR" install Kogito Jobs Service with 1 replicas
-    And "CR" deploy spring boot example service "timer-springboot-example"
+    And Install Kogito Jobs Service with 1 replicas
+    And Deploy spring boot example service "timer-springboot-example"
     And Kogito application "timer-springboot-example" has 1 pods running within 10 minutes
 
     When HTTP POST request on service "timer-springboot-example" is successful within 2 minutes with path "timer" and body:

--- a/test/features/deploy_travel_agency.feature
+++ b/test/features/deploy_travel_agency.feature
@@ -1,13 +1,13 @@
 @quarkus
-@cr
+@travelagency
 Feature: Deploy Travel agency service and verify its functionality
 
   Background:
     Given Namespace is created
     And Kogito Operator is deployed with Infinispan and Kafka operators
-    And "CR" install Kogito Data Index with 1 replicas
-    And "CR" deploy service from example file "travelapp-kogito-travel-agency.yaml"
-    And "CR" deploy service from example file "travelapp-kogito-visas.yaml"
+    And Install Kogito Data Index with 1 replicas
+    And Deploy service from example file "travelapp-kogito-travel-agency.yaml"
+    And Deploy service from example file "travelapp-kogito-visas.yaml"
     And Kogito application "kogito-travel-agency" has 1 pods running within 10 minutes
     And HTTP GET request on service "kogito-travel-agency" with path "travels" is successful within 1 minutes
     And Kogito application "kogito-visas" has 1 pods running within 10 minutes

--- a/test/features/install_dataindex.feature
+++ b/test/features/install_dataindex.feature
@@ -5,9 +5,9 @@ Feature: Kogito Data Index
     Given Namespace is created
     And Kogito Operator is deployed with Infinispan and Kafka operators
 
-  Scenario Outline: Install Kogito Data Index
-    When "<installer>" install Kogito Data Index with 1 replicas
-
+  @smoke
+  Scenario: Install Kogito Data Index
+    When Install Kogito Data Index with 1 replicas
     Then Kogito Data Index has 1 pods running within 10 minutes
     And GraphQL request on service "kogito-data-index" is successful within 2 minutes with path "graphql" and query:
     """
@@ -18,25 +18,13 @@ Feature: Kogito Data Index
     }
     """
 
-    @cr
-    Examples: CR
-      | installer |
-      | CR        |
-
-    @smoke
-    @cli
-    Examples: CLI
-      | installer |
-      | CLI       |
-
 #####
 
-  @cr
   @events
   @persistence
   Scenario Outline: Process instance events are stored in Data Index
-    Given "CR" install Kogito Data Index with 1 replicas
-    And "CR" deploy quarkus example service "jbpm-quarkus-example" with native "<native>" and persistence and events
+    Given Install Kogito Data Index with 1 replicas
+    And Deploy quarkus example service "jbpm-quarkus-example" with native <native> and persistence and events
     And Kogito application "jbpm-quarkus-example" has 1 pods running within <minutes> minutes
     And HTTP GET request on service "jbpm-quarkus-example" with path "orders" is successful within 3 minutes
 
@@ -54,12 +42,12 @@ Feature: Kogito Data Index
     Then GraphQL request on Data Index service returns ProcessInstances processName "orders" within 2 minutes
 
     Examples: Non native
-      | native | minutes |
-      | false  | 10      |
+      | native   | minutes |
+      | disabled | 10      |
 
     # Disabled because of https://issues.redhat.com/browse/KOGITO-1405
     @disabled
     @native
     Examples: Native
-      | native | minutes |
-      | true   | 20      |
+      | native  | minutes |
+      | enabled | 20      |

--- a/test/features/install_jobs_service.feature
+++ b/test/features/install_jobs_service.feature
@@ -4,10 +4,11 @@ Feature: Install Kogito Jobs Service
   Background:
     Given Namespace is created
 
-  Scenario Outline: Install Kogito Jobs Service without persistence
+  @smoke
+  Scenario: Install Kogito Jobs Service without persistence
     Given Kogito Operator is deployed
 
-    When "<installer>" install Kogito Jobs Service with 1 replicas
+    When Install Kogito Jobs Service with 1 replicas
     And Kogito Jobs Service has 1 pods running within 10 minutes
     And HTTP POST request on service "kogito-jobs-service" is successful within 2 minutes with path "jobs" and body:
       """json
@@ -21,24 +22,13 @@ Feature: Install Kogito Jobs Service
 
     Then HTTP GET request on service "kogito-jobs-service" with path "jobs/1" is successful within 1 minutes
 
-    @cr
-    Examples: CR
-      | installer |
-      | CR        |
-
-    @smoke
-    @cli
-    Examples: CLI
-      | installer |
-      | CLI       |
-
 #####
 
   @persistence
-  Scenario Outline: Install Kogito Jobs Service with persistence
+  Scenario: Install Kogito Jobs Service with persistence
     Given Kogito Operator is deployed with Infinispan operator
     
-    When "<installer>" install Kogito Jobs Service with 1 replicas and persistence
+    When Install Kogito Jobs Service with 1 replicas and persistence
     And Kogito Jobs Service has 1 pods running within 10 minutes
     And HTTP POST request on service "kogito-jobs-service" is successful within 2 minutes with path "jobs" and body:
       """json
@@ -54,13 +44,3 @@ Feature: Install Kogito Jobs Service
     And Scale Kogito Jobs Service to 1 pods within 2 minutes
 
     Then HTTP GET request on service "kogito-jobs-service" with path "jobs/1" is successful within 1 minutes
-
-    @cr
-    Examples: CR
-      | installer |
-      | CR        |
-
-    @cli
-    Examples: CLI
-      | installer |
-      | CLI       |

--- a/test/features/install_kogitoinfra.feature
+++ b/test/features/install_kogitoinfra.feature
@@ -6,22 +6,14 @@ Feature: Kogito Infra
 
   Scenario Outline: Install/Remove Kogito Infra
     Given Kogito Operator is deployed with <component> operator
-    When "<installer>" install Kogito Infra "<component>"
+    When Install Kogito Infra "<component>"
     Then Kogito Infra "<component>" should be running within <installTimeoutInMinutes> minutes
 
-    When "<installer>" remove Kogito Infra "<component>"
+    When Remove Kogito Infra "<component>"
     Then Kogito Infra "<component>" should NOT be running within <removeTimeoutInMinutes> minutes
 
-    @cr
-    Examples: CR install/Remove
-      | installer | component  | installTimeoutInMinutes | removeTimeoutInMinutes |
-      | CR        | Infinispan | 10                      | 5                      |
-      | CR        | Kafka      | 10                      | 5                      |
-      | CR        | Keycloak   | 10                      | 5                      |
-    
-    @cli
-    Examples: CLI install/Remove
-      | installer | component  | installTimeoutInMinutes | removeTimeoutInMinutes |
-      | CLI       | Infinispan | 10                      | 5                      |
-      | CLI       | Kafka      | 10                      | 5                      |
-      | CLI       | Keycloak   | 10                      | 5                      |
+    Examples:
+      | component  | installTimeoutInMinutes | removeTimeoutInMinutes |
+      | Infinispan | 10                      | 5                      |
+      | Kafka      | 10                      | 5                      |
+      | Keycloak   | 10                      | 5                      |

--- a/test/features/prometheus.feature
+++ b/test/features/prometheus.feature
@@ -1,6 +1,5 @@
 # Disabled until image metadata label processing is fixed in OCP 4.x or https://issues.redhat.com/browse/KOGITO-731 is implemented
 @disabled
-@cr
 Feature: Service Deployment: Prometheus
 
   Background:
@@ -10,7 +9,7 @@ Feature: Service Deployment: Prometheus
 
   Scenario: Deploy hr service and verify that it successfully connects to Prometheus
     Given Prometheus instance is deployed, monitoring services with label name "app" and value "hr"
-    And "CR" deploy quarkus example service "onboarding-example/hr" with native "false"
+    And Deploy quarkus example service "onboarding-example/hr" with native disabled
     And Kogito application "hr" has 1 pods running within 10 minutes
 
     When HTTP POST request on service "hr" is successful within 2 minutes with path "id" and body:

--- a/test/features/service_discovery.feature
+++ b/test/features/service_discovery.feature
@@ -1,5 +1,4 @@
 @discovery
-@cr
 Feature: Discovery with onboarding
 
   Background:
@@ -8,17 +7,17 @@ Feature: Discovery with onboarding
   Scenario Outline: Deploy onboarding example
     Given Kogito Operator is deployed
     
-    When "CR" deploy quarkus example service "onboarding-example/hr" with native "<native>" and labels 
+    When Deploy quarkus example service "onboarding-example/hr" with native <native> and labels 
       | department         | process |
       | id                 | process |
       | employeeValidation | process |
 
-    And "CR" deploy quarkus example service "onboarding-example/payroll" with native "<native>" and labels
+    And Deploy quarkus example service "onboarding-example/payroll" with native <native> and labels
       | taxes/rate         | process |
       | vacations/days     | process |
       | payments/date      | process |
 
-    And "CR" deploy quarkus example service "onboarding-example/onboarding" with native "<native>" and labels
+    And Deploy quarkus example service "onboarding-example/onboarding" with native <native> and labels
       | onboarding         | process |
 
     And Kogito application "hr" has 1 pods running within <minutes> minutes
@@ -44,12 +43,12 @@ Feature: Discovery with onboarding
       """
     
     Examples: Non Native
-      | native      | minutes |
-      | false       | 10      |
+      | native   | minutes |
+      | disabled | 10      |
 
     # disabled because of https://issues.redhat.com/browse/KOGITO-1357
     @disabled
     @native
     Examples: Native
-      | native    | minutes |
-      | true      | 20      |
+      | native  | minutes |
+      | enabled | 20      |

--- a/test/framework/cli.go
+++ b/test/framework/cli.go
@@ -17,11 +17,13 @@ package framework
 import (
 	"os"
 	"os/exec"
+
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
 )
 
 // CheckCliBinaryExist checks if the CLI binary does exist
 func CheckCliBinaryExist() (bool, error) {
-	path, err := GetConfigOperatorCliPath()
+	path, err := config.GetOperatorCliPath()
 	if err != nil {
 		return false, err
 	}
@@ -38,7 +40,7 @@ func CheckCliBinaryExist() (bool, error) {
 // ExecuteCliCommand executes a kogito cli command for a given namespace
 func ExecuteCliCommand(namespace string, args ...string) (string, error) {
 	GetLogger(namespace).Infof("Execute CLI %v", args)
-	path, err := GetConfigOperatorCliPath()
+	path, err := config.GetOperatorCliPath()
 	if err != nil {
 		return "", err
 	}

--- a/test/framework/installer.go
+++ b/test/framework/installer.go
@@ -15,8 +15,7 @@
 package framework
 
 import (
-	"fmt"
-	"strings"
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
 )
 
 // InstallerType defines the type of installer for services
@@ -34,14 +33,10 @@ var (
 	CRInstallerType InstallerType = crInstallerKey
 )
 
-// MustParseInstallerType returns the correct installer type, based on the given string
-func MustParseInstallerType(typeStr string) InstallerType {
-	switch t := strings.ToLower(typeStr); t {
-	case cliInstallerKey:
-		return CLIInstallerType
-	case crInstallerKey:
+// GetDefaultInstallerType returns the default installer type for the tests
+func GetDefaultInstallerType() InstallerType {
+	if config.IsCrDeploymentOnly() {
 		return CRInstallerType
-	default:
-		panic(fmt.Errorf("Unknown installer type %s", typeStr))
 	}
+	return CLIInstallerType
 }

--- a/test/framework/kogitodataindex.go
+++ b/test/framework/kogitodataindex.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/framework"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -77,12 +78,12 @@ func cliInstallKogitoDataIndex(namespace string, replicas int) error {
 }
 
 func getDataIndexImage() v1alpha1.Image {
-	if len(GetConfigDataIndexImageTag()) > 0 {
-		return framework.ConvertImageTagToImage(GetConfigDataIndexImageTag())
+	if len(config.GetDataIndexImageTag()) > 0 {
+		return framework.ConvertImageTagToImage(config.GetDataIndexImageTag())
 	}
 
 	image := framework.ConvertImageTagToImage(infrastructure.DefaultDataIndexImageFullTag)
-	image.Tag = GetConfigServicesImageVersion()
+	image.Tag = config.GetServicesImageVersion()
 	return image
 }
 

--- a/test/framework/kogitojobsservice.go
+++ b/test/framework/kogitojobsservice.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/framework"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,12 +66,12 @@ func cliInstallKogitoJobsService(namespace string, replicas int, persistence boo
 }
 
 func getJobsServiceImageTag() v1alpha1.Image {
-	if len(GetConfigJobsServiceImageTag()) > 0 {
-		return framework.ConvertImageTagToImage(GetConfigJobsServiceImageTag())
+	if len(config.GetJobsServiceImageTag()) > 0 {
+		return framework.ConvertImageTagToImage(config.GetJobsServiceImageTag())
 	}
 
 	image := framework.ConvertImageTagToImage(infrastructure.DefaultJobsServiceImageFullTag)
-	image.Tag = GetConfigServicesImageVersion()
+	image.Tag = config.GetServicesImageVersion()
 	return image
 }
 

--- a/test/framework/openshift.go
+++ b/test/framework/openshift.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/openshift"
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
 )
 
 // WaitForBuildComplete waits for a build to be completed
@@ -166,5 +167,5 @@ func WaitForOnOpenshift(namespace, display string, timeoutInMin int, condition f
 
 // GetOpenshiftDurationFromTimeInMin will calculate the time depending on the configured cluster load factor
 func GetOpenshiftDurationFromTimeInMin(timeoutInMin int) time.Duration {
-	return time.Duration(timeoutInMin*GetConfigLoadFactor()) * time.Minute
+	return time.Duration(timeoutInMin*config.GetLoadFactor()) * time.Minute
 }

--- a/test/framework/operator.go
+++ b/test/framework/operator.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
 	infra "github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
 
 	olmapiv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -68,7 +69,7 @@ var (
 
 // DeployKogitoOperatorFromYaml Deploy Kogito Operator from yaml files
 func DeployKogitoOperatorFromYaml(namespace string) error {
-	var deployURI = GetConfigOperatorDeployURI()
+	var deployURI = config.GetOperatorDeployURI()
 	GetLogger(namespace).Infof("Deploy Operator from yaml files in %s", deployURI)
 
 	// TODO: error handling, go lint is screaming about this
@@ -219,7 +220,7 @@ func CreateNamespacedSubscriptionIfNotExist(namespace string, subscriptionName s
 }
 
 func getOperatorImageNameAndTag() string {
-	return fmt.Sprintf("%s:%s", GetConfigOperatorImageName(), GetConfigOperatorImageTag())
+	return fmt.Sprintf("%s:%s", config.GetOperatorImageName(), config.GetOperatorImageTag())
 }
 
 // IsCommunityOperatorCrdAvailable returns whether the crd is available on cluster

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -26,17 +26,23 @@ import (
 	"time"
 
 	"github.com/cucumber/godog/gherkin"
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
+)
+
+const (
+	enabledKey  = "enabled"
+	disabledKey = "disabled"
 )
 
 // GenerateNamespaceName generates a namespace name, taking configuration into account (local or not)
 func GenerateNamespaceName(prefix string) string {
 	rand.Seed(time.Now().UnixNano())
 	ns := fmt.Sprintf("%s-%s", prefix, RandSeq(4))
-	if IsConfigLocalTests() {
+	if config.IsLocalTests() {
 		username := getEnvUsername()
 		ns = fmt.Sprintf("%s-local-%s", username, ns)
-	} else if len(GetConfigCiName()) > 0 {
-		ns = fmt.Sprintf("%s-%s", GetConfigCiName(), ns)
+	} else if len(config.GetCiName()) > 0 {
+		ns = fmt.Sprintf("%s-%s", config.GetCiName(), ns)
 	}
 	return ns
 }
@@ -149,4 +155,16 @@ func getWhitespaceStr(size int) string {
 // CreateFolder  creates a folder and all its parents if not exist
 func CreateFolder(folder string) error {
 	return os.MkdirAll(folder, os.ModePerm)
+}
+
+// MustParseEnabledDisabled parse a boolean string value
+func MustParseEnabledDisabled(value string) bool {
+	switch value {
+	case enabledKey:
+		return true
+	case disabledKey:
+		return false
+	default:
+		panic(fmt.Errorf("Unknown value for enabled/disabled: %s", value))
+	}
 }

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cucumber/godog/colors"
 	"github.com/cucumber/godog/gherkin"
 
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 	"github.com/kiegroup/kogito-cloud-operator/test/steps"
 )
@@ -46,7 +47,7 @@ var opt = godog.Options{
 
 func init() {
 	godog.BindFlags("godog.", flag.CommandLine, &opt)
-	framework.BindTestsConfigFlags(flag.CommandLine)
+	config.BindFlags(flag.CommandLine)
 }
 
 func TestMain(m *testing.M) {
@@ -60,12 +61,12 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Errorf("Error parsing features: %v", err))
 	}
-	if framework.IsConfigShowScenarios() {
+	if config.IsShowScenarios() {
 		showScenarios(features)
 	}
 
-	if !framework.IsConfigDryRun() {
-		if matchingFeature(cliTag, features) {
+	if !config.IsDryRun() {
+		if !config.IsCrDeploymentOnly() || matchingFeature(cliTag, features) {
 			// Check CLI binary is existing if needed
 			if exits, err := framework.CheckCliBinaryExist(); err != nil {
 				panic(fmt.Errorf("Error trying to get CLI binary %v", err))
@@ -73,10 +74,6 @@ func TestMain(m *testing.M) {
 				panic("CLI Binary does not exist on specified path")
 			}
 		}
-
-		// Make sure Kafka, Infinispan and Keycloak crds are imported into the cluster before starting the tests
-		// To be deleted once https://issues.redhat.com/browse/KOGITO-1376 is resolved
-		importDependentOperatorCrds()
 
 		status := godog.RunWithOptions("godogs", func(s *godog.Suite) {
 			FeatureContext(s)
@@ -91,7 +88,7 @@ func TestMain(m *testing.M) {
 }
 
 func configureTags() {
-	if framework.IsConfigSmokeTests() {
+	if config.IsSmokeTests() {
 		if len(opt.Tags) > 0 {
 			opt.Tags += " && "
 		}
@@ -109,7 +106,7 @@ func configureTags() {
 }
 
 func configureTestOutput() {
-	if framework.IsConfigSmokeTests() {
+	if config.IsSmokeTests() {
 		framework.SetLogSubFolder("smoke")
 	} else {
 		framework.SetLogSubFolder("full")
@@ -143,7 +140,7 @@ func FeatureContext(s *godog.Suite) {
 		data.AfterScenario(s, err)
 
 		// Namespace should be deleted after all other operations have been done
-		if !framework.IsConfigKeepNamespace() {
+		if !config.IsKeepNamespace() {
 			deleteNamespaceIfExists(data.Namespace)
 		}
 	})
@@ -190,52 +187,4 @@ func showScenarios(features []*gherkin.Feature) {
 		}
 	}
 	mainLogger.Info("------------------ END SHOW SCENARIOS ------------------")
-}
-
-// This does just create a namespace, install the operators via subscription if crd is missing
-// and then delete the namespace
-// Should be deleted once https://issues.redhat.com/browse/KOGITO-1376 is solved
-func importDependentOperatorCrds() {
-	mainLogger := framework.GetMainLogger()
-	mainLogger.Infof("Install dependent operator crds if needed")
-	namespace := framework.GenerateNamespaceName("crd-install")
-
-	if err := framework.CreateNamespace(namespace); err != nil {
-		panic(err)
-	}
-
-	installErr := installDependentOperatorsIfNeeded(namespace)
-	if installErr != nil {
-		mainLogger.Errorf("Error installing dependent operators: %v", installErr)
-	}
-
-	if err := framework.DeleteNamespace(namespace); err != nil {
-		panic(err)
-	}
-
-	if installErr != nil {
-		panic(installErr)
-	}
-}
-
-// Should be deleted once https://issues.redhat.com/browse/KOGITO-1376 is solved
-func installDependentOperatorsIfNeeded(namespace string) error {
-	var operatorsToWaitFor []string
-	for operatorName := range framework.KogitoOperatorCommunityDependencies {
-		if installed, err := framework.IsCommunityOperatorCrdAvailable(operatorName); err != nil {
-			return err
-		} else if !installed {
-			if err := framework.InstallCommunityKogitoOperatorDependency(namespace, operatorName); err != nil {
-				return err
-			}
-			operatorsToWaitFor = append(operatorsToWaitFor, operatorName)
-		}
-	}
-
-	for _, operatorName := range operatorsToWaitFor {
-		if err := framework.WaitForKogitoOperatorCrdAvailable(namespace, operatorName); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/test/steps/data.go
+++ b/test/steps/data.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cucumber/godog"
 
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
@@ -55,7 +56,7 @@ func (data *Data) BeforeScenario(s interface{}) {
 }
 
 func getNamespaceName() string {
-	if namespaceName := framework.GetConfigNamespaceName(); len(namespaceName) > 0 {
+	if namespaceName := config.GetNamespaceName(); len(namespaceName) > 0 {
 		return namespaceName
 	}
 	return framework.GenerateNamespaceName("cucumber")

--- a/test/steps/graphql.go
+++ b/test/steps/graphql.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-// registerHTTPSteps register all HTTP steps existing
 func registerGraphQLSteps(s *godog.Suite, data *Data) {
 	s.Step(`^GraphQL request on service "([^"]*)" is successful within (\d+) minutes with path "([^"]*)" and query:$`, data.graphqlRequestOnServiceIsSuccessfulWithinMinutesWithPathAndQuery)
 	s.Step(`^GraphQL request on Data Index service returns ProcessInstances processName "([^"]*)" within (\d+) minutes$`, data.graphqlRequestOnDataIndexReturnsProcessInstancesProcessNameWithinMinutes)

--- a/test/steps/http.go
+++ b/test/steps/http.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-// registerHTTPSteps register all HTTP steps existing
 func registerHTTPSteps(s *godog.Suite, data *Data) {
 	s.Step(`^HTTP GET request on service "([^"]*)" with path "([^"]*)" is successful within (\d+) minutes$`, data.httpGetRequestOnServiceWithPathIsSuccessfulWithinMinutes)
 	s.Step(`^HTTP GET request on service "([^"]*)" with path "([^"]*)" should return an array of size (\d+) within (\d+) minutes$`, data.httpGetRequestOnServiceWithPathShouldReturnAnArrayofSizeWithinMinutes)

--- a/test/steps/kogitoapp.go
+++ b/test/steps/kogitoapp.go
@@ -20,23 +20,21 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/gherkin"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
-	"github.com/kiegroup/kogito-cloud-operator/pkg/util"
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 	"github.com/rdumont/assistdog"
 )
 
 var assist = assistdog.NewDefault()
 
-// RegisterCliSteps register all CLI steps existing
 func registerKogitoAppSteps(s *godog.Suite, data *Data) {
 	// Deploy steps
-	s.Step(`^"([^"]*)" deploy quarkus example service "([^"]*)" with native "([^"]*)"$`, data.deployQuarkusExampleServiceWithNative)
-	s.Step(`^"([^"]*)" deploy quarkus example service "([^"]*)" with native "([^"]*)" and labels$`, data.deployQuarkusExampleServiceWithNativeAndLabels)
-	s.Step(`^"([^"]*)" deploy quarkus example service "([^"]*)" with native "([^"]*)" and persistence$`, data.deployQuarkusExampleServiceWithNativeAndPersistence)
-	s.Step(`^"([^"]*)" deploy quarkus example service "([^"]*)" with native "([^"]*)" and persistence and events$`, data.deployQuarkusExampleServiceWithNativeAndPersistenceAndEvents)
-	s.Step(`^"([^"]*)" deploy spring boot example service "([^"]*)"$`, data.deploySpringBootExampleService)
-	s.Step(`^"([^"]*)" deploy spring boot example service "([^"]*)" with persistence$`, data.deploySpringBootExampleServiceWithPersistence)
-	s.Step(`^"CR" deploy service from example file "([^"]*)"$`, data.deployServiceFromExampleFile)
+	s.Step(`^Deploy quarkus example service "([^"]*)" with native (enabled|disabled)$`, data.deployQuarkusExampleServiceWithNative)
+	s.Step(`^Deploy quarkus example service "([^"]*)" with native (enabled|disabled) and labels$`, data.deployQuarkusExampleServiceWithNativeAndLabels)
+	s.Step(`^Deploy quarkus example service "([^"]*)" with native (enabled|disabled) and persistence$`, data.deployQuarkusExampleServiceWithNativeAndPersistence)
+	s.Step(`^Deploy quarkus example service "([^"]*)" with native (enabled|disabled) and persistence and events$`, data.deployQuarkusExampleServiceWithNativeAndPersistenceAndEvents)
+	s.Step(`^Deploy spring boot example service "([^"]*)"$`, data.deploySpringBootExampleService)
+	s.Step(`^Deploy spring boot example service "([^"]*)" with persistence$`, data.deploySpringBootExampleServiceWithPersistence)
+	s.Step(`^Deploy service from example file "([^"]*)"$`, data.deployServiceFromExampleFile)
 
 	// Build steps
 	s.Step(`^Build "([^"]*)" is complete after (\d+) minutes$`, data.buildIsCompleteAfterMinutes)
@@ -52,64 +50,64 @@ func registerKogitoAppSteps(s *godog.Suite, data *Data) {
 }
 
 // Deploy service steps
-func (data *Data) deployQuarkusExampleServiceWithNative(installerType, contextDir, native string) error {
-	return framework.DeployExample(data.Namespace, framework.MustParseInstallerType(installerType),
+func (data *Data) deployQuarkusExampleServiceWithNative(contextDir, native string) error {
+	return framework.DeployExample(data.Namespace, framework.GetDefaultInstallerType(),
 		framework.KogitoAppDeployment{
 			AppName:     filepath.Base(contextDir),
 			ContextDir:  contextDir,
 			Runtime:     v1alpha1.QuarkusRuntimeType,
-			Native:      util.MustParseBool(native),
+			Native:      framework.MustParseEnabledDisabled(native),
 			Persistence: false,
 			Events:      false,
 			Labels:      nil,
 		})
 }
 
-func (data *Data) deployQuarkusExampleServiceWithNativeAndLabels(installerType, contextDir, native string, dt *gherkin.DataTable) error {
+func (data *Data) deployQuarkusExampleServiceWithNativeAndLabels(contextDir, native string, dt *gherkin.DataTable) error {
 	labels, err := assist.ParseMap(dt)
 	if err != nil {
 		return err
 	}
-	return framework.DeployExample(data.Namespace, framework.MustParseInstallerType(installerType),
+	return framework.DeployExample(data.Namespace, framework.GetDefaultInstallerType(),
 		framework.KogitoAppDeployment{
 			AppName:     filepath.Base(contextDir),
 			ContextDir:  contextDir,
 			Runtime:     v1alpha1.QuarkusRuntimeType,
-			Native:      util.MustParseBool(native),
+			Native:      framework.MustParseEnabledDisabled(native),
 			Persistence: false,
 			Events:      false,
 			Labels:      labels,
 		})
 }
 
-func (data *Data) deployQuarkusExampleServiceWithNativeAndPersistence(installerType, contextDir, native string) error {
-	return framework.DeployExample(data.Namespace, framework.MustParseInstallerType(installerType),
+func (data *Data) deployQuarkusExampleServiceWithNativeAndPersistence(contextDir, native string) error {
+	return framework.DeployExample(data.Namespace, framework.GetDefaultInstallerType(),
 		framework.KogitoAppDeployment{
 			AppName:     filepath.Base(contextDir),
 			ContextDir:  contextDir,
 			Runtime:     v1alpha1.QuarkusRuntimeType,
-			Native:      util.MustParseBool(native),
+			Native:      framework.MustParseEnabledDisabled(native),
 			Persistence: true,
 			Events:      false,
 			Labels:      nil,
 		})
 }
 
-func (data *Data) deployQuarkusExampleServiceWithNativeAndPersistenceAndEvents(installerType, contextDir, native string) error {
-	return framework.DeployExample(data.Namespace, framework.MustParseInstallerType(installerType),
+func (data *Data) deployQuarkusExampleServiceWithNativeAndPersistenceAndEvents(contextDir, native string) error {
+	return framework.DeployExample(data.Namespace, framework.GetDefaultInstallerType(),
 		framework.KogitoAppDeployment{
 			AppName:     filepath.Base(contextDir),
 			ContextDir:  contextDir,
 			Runtime:     v1alpha1.QuarkusRuntimeType,
-			Native:      util.MustParseBool(native),
+			Native:      framework.MustParseEnabledDisabled(native),
 			Persistence: true,
 			Events:      true,
 			Labels:      nil,
 		})
 }
 
-func (data *Data) deploySpringBootExampleService(installerType, contextDir string) error {
-	return framework.DeployExample(data.Namespace, framework.MustParseInstallerType(installerType),
+func (data *Data) deploySpringBootExampleService(contextDir string) error {
+	return framework.DeployExample(data.Namespace, framework.GetDefaultInstallerType(),
 		framework.KogitoAppDeployment{
 			AppName:     filepath.Base(contextDir),
 			ContextDir:  contextDir,
@@ -121,8 +119,8 @@ func (data *Data) deploySpringBootExampleService(installerType, contextDir strin
 		})
 }
 
-func (data *Data) deploySpringBootExampleServiceWithPersistence(installerType, contextDir string) error {
-	return framework.DeployExample(data.Namespace, framework.MustParseInstallerType(installerType),
+func (data *Data) deploySpringBootExampleServiceWithPersistence(contextDir string) error {
+	return framework.DeployExample(data.Namespace, framework.GetDefaultInstallerType(),
 		framework.KogitoAppDeployment{
 			AppName:     filepath.Base(contextDir),
 			ContextDir:  contextDir,

--- a/test/steps/kogitodataindex.go
+++ b/test/steps/kogitodataindex.go
@@ -20,12 +20,12 @@ import (
 )
 
 func registerKogitoDataIndexServiceSteps(s *godog.Suite, data *Data) {
-	s.Step(`^"([^"]*)" install Kogito Data Index with (\d+) replicas$`, data.installKogitoDataIndexServiceWithReplicas)
+	s.Step(`^Install Kogito Data Index with (\d+) replicas$`, data.installKogitoDataIndexServiceWithReplicas)
 	s.Step(`^Kogito Data Index has (\d+) pods running within (\d+) minutes$`, data.kogitoDataIndexHasPodsRunningWithinMinutes)
 }
 
-func (data *Data) installKogitoDataIndexServiceWithReplicas(installerType string, replicas int) error {
-	return framework.InstallKogitoDataIndexService(data.Namespace, framework.MustParseInstallerType(installerType), replicas)
+func (data *Data) installKogitoDataIndexServiceWithReplicas(replicas int) error {
+	return framework.InstallKogitoDataIndexService(data.Namespace, framework.GetDefaultInstallerType(), replicas)
 }
 
 func (data *Data) kogitoDataIndexHasPodsRunningWithinMinutes(podNb, timeoutInMin int) error {

--- a/test/steps/kogitoinfra.go
+++ b/test/steps/kogitoinfra.go
@@ -19,20 +19,19 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-// registerKogitoInfraSteps register all Kogito Infra steps existing
 func registerKogitoInfraSteps(s *godog.Suite, data *Data) {
-	s.Step(`^"([^"]*)" install Kogito Infra "([^"]*)"$`, data.installKogitoInfra)
-	s.Step(`^"([^"]*)" remove Kogito Infra "([^"]*)"$`, data.removeKogitoInfra)
+	s.Step(`^Install Kogito Infra "([^"]*)"$`, data.installKogitoInfra)
+	s.Step(`^Remove Kogito Infra "([^"]*)"$`, data.removeKogitoInfra)
 	s.Step(`^Kogito Infra "([^"]*)" should be running within (\d+) minutes$`, data.kogitoInfraShouldBeRunningWithinMinutes)
 	s.Step(`^Kogito Infra "([^"]*)" should NOT be running within (\d+) minutes$`, data.kogitoInfraShouldNOTBeRunningWithinMinutes)
 }
 
-func (data *Data) installKogitoInfra(installerType, component string) error {
-	return framework.InstallKogitoInfraComponent(data.Namespace, framework.MustParseInstallerType(installerType), framework.ParseKogitoInfraComponent(component))
+func (data *Data) installKogitoInfra(component string) error {
+	return framework.InstallKogitoInfraComponent(data.Namespace, framework.GetDefaultInstallerType(), framework.ParseKogitoInfraComponent(component))
 }
 
-func (data *Data) removeKogitoInfra(installerType, component string) error {
-	return framework.RemoveKogitoInfraComponent(data.Namespace, framework.MustParseInstallerType(installerType), framework.ParseKogitoInfraComponent(component))
+func (data *Data) removeKogitoInfra(component string) error {
+	return framework.RemoveKogitoInfraComponent(data.Namespace, framework.GetDefaultInstallerType(), framework.ParseKogitoInfraComponent(component))
 }
 
 func (data *Data) kogitoInfraShouldBeRunningWithinMinutes(component string, timeoutInMin int) error {

--- a/test/steps/kogitojobsservice.go
+++ b/test/steps/kogitojobsservice.go
@@ -19,20 +19,19 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-// RegisterCliSteps register all CLI steps existing
 func registerKogitoJobsServiceSteps(s *godog.Suite, data *Data) {
-	s.Step(`^"([^"]*)" install Kogito Jobs Service with (\d+) replicas$`, data.installKogitoJobsServiceWithReplicas)
-	s.Step(`^"([^"]*)" install Kogito Jobs Service with (\d+) replicas and persistence$`, data.installKogitoJobsServiceWithReplicasAndPersistence)
+	s.Step(`^Install Kogito Jobs Service with (\d+) replicas$`, data.installKogitoJobsServiceWithReplicas)
+	s.Step(`^Install Kogito Jobs Service with (\d+) replicas and persistence$`, data.installKogitoJobsServiceWithReplicasAndPersistence)
 	s.Step(`^Kogito Jobs Service has (\d+) pods running within (\d+) minutes$`, data.kogitoJobsServiceHasPodsRunningWithinMinutes)
 	s.Step(`^Scale Kogito Jobs Service to (\d+) pods within (\d+) minutes$`, data.scaleKogitoJobsServiceToPodsWithinMinutes)
 }
 
-func (data *Data) installKogitoJobsServiceWithReplicas(installerType string, replicas int) error {
-	return framework.InstallKogitoJobsService(data.Namespace, framework.MustParseInstallerType(installerType), replicas, false)
+func (data *Data) installKogitoJobsServiceWithReplicas(replicas int) error {
+	return framework.InstallKogitoJobsService(data.Namespace, framework.GetDefaultInstallerType(), replicas, false)
 }
 
-func (data *Data) installKogitoJobsServiceWithReplicasAndPersistence(installerType string, replicas int) error {
-	return framework.InstallKogitoJobsService(data.Namespace, framework.MustParseInstallerType(installerType), replicas, true)
+func (data *Data) installKogitoJobsServiceWithReplicasAndPersistence(replicas int) error {
+	return framework.InstallKogitoJobsService(data.Namespace, framework.GetDefaultInstallerType(), replicas, true)
 }
 
 func (data *Data) kogitoJobsServiceHasPodsRunningWithinMinutes(pods, timeoutInMin int) error {

--- a/test/steps/kubernetes.go
+++ b/test/steps/kubernetes.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-// RegisterNamespaceSteps register Kubernetes object steps existing
 func registerKubernetesSteps(s *godog.Suite, data *Data) {
 	s.Step(`^Namespace is created$`, data.namespaceIsCreated)
 	s.Step(`^Namespace is deleted$`, data.namespaceIsDeleted)

--- a/test/steps/operator.go
+++ b/test/steps/operator.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-// RegisterCliSteps register all CLI steps existing
 func registerOperatorSteps(s *godog.Suite, data *Data) {
 	s.Step(`^Kogito operator should be installed with dependencies$`, data.kogitoOperatorShouldBeInstalledWithDependencies)
 	s.Step(`^Kogito Operator is deployed$`, data.kogitoOperatorIsDeployed)

--- a/test/steps/process.go
+++ b/test/steps/process.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-// registerProcessSteps register all process steps
 func registerProcessSteps(s *godog.Suite, data *Data) {
 	s.Step(`^Start "([^"]*)" process on service "([^"]*)" with body:$`, data.startProcessOnService)
 	s.Step(`^Service "([^"]*)" contains (\d+) (?:instance|instances) of process with name "([^"]*)"$`, data.serviceContainsInstancesOfProcess)

--- a/test/steps/prometheus.go
+++ b/test/steps/prometheus.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-// RegisterCliSteps register all CLI steps existing
 func registerPrometheusSteps(s *godog.Suite, data *Data) {
 	s.Step(`^Prometheus Operator is deployed$`, data.prometheusOperatorIsDeployed)
 	s.Step(`^Prometheus instance is deployed, monitoring services with label name "([^"]*)" and value "([^"]*)"$`, data.prometheusInstanceIsDeployed)

--- a/test/steps/task.go
+++ b/test/steps/task.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-// registerTaskSteps register all task steps
 func registerTaskSteps(s *godog.Suite, data *Data) {
 	s.Step(`^Service "([^"]*)" contains (\d+) (?:task|tasks) of process with name "([^"]*)" and task name "([^"]*)"$`, data.serviceContainsTasksOfProcessWithNameAndTaskName)
 	s.Step(`^Complete "([^"]*)" task on service "([^"]*)" and process with name "([^"]*)" with body:$`, data.completeTaskOnServiceAndProcessWithName)


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-1439

removed CR / CLI differenciation.
By default, it will try to use the CLI to deploy. When executed, CLI command is creating a CR to deploy on Openshift.

Use `make run-tests cr_deployment_only=true` to tell the tests that we want only to test via CR and not CLI (because, for example, CLI is not available)

Also solve https://issues.redhat.com/browse/KOGITO-1435 (code removal)

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster