### PR TITLE
KOGITO-1002: Cucumber Tests: Test Management Console provisioning via CR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ cli_path=
 services_image_version=
 data_index_image_tag=
 jobs_service_image_tag=
+management_console_image_tag=
 # build
 maven_mirror=
 build_image_version=
@@ -129,6 +130,7 @@ run-tests:
 		--services_image_version ${services_image_version} \
 		--data_index_image_tag ${data_index_image_tag} \
 		--jobs_service_image_tag ${jobs_service_image_tag} \
+		--management_console_image_tag ${management_console_image_tag} \
 		--maven_mirror $(maven_mirror) \
 		--build_image_version ${build_image_version} \
 		--build_s2i_image_tag ${build_s2i_image_tag} \

--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,7 @@ You can set those optional keys:
 - `services_image_version` sets the services (jobs-service, data-index, ...) image version. Default is current operator version.
 - `data_index_image_tag` sets the Kogito Data Index image tag ('services_image_version' is ignored)
 - `jobs_service_image_tag` sets the Kogito Jobs Service image tag ('services_image_version' is ignored)
+- `management_console_image_tag` sets the Kogito Management Console image tag ('services_image_version' is ignored)
 - `maven_mirror` is the Maven mirror URL.  
   This is helpful when you need to speed up the build time by referring to a closer Maven repository.
 - `build_image_version` sets the build image version. Default is current operator version.

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -55,7 +55,7 @@ function usage(){
   printf "\n--cr_deployment_only\n\tUse this option if you have no CLI to test against. It will use only direct CR deployments."
 
   # operator information
-  printf "\n--operator_image {NAME}\n\tOperator image name. Default is 'quay.io/kiegroup' one."
+  printf "\n--operator_image {NAME}\n\tOperator image name. Default is 'quay.io/kiegroup/kogito-cloud-operator' one."
   printf "\n--operator_tag {TAG}\n\tOperator image tag. Default is operator version."
 
   # files/binaries
@@ -66,6 +66,7 @@ function usage(){
   printf "\n--services_image_version {VERSION}\n\tSet the services image version. Default to current operator version"
   printf "\n--data_index_image_tag {IMAGE_TAG}\n\tSet the Kogito Data Index image tag ('services_image_version' is ignored)"
   printf "\n--jobs_service_image_tag {IMAGE_TAG}\n\tSet the Kogito Jobs Service image tag ('services_image_version' is ignored)"
+  printf "\n--management_console_image_tag {IMAGE_TAG}\n\tSet the Kogito Management Console image tag ('services_image_version' is ignored)"
 
   # build
   printf "\n--maven_mirror {URI}\n\tMaven mirror url to be used when building app in the tests."
@@ -244,6 +245,10 @@ case $1 in
     shift
     if addParamKeyValueIfAccepted "--tests.jobs-service-image-tag" ${1}; then shift; fi
   ;;
+  --management_console_image_tag)
+    shift
+    if addParamKeyValueIfAccepted "--tests.management-console-image-tag" ${1}; then shift; fi
+  ;;
 
   # build
   --maven_mirror)
@@ -328,9 +333,8 @@ if ${CRDS_UPDATE}; then
 fi
 
 echo "-------- Running BDD tests"
-
-echo "DEBUG=${DEBUG} go test ./test -v -timeout \"${TIMEOUT}m\" --godog.tags=\"${TAGS}\" ${PARAMS} ${FEATURE}"
-DEBUG=${DEBUG} go test ./test -v -timeout "${TIMEOUT}m" --godog.tags="${TAGS}" ${PARAMS} ${FEATURE}
+echo "DEBUG=${DEBUG} go test ${SCRIPT_DIR}/../test -v -timeout \"${TIMEOUT}m\" --godog.tags=\"${TAGS}\" ${PARAMS} ${FEATURE}"
+DEBUG=${DEBUG} go test ${SCRIPT_DIR}/../test -v -timeout "${TIMEOUT}m" --godog.tags="${TAGS}" ${PARAMS} ${FEATURE}
 exit_code=$?
 echo "Tests finished with code ${exit_code}"
 

--- a/hack/run-tests.sh.bats
+++ b/hack/run-tests.sh.bats
@@ -296,6 +296,24 @@
     [[ "${output}" != *"--tests.jobs-service-image-tag"* ]]
 }
 
+@test "invoke run-tests with management_console_image_tag" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --management_console_image_tag tag --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "--tests.management-console-image-tag=tag" ]]
+}
+
+@test "invoke run-tests with management_console_image_tag missing value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --management_console_image_tag --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.management-console-image-tag"* ]]
+}
+
+@test "invoke run-tests with management_console_image_tag empty value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --management_console_image_tag "" --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.management-console-image-tag"* ]]
+}
+
 # build
 
 @test "invoke run-tests with maven_mirror" {

--- a/test/README.md
+++ b/test/README.md
@@ -13,6 +13,16 @@ It is using the [Godog](https://github.com/cucumber/godog) framework.
 
 `../hack/run-tests.sh --feature {FEATURE}`
 
+Example:
+
+`../hack/run-tests.sh --feature "features/install_kogitoinfra.feature`
+
+### Run using your own Kogito Operator repository
+
+`../hack/run-tests.sh --operator_image quay.io/jcarvaja/kogito-cloud-operator --operator_tag 0.9.0-rc2`
+
+Useful if you built your own image into your repository.
+
 ### Run in concurrent mode
 
 `../hack/run-tests.sh --concurrent {NB_OF_CONCURRENT_TESTS}`
@@ -22,3 +32,12 @@ It is using the [Godog](https://github.com/cucumber/godog) framework.
 Check the usage of the tests script:
 
 `../hack/run-tests.sh -h`
+
+## Development
+
+### Useful Extensions for VS Code
+
+- [Cucumber (Gherkin)](https://marketplace.visualstudio.com/items?itemName=alexkrechik.cucumberautocomplete))
+- [Go](https://github.com/microsoft/vscode-go) extension
+- [Go Documentation](https://github.com/msyrus/vscode-go-doc)
+

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -42,6 +42,7 @@ type TestConfig struct {
 	servicesImageVersion string
 	dataIndexImageTag    string
 	jobsServiceImageTag  string
+	mgmtConsoleImageTag  string
 
 	// build
 	mavenMirrorURL       string
@@ -101,6 +102,7 @@ func BindFlags(set *flag.FlagSet) {
 	set.StringVar(&env.servicesImageVersion, prefix+"services-image-version", version.Version, "Set the services (jobs-service, data-index) image version")
 	set.StringVar(&env.dataIndexImageTag, prefix+"data-index-image-tag", "", "Set the Kogito Data Index image tag ('services-image-version' is ignored)")
 	set.StringVar(&env.jobsServiceImageTag, prefix+"jobs-service-image-tag", "", "Set the Kogito Jobs Service image tag ('services-image-version' is ignored)")
+	set.StringVar(&env.mgmtConsoleImageTag, prefix+"management-console-image-tag", "", "Set the Kogito Management Console image tag ('services-image-version' is ignored)")
 
 	// build
 	set.StringVar(&env.mavenMirrorURL, prefix+"maven-mirror-url", "", "Maven mirror url to be used when building app in the tests")
@@ -185,6 +187,11 @@ func GetDataIndexImageTag() string {
 // GetJobsServiceImageTag return the Kogito Jobs Service image tag
 func GetJobsServiceImageTag() string {
 	return env.jobsServiceImageTag
+}
+
+// GetManagementConsoleImageTag return the Kogito Management Console image tag
+func GetManagementConsoleImageTag() string {
+	return env.mgmtConsoleImageTag
 }
 
 // build

--- a/test/features/install_mgmtconsole.feature
+++ b/test/features/install_mgmtconsole.feature
@@ -1,0 +1,13 @@
+@managementconsole
+Feature: Install Kogito Management Console
+
+  Background:
+    Given Namespace is created
+    And Kogito Operator is deployed with Infinispan and Kafka operators
+
+  Scenario: Install Kogito Management Console
+    Given Install Kogito Data Index with 1 replicas
+    And Kogito Data Index has 1 pods running within 10 minutes
+    When Install Kogito Management Console with 1 replicas
+    Then Kogito Management Console has 1 pods running within 10 minutes
+    And HTTP GET request on service "management-console" with path "" is successful within 2 minutes

--- a/test/framework/kogitomgmtconsole.go
+++ b/test/framework/kogitomgmtconsole.go
@@ -1,0 +1,101 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"fmt"
+
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/framework"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
+	apps "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// InstallKogitoManagementConsole deploy the Kogito Management Console
+func InstallKogitoManagementConsole(namespace string, installerType InstallerType, replicas int) error {
+	GetLogger(namespace).Infof("%s install Kogito Management Console with %d replicas", installerType, replicas)
+	switch installerType {
+	case CRInstallerType:
+		return crInstallKogitoManagementConsole(namespace, replicas)
+	default:
+		panic(fmt.Errorf("Unknown installer type %s", installerType))
+	}
+}
+
+func crInstallKogitoManagementConsole(namespace string, replicas int) error {
+	service := getManagementConsoleStub(namespace, int32(replicas))
+
+	if _, err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(service); err != nil {
+		return fmt.Errorf("Error creating Kogito Management Console: %v", err)
+	}
+	return nil
+}
+
+func getManagementConsoleImageTag() v1alpha1.Image {
+	if len(config.GetManagementConsoleImageTag()) > 0 {
+		return framework.ConvertImageTagToImage(config.GetManagementConsoleImageTag())
+	}
+
+	image := framework.ConvertImageTagToImage(infrastructure.DefaultMgmtConsoleImageFullTag)
+	image.Tag = config.GetServicesImageVersion()
+	return image
+}
+
+// GetKogitoManagementConsoleDeployment retrieves the running management console deployment
+func GetKogitoManagementConsoleDeployment(namespace string) (*apps.Deployment, error) {
+	return GetDeployment(namespace, infrastructure.DefaultMgmtConsoleName)
+}
+
+// WaitForKogitoManagementConsole waits that the management console has a certain number of replicas
+func WaitForKogitoManagementConsole(namespace string, replicas, timeoutInMin int) error {
+	return WaitForOnOpenshift(namespace, "Kogito Management Console running", timeoutInMin,
+		func() (bool, error) {
+			deployment, err := GetKogitoManagementConsoleDeployment(namespace)
+			if err != nil {
+				return false, err
+			}
+			if deployment == nil {
+				return false, nil
+			}
+			return deployment.Status.Replicas == int32(replicas) && deployment.Status.AvailableReplicas == int32(replicas), nil
+		})
+}
+
+func getManagementConsoleStub(namespace string, replicas int32) *v1alpha1.KogitoMgmtConsole {
+	service := &v1alpha1.KogitoMgmtConsole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      infrastructure.DefaultMgmtConsoleName,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.KogitoMgmtConsoleSpec{
+			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{
+				Replicas: &replicas,
+				Image:    getManagementConsoleImageTag(),
+			},
+		},
+		Status: v1alpha1.KogitoMgmtConsoleStatus{
+			KogitoServiceStatus: v1alpha1.KogitoServiceStatus{
+				ConditionsMeta: v1alpha1.ConditionsMeta{
+					Conditions: []v1alpha1.Condition{},
+				},
+			},
+		},
+	}
+
+	return service
+}

--- a/test/steps/data.go
+++ b/test/steps/data.go
@@ -41,6 +41,7 @@ func (data *Data) RegisterAllSteps(s *godog.Suite) {
 	registerKogitoDataIndexServiceSteps(s, data)
 	registerKogitoInfraSteps(s, data)
 	registerKogitoJobsServiceSteps(s, data)
+	registerKogitoManagementConsoleSteps(s, data)
 	registerKubernetesSteps(s, data)
 	registerMavenSteps(s, data)
 	registerOpenShiftSteps(s, data)

--- a/test/steps/kogitomgmtconsole.go
+++ b/test/steps/kogitomgmtconsole.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"github.com/cucumber/godog"
+	"github.com/kiegroup/kogito-cloud-operator/test/framework"
+)
+
+// RegisterCliSteps register all CLI steps existing
+func registerKogitoManagementConsoleSteps(s *godog.Suite, data *Data) {
+	s.Step(`^Install Kogito Management Console with (\d+) replicas$`, data.installKogitoManagementConsoleWithReplicas)
+	s.Step(`^Kogito Management Console has (\d+) pods running within (\d+) minutes$`, data.kogitoManagementConsoleHasPodsRunningWithinMinutes)
+}
+
+func (data *Data) installKogitoManagementConsoleWithReplicas(replicas int) error {
+	return framework.InstallKogitoManagementConsole(data.Namespace, framework.CRInstallerType, replicas)
+}
+
+func (data *Data) kogitoManagementConsoleHasPodsRunningWithinMinutes(pods, timeoutInMin int) error {
+	return framework.WaitForKogitoManagementConsole(data.Namespace, pods, timeoutInMin)
+}


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/KOGITO-1002
Description: As part of https://issues.redhat.com/browse/KOGITO-755, operator will be able to provision the management console via CR.

How to run tests:

```
../hack/run-tests.sh --feature "features/install_mgmtconsole.feature" --disabled_crds_update --operator_image quay.io/jcarvaja/kogito-cloud-operator --services_image_version 0.9.0-rc2 --cr_deployment_only
```

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster