### PR TITLE
[KOGITO-1193] Mount Config Maps for Kogito Services and Runtimes application properties configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Table of Contents
          * [Binary Builds](#binary-builds)
          * [Cleaning up a Kogito service deployment](#cleaning-up-a-kogito-service-deployment)
          * [Native X JVM builds](#native-x-jvm-builds)
+         * [Kogito Runtimes properties configuration](#kogito-runtimes-properties-configuration)
          * [Troubleshooting Kogito Runtimes service deployment](#troubleshooting-kogito-runtimes-service-deployment)
             * [No builds are running](#no-builds-are-running)
       * [Kogito Data Index Service deployment](#kogito-data-index-service-deployment)
@@ -30,12 +31,14 @@ Table of Contents
             * [Installing the Kogito Data Index Service with the Operator Catalog (OLM)](#installing-the-kogito-data-index-service-with-the-operator-catalog-olm)
             * [Installing the Kogito Data Index Service with the oc client](#installing-the-kogito-data-index-service-with-the-oc-client)
          * [Kogito Data Index Integration with persistent Kogito Services](#kogito-data-index-integration-with-persistent-kogito-services)
+         * [Kogito Data Index Service properties configuration](#kogito-data-index-service-properties-configuration)
       * [Kogito Jobs Service deployment](#kogito-jobs-service-deployment)
          * [Kogito Jobs Service installation](#kogito-jobs-service-installation)
             * [Installing the Kogito Jobs Service with the Kogito CLI](#installing-the-kogito-jobs-service-with-the-kogito-cli)
             * [Installing the Kogito Jobs Service with the Operator Catalog (OLM)](#installing-the-kogito-jobs-service-with-the-operator-catalog-olm)
             * [Installing the Kogito Jobs Service with the oc client](#installing-the-kogito-jobs-service-with-the-oc-client)
          * [Enabling Persistence with Infinispan](#enabling-persistence-with-infinispan)
+         * [Kogito Jobs Service properties configuration](#kogito-jobs-service-properties-configuration)
       * [Kogito CLI](#kogito-cli)
          * [Kogito CLI requirements](#kogito-cli-requirements)
          * [Kogito CLI installation](#kogito-cli-installation)
@@ -256,6 +259,27 @@ To deploy a service using native builds, run the `deploy-service` command with t
 $ kogito deploy-service example-quarkus https://github.com/kiegroup/kogito-examples/ --context-dir=drools-quarkus-example --native
 ```
 
+### Kogito Runtimes properties configuration
+
+When a Kogito service is deployed, a `configMap` will be created for the `application.properties` configuration of the Kogito service.
+
+The name of the `configMap` consists of the name of the Kogito service and the suffix `-properties`. For example:
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: jbpm-quarkus-example-properties
+data:
+  application.properties : |-
+    dummy1=dummy1
+    dummy2=dummy2
+```    
+
+The data `application.properties` of the `configMap` will be mounted in a volume to the container of the Kogito service. Any runtime properties added to `application.properties` will override the default application configuration properties of the Kogito service.
+
+When there are changes to `application.properties` of the `configMap`, a rolling update will take place to update the deployment and configuration of the Kogito service. 
+
 ### Troubleshooting Kogito Runtimes service deployment
 
 #### No builds are running
@@ -406,6 +430,27 @@ property in your domain data, this data will be reflect automatically in the Dat
 _Please note that removed Kogito Services will remove the protobuf files associated to it as well. This means that you won't
 be able to see the data through the Data Index anymore, although the data still persisted in Infinispan._
 
+### Kogito Data Index Service properties configuration
+
+When Data Index is deployed, a `configMap` will be created for the `application.properties` configuration of Data Index.
+
+The name of the `configMap` consists of the name of the Data Index and the suffix `-properties`. For example:
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kogito-data-index-properties
+data:
+  application.properties : |-
+    dummy1=dummy1
+    dummy2=dummy2
+```    
+
+The data `application.properties` of the `configMap` will be mounted in a volume to the container of the Data Index. Any runtime properties added to `application.properties` will override the default application configuration properties of Data Index.
+
+When there are changes to `application.properties` of the `configMap`, a rolling update will take place to update the deployment and configuration of Data Index. 
+
 ## Kogito Jobs Service deployment
 
 Like Data Index, [Jobs Service](https://github.com/kiegroup/kogito-runtimes/wiki/Jobs-Service) can be deployed via Operator or CLI. 
@@ -473,6 +518,27 @@ It's also possible to fine tune the Infinispan integration by setting the proper
 and the Jobs Service will try to connect to the given URI. Just make sure that your cluster have access to this URI.
 
 This process behaves similarly to the one defined by the [Data Index Service](#deploying-infinispan). 
+
+### Kogito Jobs Service properties configuration
+
+When Jobs Service is deployed, a `configMap` will be created for the `application.properties` configuration of Jobs Service.
+
+The name of the `configMap` consists of the name of the Jobs Service and the suffix `-properties`. For example:
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: jobs-service-properties
+data:
+  application.properties : |-
+    dummy1=dummy1
+    dummy2=dummy2
+```    
+
+The data `application.properties` of the `configMap` will be mounted in a volume to the container of the Jobs Service. Any runtime properties added to `application.properties` will override the default application configuration properties of Jobs Service.
+
+When there are changes to `application.properties` of the `configMap`, a rolling update will take place to update the deployment and configuration of Jobs Service. 
 
 ## Kogito CLI
 

--- a/pkg/controller/kogitoapp/kogitoapp_controller.go
+++ b/pkg/controller/kogitoapp/kogitoapp_controller.go
@@ -530,6 +530,9 @@ func getKubernetesResources(kogitoRes *kogitores.KogitoAppResources) []utilsres.
 	if kogitoRes.ProtoBufCM != nil {
 		k8sRes = append(k8sRes, kogitoRes.ProtoBufCM)
 	}
+	if kogitoRes.AppPropCM != nil {
+		k8sRes = append(k8sRes, kogitoRes.AppPropCM)
+	}
 
 	return k8sRes
 }

--- a/pkg/controller/kogitoapp/resource/deployed_resources.go
+++ b/pkg/controller/kogitoapp/resource/deployed_resources.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/prometheus"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure/services"
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	imgv1 "github.com/openshift/api/image/v1"
@@ -57,6 +58,8 @@ func GetDeployedResources(instance *v1alpha1.KogitoApp, client *client.Client) (
 		log.Warn("Failed to list deployed objects. ", err)
 		return nil, err
 	}
+
+	services.ExcludeAppPropConfigMapFromResource(instance.GetName(), resourceMap)
 	return resourceMap, nil
 }
 

--- a/pkg/controller/kogitoapp/resource/resources.go
+++ b/pkg/controller/kogitoapp/resource/resources.go
@@ -42,4 +42,6 @@ type KogitoAppResources struct {
 	ServiceMonitor     *monv1.ServiceMonitor
 	RuntimeImage       *dockerv10.DockerImage
 	ProtoBufCM         *corev1.ConfigMap
+	AppPropCM          *corev1.ConfigMap
+	AppPropContentHash string
 }

--- a/pkg/controller/kogitoapp/resource/service_test.go
+++ b/pkg/controller/kogitoapp/resource/service_test.go
@@ -54,11 +54,11 @@ func Test_serviceResource_NewWithAndWithoutDockerImg(t *testing.T) {
 	}
 	bcS2I, _ := newBuildConfigS2I(kogitoApp)
 	bcRuntime, _ := newBuildConfigRuntime(kogitoApp, &bcS2I)
-	dc, _ := newDeploymentConfig(kogitoApp, &bcRuntime, nil)
+	dc, _ := newDeploymentConfig(kogitoApp, &bcRuntime, nil, "abc")
 	svc := newService(kogitoApp, dc)
 	assert.Nil(t, svc)
 	// try again, now with ports
-	dc, _ = newDeploymentConfig(kogitoApp, &bcRuntime, dockerImage)
+	dc, _ = newDeploymentConfig(kogitoApp, &bcRuntime, dockerImage, "abc")
 	svc = newService(kogitoApp, dc)
 	assert.NotNil(t, svc)
 	assert.Len(t, svc.Spec.Ports, 1)

--- a/pkg/controller/kogitodataindex/kogitodataindex_controller.go
+++ b/pkg/controller/kogitodataindex/kogitodataindex_controller.go
@@ -53,7 +53,7 @@ var watchedObjects = []framework.WatchedObjects{
 		AddToScheme:  imgv1.Install,
 		Objects:      []runtime.Object{&imgv1.ImageStream{}},
 	},
-	{Objects: []runtime.Object{&corev1.Service{}, &appsv1.Deployment{}}},
+	{Objects: []runtime.Object{&corev1.Service{}, &appsv1.Deployment{}, &corev1.ConfigMap{}}},
 }
 
 var controllerWatcher framework.ControllerWatcher

--- a/pkg/controller/kogitojobsservice/kogitojobsservice_controller.go
+++ b/pkg/controller/kogitojobsservice/kogitojobsservice_controller.go
@@ -50,7 +50,7 @@ var watchedObjects = []framework.WatchedObjects{
 		Objects:      []runtime.Object{&imagev1.ImageStream{}},
 	},
 	{
-		Objects: []runtime.Object{&corev1.Service{}, &appsv1.Deployment{}},
+		Objects: []runtime.Object{&corev1.Service{}, &appsv1.Deployment{}, &corev1.ConfigMap{}},
 	},
 }
 

--- a/pkg/infrastructure/services/configmap.go
+++ b/pkg/infrastructure/services/configmap.go
@@ -1,0 +1,129 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"crypto/md5"
+	"fmt"
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+)
+
+const (
+	appPropConfigMapSuffix = "-properties"
+	appPropContentKey      = "application.properties"
+	defaultAppPropContent  = ""
+
+	// AppPropContentHashKey is the annotation key for the content hash of application.properties
+	AppPropContentHashKey = "appPropContentHash"
+	// AppPropVolumeName is the name of the volume for application.properties
+	AppPropVolumeName = "app-prop-config"
+
+	appPropDefaultMode = int32(420)
+	appPropFileName    = "application.properties"
+	appPropFilePath    = "/home/kogito/config"
+)
+
+// GetAppPropConfigMapContentHash calculates the hash of the application.properties contents in the ConfigMap
+// If the ConfigMap doesn't exist, create a new one and return it.
+func GetAppPropConfigMapContentHash(name, namespace string, cli *client.Client) (string, *corev1.ConfigMap, error) {
+	configMapName := GetAppPropConfigMapName(name)
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: namespace}}
+
+	exist, err := kubernetes.ResourceC(cli).Fetch(configMap)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if exist {
+		if _, ok := configMap.Data[appPropContentKey]; !ok {
+			exist = false
+		}
+	}
+
+	if !exist {
+		configMap.Data = map[string]string{
+			appPropContentKey: defaultAppPropContent,
+		}
+	}
+
+	contentHash := fmt.Sprintf("%x", md5.Sum([]byte(configMap.Data[appPropContentKey])))
+
+	if exist {
+		return contentHash, nil, nil
+	}
+
+	return contentHash, configMap, nil
+}
+
+// GetAppPropConfigMapName generates the name of the config map for application.properties
+func GetAppPropConfigMapName(name string) string {
+	return name + appPropConfigMapSuffix
+}
+
+// CreateAppPropVolumeMount creates a container volume mount for mounting application.properties
+func CreateAppPropVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      AppPropVolumeName,
+		MountPath: appPropFilePath,
+		ReadOnly:  true,
+	}
+}
+
+// CreateAppPropVolume creates a volume for application.properties
+func CreateAppPropVolume(name string) corev1.Volume {
+	defaultMode := appPropDefaultMode
+
+	return corev1.Volume{
+		Name: AppPropVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: GetAppPropConfigMapName(name),
+				},
+				Items: []corev1.KeyToPath{
+					{
+						Key:  appPropContentKey,
+						Path: appPropFileName,
+					},
+				},
+				DefaultMode: &defaultMode,
+			},
+		},
+	}
+}
+
+// ExcludeAppPropConfigMapFromResource excludes the application properties config map from the resources to be compared for changes.
+// The config map is supposed to be modified by users directly, the operator should not overwrite the changes made by users.
+func ExcludeAppPropConfigMapFromResource(name string, resourceMap map[reflect.Type][]resource.KubernetesResource) {
+	tp := reflect.TypeOf(corev1.ConfigMap{})
+	if configmaps, ok := resourceMap[tp]; ok {
+		name := GetAppPropConfigMapName(name)
+		for i, cm := range configmaps {
+			if cm.GetName() == name {
+				if i == len(configmaps)-1 {
+					resourceMap[tp] = configmaps[:i]
+				} else {
+					resourceMap[tp] = append(configmaps[:i], configmaps[i+1:]...)
+				}
+				return
+			}
+		}
+	}
+}

--- a/pkg/infrastructure/services/configmap_test.go
+++ b/pkg/infrastructure/services/configmap_test.go
@@ -1,0 +1,208 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
+	"testing"
+)
+
+func TestExcludeAppPropConfigMapFromResource(t *testing.T) {
+	type args struct {
+		name        string
+		resourceMap map[reflect.Type][]resource.KubernetesResource
+	}
+	tests := []struct {
+		name   string
+		args   args
+		length int
+	}{
+		{
+			"No Element",
+			args{
+				name:        "test",
+				resourceMap: map[reflect.Type][]resource.KubernetesResource{},
+			},
+			0,
+		},
+		{
+			"One Element",
+			args{
+				name: "test",
+				resourceMap: map[reflect.Type][]resource.KubernetesResource{
+					reflect.TypeOf(corev1.ConfigMap{}): {
+						&corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test" + appPropConfigMapSuffix,
+							},
+						},
+					},
+				},
+			},
+			0,
+		},
+		{
+			"First Element",
+			args{
+				name: "test",
+				resourceMap: map[reflect.Type][]resource.KubernetesResource{
+					reflect.TypeOf(corev1.ConfigMap{}): {
+						&corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test" + appPropConfigMapSuffix,
+							},
+						},
+						&corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test",
+							},
+						},
+					},
+				},
+			},
+			1,
+		},
+		{
+			"Last Element",
+			args{
+				name: "test",
+				resourceMap: map[reflect.Type][]resource.KubernetesResource{
+					reflect.TypeOf(corev1.ConfigMap{}): {
+						&corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test",
+							},
+						},
+						&corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test" + appPropConfigMapSuffix,
+							},
+						},
+					},
+				},
+			},
+			1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ExcludeAppPropConfigMapFromResource(tt.args.name, tt.args.resourceMap)
+			if tt.length != len(tt.args.resourceMap[reflect.TypeOf(corev1.ConfigMap{})]) {
+				t.Errorf("ExcludeAppPropConfigMapFromResource() error = %v, wantErr %v", tt.args.resourceMap, tt.length)
+				return
+			}
+		})
+	}
+}
+
+func TestGetAppPropConfigMapContentHash(t *testing.T) {
+	serviceName := "test"
+	serviceNamespace := "test"
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName + appPropConfigMapSuffix,
+			Namespace: serviceNamespace,
+		},
+		Data: map[string]string{
+			appPropFileName: defaultAppPropContent,
+		},
+	}
+
+	type args struct {
+		name      string
+		namespace string
+		cli       *client.Client
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   *corev1.ConfigMap
+		wantErr bool
+	}{
+		{
+			"New ConfigMap",
+			args{
+				serviceName,
+				serviceNamespace,
+				test.CreateFakeClientOnOpenShift([]runtime.Object{}, nil, nil),
+			},
+			"d41d8cd98f00b204e9800998ecf8427e",
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName + appPropConfigMapSuffix,
+					Namespace: serviceNamespace,
+				},
+				Data: map[string]string{
+					appPropFileName: defaultAppPropContent,
+				},
+			},
+			false,
+		},
+		{
+			"No New ConfigMap",
+			args{
+				serviceName,
+				serviceNamespace,
+				test.CreateFakeClientOnOpenShift([]runtime.Object{cm}, nil, nil),
+			},
+			"d41d8cd98f00b204e9800998ecf8427e",
+			nil,
+			false,
+		},
+		{
+			"No Data",
+			args{
+				serviceName,
+				serviceNamespace,
+				test.CreateFakeClientOnOpenShift([]runtime.Object{&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      serviceName + appPropConfigMapSuffix,
+						Namespace: serviceNamespace,
+					},
+					Data: map[string]string{},
+				}}, nil, nil),
+			},
+			"d41d8cd98f00b204e9800998ecf8427e",
+			cm,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := GetAppPropConfigMapContentHash(tt.args.name, tt.args.namespace, tt.args.cli)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAppPropConfigMapContentHash() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetAppPropConfigMapContentHash() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("GetAppPropConfigMapContentHash() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-1193

Description: Quarkus and Springboot support application.properties override based on a directory in the file system. We could leverage from this to mount ConfigMaps to the deployed Kogito Services (either provided or built) for users to fine tune their configuration, not having to always rely on environment variables for that.

Implementation: Calculate the content hash of the `application.properties` of the config map in the reconcile loop. Store the content hash as an annotation of the deployment of the services. When the content hash changes, the deployment will rolling update.

Test: Only tested with quarkus for kogito runtime service and data index service. Springboot and Jobs service should work in the same way. 

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster