### PR TITLE
[KOGITO-586] - Add Quarkus probes to Kogito Services definition

### DIFF
--- a/pkg/controller/kogitodataindex/kogitodataindex_controller_test.go
+++ b/pkg/controller/kogitodataindex/kogitodataindex_controller_test.go
@@ -153,8 +153,8 @@ func TestReconcileKogitoDataIndex_UpdateHTTPPort(t *testing.T) {
 	})
 
 	assert.Equal(t, int32(9090), deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
-	assert.Equal(t, int32(9090), deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket.Port.IntVal)
-	assert.Equal(t, int32(9090), deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port.IntVal)
+	assert.Equal(t, int32(9090), deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, int32(9090), deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.IntVal)
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: instance.Name, Namespace: instance.Namespace},

--- a/pkg/controller/kogitojobsservice/kogitojobsservice_controller.go
+++ b/pkg/controller/kogitojobsservice/kogitojobsservice_controller.go
@@ -127,6 +127,7 @@ func (r *ReconcileKogitoJobsService) Reconcile(request reconcile.Request) (resul
 		SingleReplica:       true,
 		RequiresPersistence: false,
 		RequiresMessaging:   false,
+		HealthCheckProbe:    services.QuarkusHealthCheckProbe,
 	}
 	if requeueAfter, err := services.NewSingletonServiceDeployer(definition, instances, r.client, r.scheme).Deploy(); err != nil {
 		return reconcile.Result{}, err

--- a/pkg/infrastructure/services/deployer.go
+++ b/pkg/infrastructure/services/deployer.go
@@ -50,6 +50,8 @@ type ServiceDefinition struct {
 	RequiresMessaging bool
 	// KafkaTopics is a collection of Kafka Topics to be created within the service
 	KafkaTopics []KafkaTopicDefinition
+	// HealthCheckProbe is the probe that needs to be configured in the service. Defaults to TCPHealthCheckProbe
+	HealthCheckProbe HealthCheckProbeType
 	// infinispanAware whether or not to handle Infinispan integration in this service (inject variables, deploy if needed, and so on)
 	infinispanAware bool
 	// kafkaAware whether or not to handle Kafka integration in this service (inject variables, deploy if needed, and so on)

--- a/pkg/infrastructure/services/deployment_test.go
+++ b/pkg/infrastructure/services/deployment_test.go
@@ -1,0 +1,53 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func Test_createRequiredDeployment_CheckQuarkusProbe(t *testing.T) {
+	kogitoService := &v1alpha1.KogitoDataIndex{
+		ObjectMeta: v1.ObjectMeta{Name: infrastructure.DefaultDataIndexImageName, Namespace: t.Name()},
+	}
+	serviceDef := ServiceDefinition{HealthCheckProbe: QuarkusHealthCheckProbe}
+	deployment := createRequiredDeployment(kogitoService, infrastructure.DefaultDataIndexImageFullTag, serviceDef)
+	assert.NotNil(t, deployment)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet)
+	assert.Nil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket)
+	assert.Nil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket)
+}
+
+func Test_createRequiredDeployment_CheckDefaultProbe(t *testing.T) {
+	kogitoService := &v1alpha1.KogitoDataIndex{
+		ObjectMeta: v1.ObjectMeta{Name: infrastructure.DefaultDataIndexImageName, Namespace: t.Name()},
+	}
+	serviceDef := ServiceDefinition{}
+	deployment := createRequiredDeployment(kogitoService, infrastructure.DefaultDataIndexImageFullTag, serviceDef)
+	assert.NotNil(t, deployment)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe)
+	assert.NotNil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket)
+	assert.Nil(t, deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet)
+	assert.Nil(t, deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet)
+}

--- a/pkg/infrastructure/services/probe.go
+++ b/pkg/infrastructure/services/probe.go
@@ -1,0 +1,105 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/framework"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// HealthCheckProbeType defines the supported probes for the ServiceDefinition
+type HealthCheckProbeType string
+
+const (
+	// QuarkusHealthCheckProbe probe implemented with Quarkus Microprofile Health. See: https://quarkus.io/guides/microprofile-health.
+	// the operator will set the probe to the default path /health/live and /health/ready for liveness and readiness probes, respectively.
+	QuarkusHealthCheckProbe HealthCheckProbeType = "quarkus"
+	// TCPHealthCheckProbe default health check probe that binds to port 8080
+	TCPHealthCheckProbe HealthCheckProbeType = "TCP"
+
+	quarkusProbeLivenessPath  = "/health/live"
+	quarkusProbeReadinessPath = "/health/ready"
+)
+
+type healthCheckProbe struct {
+	readiness *corev1.Probe
+	liveness  *corev1.Probe
+}
+
+// getProbeForKogitoService gets the appropriate liveness (index 0) and readiness (index 1) probes based on the given service definition
+func getProbeForKogitoService(serviceDefinition ServiceDefinition) healthCheckProbe {
+	switch serviceDefinition.HealthCheckProbe {
+	case QuarkusHealthCheckProbe:
+		return healthCheckProbe{
+			readiness: getQuarkusHealthCheckReadiness(),
+			liveness:  getQuarkusHealthCheckLiveness(),
+		}
+	case TCPHealthCheckProbe:
+		return healthCheckProbe{
+			readiness: getTCPHealthCheckProbe(),
+			liveness:  getTCPHealthCheckProbe(),
+		}
+	default:
+		return healthCheckProbe{
+			readiness: getTCPHealthCheckProbe(),
+			liveness:  getTCPHealthCheckProbe(),
+		}
+	}
+}
+
+func getTCPHealthCheckProbe() *corev1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			TCPSocket: &corev1.TCPSocketAction{Port: intstr.IntOrString{IntVal: framework.DefaultExposedPort}},
+		},
+		TimeoutSeconds:   int32(1),
+		PeriodSeconds:    int32(10),
+		SuccessThreshold: int32(1),
+		FailureThreshold: int32(3),
+	}
+}
+
+func getQuarkusHealthCheckLiveness() *corev1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   quarkusProbeLivenessPath,
+				Port:   intstr.IntOrString{IntVal: framework.DefaultExposedPort},
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+		TimeoutSeconds:   int32(1),
+		PeriodSeconds:    int32(10),
+		SuccessThreshold: int32(1),
+		FailureThreshold: int32(3),
+	}
+}
+
+func getQuarkusHealthCheckReadiness() *corev1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   quarkusProbeReadinessPath,
+				Port:   intstr.IntOrString{IntVal: framework.DefaultExposedPort},
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+		TimeoutSeconds:   int32(1),
+		PeriodSeconds:    int32(10),
+		SuccessThreshold: int32(1),
+		FailureThreshold: int32(3),
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See:
https://issues.redhat.com/browse/KOGITO-586

In this PR we introduce a way of services to fine tune their probe type based on the new health checks added in the Data Index and Jobs Services.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster