### PR TITLE
[KOGITO-1516] Allow "make vet" to work from any directory

### DIFF
--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -24,8 +24,8 @@ if [[ -z ${CI} ]]; then
     which ./bin/openapi-gen > /dev/null || go build -o ./bin/openapi-gen k8s.io/kube-openapi/cmd/openapi-gen
     # generate the openapi files
     echo "Generating openapi files"
-    ./bin/openapi-gen --logtostderr=true -o "" -i ./pkg/apis/app/v1alpha1 -O zz_generated.openapi -p ./pkg/apis/app/v1alpha1 -h ./hack/boilerplate.go.txt -r "-"
-    ./bin/openapi-gen --logtostderr=true -o "" -i ./pkg/apis/kafka/v1beta1 -O zz_generated.openapi -p ./pkg/apis/kafka/v1beta1 -h ./hack/boilerplate.go.txt -r "-"
+    ./bin/openapi-gen --logtostderr=true -o "" -i github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1 -O zz_generated.openapi -p ./pkg/apis/app/v1alpha1 -h ./hack/boilerplate.go.txt -r "-"
+    ./bin/openapi-gen --logtostderr=true -o "" -i github.com/kiegroup/kogito-cloud-operator/pkg/apis/kafka/v1beta1 -O zz_generated.openapi -p ./pkg/apis/kafka/v1beta1 -h ./hack/boilerplate.go.txt -r "-"
 
     operator-sdk generate csv --csv-version 0.9.0 --update-crds --operator-name kogito-operator
 fi


### PR DESCRIPTION
https://issues.redhat.com/projects/KOGITO/issues/KOGITO-1516

Use the canonical path ("github.com/kiegroup/kogito-cloud-operator")
instead of the relative path as argument to the "-i" flag when running
the openapi-gen command, allowing this script to be ran from any
directory without making any modifications.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster