### PR TITLE
[KOGITO-851] Adding event support to Jobs Service

### DIFF
--- a/deploy/crds/app.kiegroup.org_kogitojobsservices_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitojobsservices_crd.yaml
@@ -201,6 +201,29 @@ spec:
                     all other properties to provide your own infrastructure
                   type: boolean
               type: object
+            kafka:
+              description: Has the data used by the service to connect to the Kafka
+                cluster.
+              properties:
+                externalURI:
+                  description: URI is the service URI to connect to the Kafka cluster,
+                    for example, my-cluster-kafka-bootstrap:9092
+                  type: string
+                instance:
+                  description: Instance is the Kafka instance to be used, for example,
+                    kogito-kafka
+                  type: string
+                useKogitoInfra:
+                  description: UseKogitoInfra flags if the instance will use a provided
+                    infrastructure by KogitoInfra CR. Setting this to true will configure
+                    a KogitoInfra CR to install Kafka via Strimzi Operator. Strimzi
+                    Operator MUST be installed in the namespace for this to work.
+                    On OpenShift, OLM should install it for you. If running on Kubernetes
+                    without OLM installed, please install Strimzi Operator first.
+                    Set this to false and fill other properties to provide your own
+                    infrastructure
+                  type: boolean
+              type: object
             maxIntervalLimitToRetryMillis:
               description: 'Maximum interval in milliseconds when retrying to execute
                 jobs, in case of failures. Default to service default, see: https://github.com/kiegroup/kogito-runtimes/wiki/Jobs-Service#configuration-properties'

--- a/deploy/olm-catalog/kogito-operator/0.9.0/app.kiegroup.org_kogitojobsservices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/0.9.0/app.kiegroup.org_kogitojobsservices_crd.yaml
@@ -201,6 +201,29 @@ spec:
                     all other properties to provide your own infrastructure
                   type: boolean
               type: object
+            kafka:
+              description: Has the data used by the service to connect to the Kafka
+                cluster.
+              properties:
+                externalURI:
+                  description: URI is the service URI to connect to the Kafka cluster,
+                    for example, my-cluster-kafka-bootstrap:9092
+                  type: string
+                instance:
+                  description: Instance is the Kafka instance to be used, for example,
+                    kogito-kafka
+                  type: string
+                useKogitoInfra:
+                  description: UseKogitoInfra flags if the instance will use a provided
+                    infrastructure by KogitoInfra CR. Setting this to true will configure
+                    a KogitoInfra CR to install Kafka via Strimzi Operator. Strimzi
+                    Operator MUST be installed in the namespace for this to work.
+                    On OpenShift, OLM should install it for you. If running on Kubernetes
+                    without OLM installed, please install Strimzi Operator first.
+                    Set this to false and fill other properties to provide your own
+                    infrastructure
+                  type: boolean
+              type: object
             maxIntervalLimitToRetryMillis:
               description: 'Maximum interval in milliseconds when retrying to execute
                 jobs, in case of failures. Default to service default, see: https://github.com/kiegroup/kogito-runtimes/wiki/Jobs-Service#configuration-properties'

--- a/pkg/apis/app/v1alpha1/kogitojobsservice_types.go
+++ b/pkg/apis/app/v1alpha1/kogitojobsservice_types.go
@@ -22,6 +22,7 @@ import (
 // +k8s:openapi-gen=true
 type KogitoJobsServiceSpec struct {
 	InfinispanMeta    `json:",inline"`
+	KafkaMeta         `json:",inline"`
 	KogitoServiceSpec `json:",inline"`
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 

--- a/pkg/apis/app/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.deepcopy.go
@@ -754,6 +754,7 @@ func (in *KogitoJobsServiceList) DeepCopyObject() runtime.Object {
 func (in *KogitoJobsServiceSpec) DeepCopyInto(out *KogitoJobsServiceSpec) {
 	*out = *in
 	out.InfinispanMeta = in.InfinispanMeta
+	out.KafkaMeta = in.KafkaMeta
 	in.KogitoServiceSpec.DeepCopyInto(&out.KogitoServiceSpec)
 	return
 }

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -1081,6 +1081,12 @@ func schema_pkg_apis_app_v1alpha1_KogitoJobsServiceSpec(ref common.ReferenceCall
 							Ref:         ref("github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.InfinispanConnectionProperties"),
 						},
 					},
+					"kafka": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Has the data used by the service to connect to the Kafka cluster.",
+							Ref:         ref("github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.KafkaConnectionProperties"),
+						},
+					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Number of replicas that the service will have deployed in the cluster Default value: 1",
@@ -1136,7 +1142,7 @@ func schema_pkg_apis_app_v1alpha1_KogitoJobsServiceSpec(ref common.ReferenceCall
 			},
 		},
 		Dependencies: []string{
-			"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Image", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.InfinispanConnectionProperties", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
+			"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.Image", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.InfinispanConnectionProperties", "github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1.KafkaConnectionProperties", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 

--- a/pkg/controller/kogitojobsservice/kogitojobsservice_controller.go
+++ b/pkg/controller/kogitojobsservice/kogitojobsservice_controller.go
@@ -128,6 +128,7 @@ func (r *ReconcileKogitoJobsService) Reconcile(request reconcile.Request) (resul
 		RequiresPersistence: false,
 		RequiresMessaging:   false,
 		HealthCheckProbe:    services.QuarkusHealthCheckProbe,
+		KafkaTopics:         kafkaTopics,
 	}
 	if requeueAfter, err := services.NewSingletonServiceDeployer(definition, instances, r.client, r.scheme).Deploy(); err != nil {
 		return reconcile.Result{}, err
@@ -143,7 +144,12 @@ const (
 	maxIntervalLimitRetryEnvKey       = "MAX_INTERVAL_LIMIT_RETRY"
 	backOffRetryDefaultValue          = 1000
 	maxIntervalLimitRetryDefaultValue = 60000
+	kafkaTopicNameJobsEvents          = "kogito-job-service-job-status-events"
 )
+
+var kafkaTopics = []services.KafkaTopicDefinition{
+	{TopicName: kafkaTopicNameJobsEvents, MessagingType: services.KafkaTopicOutgoing},
+}
 
 func onDeploymentCreate(deployment *appsv1.Deployment, service appv1alpha1.KogitoService) error {
 	jobService := service.(*appv1alpha1.KogitoJobsService)

--- a/pkg/infrastructure/services/kafka.go
+++ b/pkg/infrastructure/services/kafka.go
@@ -24,8 +24,6 @@ import (
 )
 
 const (
-	kafkaURINotFoundError string = "there's no Kafka instance URI found in the namespace and Kafka external URI is not specified, cannot deploy Data Index service"
-
 	quarkusTopicBootstrapEnvVar = "MP_MESSAGING_%s_%s_BOOTSTRAP_SERVERS"
 )
 
@@ -51,7 +49,7 @@ func getKafkaServerURI(kafkaProp v1alpha1.KafkaConnectionProperties, namespace s
 		}
 	}
 
-	return "", fmt.Errorf(kafkaURINotFoundError)
+	return "", nil
 }
 
 func getKafkaInstance(kafka v1alpha1.KafkaConnectionProperties, namespace string, client *client.Client) (*kafkabetav1.Kafka, error) {

--- a/pkg/infrastructure/services/resources.go
+++ b/pkg/infrastructure/services/resources.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	enablePersistenceEnvKey = "ENABLE_PERSISTENCE"
+	enableEventsEnvKey      = "ENABLE_EVENTS"
 )
 
 // createRequiredResources creates the required resources given the KogitoService instance
@@ -161,12 +162,15 @@ func (s *serviceDeployer) applyKafkaConfigurations(deployment *appsv1.Deployment
 	}
 
 	if len(URI) > 0 {
+		framework.SetEnvVar(enableEventsEnvKey, "true", &deployment.Spec.Template.Spec.Containers[0])
 		for _, kafkaTopic := range s.definition.KafkaTopics {
 			framework.SetEnvVar(fromKafkaTopicToQuarkusEnvVar(kafkaTopic), URI, &deployment.Spec.Template.Spec.Containers[0])
 		}
 		for _, kafkaEnv := range quarkusBootstrapEnvVars {
 			framework.SetEnvVar(kafkaEnv, URI, &deployment.Spec.Template.Spec.Containers[0])
 		}
+	} else {
+		framework.SetEnvVar(enableEventsEnvKey, "false", &deployment.Spec.Template.Spec.Containers[0])
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See:
https://issues.redhat.com/browse/KOGITO-851

Depends on:
https://github.com/kiegroup/kogito-images/pull/114

Image for testing:
`quay.io/ricardozanini/kogito-jobs-service:0.9.0-rc1`

In this PR we introduce the Kafka integration with Jobs Service. When any parameter is set (URL, service instance or `useKogitoInfra`), eventing is automatically enabled in the Jobs Service image.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster