### PR TITLE
[master][KOGITO-1044] - Kogito runtime performance and load tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ concurrent=1
 timeout=240
 debug=false
 smoke=false
+performance=false
 load_factor=1
 local=false
 ci=
@@ -115,6 +116,7 @@ run-tests:
 	declare -a opts \
 	&& if [ "${debug}" = "true" ]; then opts+=("--debug"); fi \
 	&& if [ "${smoke}" = "true" ]; then opts+=("--smoke"); fi \
+	&& if [ "${performance}" = "true" ]; then opts+=("--performance"); fi \
 	&& if [ "${local}" = "true" ]; then opts+=("--local"); fi \
 	&& if [ "${cr_deployment_only}" = "true" ]; then opts+=("--cr_deployment_only"); fi \
 	&& if [ "${show_scenarios}" = "true" ]; then opts+=("--show_scenarios"); fi \
@@ -149,6 +151,10 @@ run-tests:
 .PHONY: run-smoke-tests
 run-smoke-tests: 
 	make run-tests smoke=true
+
+.PHONY: run-performance-tests
+run-performance-tests:
+	make run-tests performance=true
 
 .PHONY: prepare-olm
 version = ""

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Table of Contents
             * [Running BDD tests with current branch](#running-bdd-tests-with-current-branch)
             * [Running BDD tests with custom Kogito Build images' version](#running-bdd-tests-with-custom-kogito-build-images-version)
             * [Running smoke tests](#running-smoke-tests)
+            * [Running performance tests](#running-performance-tests)
          * [Running the Kogito Operator locally](#running-the-kogito-operator-locally)
       * [Contributing to the Kogito Operator](#contributing-to-the-kogito-operator)
 
@@ -1147,6 +1148,20 @@ $ make run-smoke-tests [key=value]*
 
 It will run only tests tagged with `@smoke`.
 All options from BDD tests do also apply here.
+
+#### Running performance tests
+
+The BDD tests also provide performance tests. These tests are ignored unless you
+specifically provide the `@performance` tag or run:
+
+```bash
+$ make run-performance-tests [key=value]*
+```
+
+It will run only tests tagged with `@performance`. 
+All options from BDD tests do also apply here.
+
+**NOTE:** Performance tests should be run without concurrency.
 
 ### Running the Kogito Operator locally
 

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -41,6 +41,7 @@ function usage(){
   printf "\n--timeout {TIMEOUT_IN_MINUTES}\n\tSet a timeout overall tests run in minutes. Default is 240."
   printf "\n--debug\n\tRun in debug mode."
   printf "\n--smoke\n\tFilter to run only the tests tagged with '@smoke'."
+  printf "\n--performance\n\tFilter to run only the tests tagged with '@performance'. If not provided and the tag itself is not specified, these tests will be ignored."
   printf "\n--load_factor {INT_VALUE}\n\tSet the tests load factor. Useful for the tests to take into account that the cluster can be overloaded, for example for the calculation of timouts. Default value is 1."
   printf "\n--local\n\tSpecify whether you run test in local."
   printf "\n--ci {CI_NAME}\n\tSpecify whether you run test with ci, give also the name of the CI."
@@ -159,6 +160,10 @@ case $1 in
   ;;
   --smoke)
     addParam "--tests.smoke"
+    shift
+  ;;
+  --performance)
+    addParam "--tests.performance"
     shift
   ;;
   --load_factor)

--- a/hack/run-tests.sh.bats
+++ b/hack/run-tests.sh.bats
@@ -116,6 +116,18 @@
     [[ "${output}" != *"--tests.smoke"* ]]
 }
 
+@test "invoke run-tests with performance" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --performance --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "--tests.performance" ]]
+}
+
+@test "invoke run-tests without performance" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.performance"* ]]
+}
+
 @test "invoke run-tests with load_factor" {
     run ${BATS_TEST_DIRNAME}/run-tests.sh --load_factor 3 --dry_run
     [ "$status" -eq 0 ]

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -25,6 +25,7 @@ import (
 type TestConfig struct {
 	// tests configuration
 	smoke            bool
+	performance      bool
 	loadFactor       int
 	localTests       bool
 	ciName           string
@@ -85,6 +86,7 @@ func BindFlags(set *flag.FlagSet) {
 
 	// tests configuration
 	set.BoolVar(&env.smoke, prefix+"smoke", false, "Launch only smoke tests")
+	set.BoolVar(&env.performance, prefix+"performance", false, "Launch performance tests")
 	set.IntVar(&env.loadFactor, prefix+"load-factor", defaultLoadFactor, "Set the tests load factor. Useful for the tests to take into account that the cluster can be overloaded, for example for the calculation of timeouts. Default value is 1.")
 	set.BoolVar(&env.localTests, prefix+"local", false, "If tests are launch on local machine")
 	set.StringVar(&env.ciName, prefix+"ci", "", "If tests are launch on ci machine, give the CI name")
@@ -123,9 +125,14 @@ func BindFlags(set *flag.FlagSet) {
 
 // tests configuration
 
-// IsSmokeTests return whether tests are executed in local
+// IsSmokeTests return whether smoke tests should be executed
 func IsSmokeTests() bool {
 	return env.smoke
+}
+
+// IsPerformanceTests return whether performance tests should be executed
+func IsPerformanceTests() bool {
+	return env.performance
 }
 
 // GetLoadFactor return the load factor of the cluster

--- a/test/features/kogito_service_performance.feature
+++ b/test/features/kogito_service_performance.feature
@@ -1,0 +1,152 @@
+# Commented code will be addressed by further enhancements:
+# https://issues.redhat.com/browse/KOGITO-1699
+# https://issues.redhat.com/browse/KOGITO-1700
+# https://issues.redhat.com/browse/KOGITO-1701
+
+@performance
+Feature: Kogito Service Performance
+
+  Background:
+    Given Namespace is created
+
+  @quarkus
+  Scenario Outline: Quarkus Kogito Service Performance without persistence
+    Given Kogito Operator is deployed
+    And Deploy quarkus example service "jbpm-quarkus-example" with native <native>
+    And Kogito application "jbpm-quarkus-example" has 1 pods running within <minutes> minutes
+    And HTTP GET request on service "jbpm-quarkus-example" with path "orders" is successful within 3 minutes
+
+    When <requests> HTTP POST requests with report using 100 threads on service "jbpm-quarkus-example" with path "orders" and body:
+      """json
+      {
+        "approver" : "john",
+        "order" : {
+          "orderNumber" : "12345",
+          "shipped" : false
+        }
+      }
+      """
+
+    Then HTTP GET request on service "jbpm-quarkus-example" with path "orders" should return an array of size <requests> within 1 minutes
+    And HTTP GET request on service "jbpm-quarkus-example" with path "orderItems" should return an array of size <requests> within 1 minutes
+    #And All human tasks on path "orderItems" with path task name "Verify_order" are successfully "completed" with timing "true"
+
+
+    Examples: Non Native
+      | native   | minutes | requests |
+      | disabled | 10      | 40000    |
+      | disabled | 10      | 80000    |
+#      | disabled | 10      | 160000   |
+#      | disabled | 10      | 320000   |
+
+    @native
+    Examples: Native
+      | native  | minutes | requests |
+      | enabled | 20      | 40000    |
+      | enabled | 20      | 80000    |
+#      | enabled | 20      | 160000   |
+#      | enabled | 20      | 320000   |
+
+#####
+
+  @quarkus
+  @persistence
+  Scenario Outline: Quarkus Kogito Service Performance with persistence
+    Given Kogito Operator is deployed with Infinispan operator
+    And Deploy quarkus example service "jbpm-quarkus-example" with native <native> and persistence
+    And Kogito application "jbpm-quarkus-example" has 1 pods running within <minutes> minutes
+    And HTTP GET request on service "jbpm-quarkus-example" with path "orders" is successful within 3 minutes
+
+    When <requests> HTTP POST requests with report using 100 threads on service "jbpm-quarkus-example" with path "orders" and body:
+      """json
+      {
+        "approver" : "john",
+        "order" : {
+          "orderNumber" : "12345",
+          "shipped" : false
+        }
+      }
+      """
+
+    Then HTTP GET request on service "jbpm-quarkus-example" with path "orders" should return an array of size <requests> within 1 minutes
+    And HTTP GET request on service "jbpm-quarkus-example" with path "orderItems" should return an array of size <requests> within 1 minutes
+    #And All human tasks on path "orderItems" with path task name "Verify_order" are successfully "completed" with timing "true"
+
+
+    Examples: Non Native
+      | native   | minutes | requests |
+      | disabled | 10      | 40000    |
+      | disabled | 10      | 80000    |
+#      | disabled | 10      | 160000   |
+#      | disabled | 10      | 320000   |
+
+    @native
+    Examples: Native
+      | native  | minutes | requests |
+      | enabled | 20      | 40000    |
+      | enabled | 20      | 80000    |
+#      | enabled | 20      | 160000   |
+#      | enabled | 20      | 320000   |
+
+#####
+
+  @springboot
+  Scenario Outline: Spring Boot Kogito Service Performance without persistence
+    Given Kogito Operator is deployed
+    And Deploy spring boot example service "jbpm-springboot-example"
+    And Kogito application "jbpm-springboot-example" has 1 pods running within <minutes> minutes
+    And HTTP GET request on service "jbpm-springboot-example" with path "orders" is successful within 3 minutes
+
+    When <requests> HTTP POST requests with report using 100 threads on service "jbpm-springboot-example" with path "orders" and body:
+      """json
+      {
+        "approver" : "john",
+        "order" : {
+          "orderNumber" : "12345",
+          "shipped" : false
+        }
+      }
+      """
+
+    Then HTTP GET request on service "jbpm-springboot-example" with path "orders" should return an array of size <requests> within 1 minutes
+    And HTTP GET request on service "jbpm-springboot-example" with path "orderItems" should return an array of size <requests> within 1 minutes
+    #And All human tasks on path "orderItems" with path task name "Verify_order" are successfully "completed" with timing "true"
+
+    Examples:
+      | minutes | requests |
+      | 10      | 40000    |
+      | 10      | 80000    |
+#      | 10      | 160000   |
+#      | 10      | 320000   |
+
+#####
+
+  @springboot
+  @persistence
+  Scenario Outline: Spring Boot Kogito Service Performance with persistence
+    Given Kogito Operator is deployed with Infinispan operator
+    And Deploy spring boot example service "jbpm-springboot-example" with persistence
+    And Kogito application "jbpm-springboot-example" has 1 pods running within <minutes> minutes
+    And HTTP GET request on service "jbpm-springboot-example" with path "orders" is successful within 3 minutes
+
+    When <requests> HTTP POST requests with report using 100 threads on service "jbpm-springboot-example" with path "orders" and body:
+      """json
+      {
+        "approver" : "john",
+        "order" : {
+          "orderNumber" : "12345",
+          "shipped" : false
+        }
+      }
+      """
+
+    Then HTTP GET request on service "jbpm-springboot-example" with path "orders" should return an array of size <requests> within 1 minutes
+    And HTTP GET request on service "jbpm-springboot-example" with path "orderItems" should return an array of size <requests> within 1 minutes
+    #And All human tasks on path "orderItems" with path task name "Verify_order" are successfully "completed" with timing "true"
+
+    Examples:
+      | minutes | requests |
+      | 10      | 40000    |
+      | 10      | 80000    |
+#      | 10      | 160000   |
+#      | 10      | 320000   |

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -33,9 +33,10 @@ import (
 )
 
 const (
-	disabledTag = "@disabled"
-	cliTag      = "@cli"
-	smokeTag    = "@smoke"
+	disabledTag    = "@disabled"
+	cliTag         = "@cli"
+	smokeTag       = "@smoke"
+	performanceTag = "@performance"
 )
 
 var opt = godog.Options{
@@ -89,20 +90,29 @@ func TestMain(m *testing.M) {
 
 func configureTags() {
 	if config.IsSmokeTests() {
-		if len(opt.Tags) > 0 {
-			opt.Tags += " && "
-		}
 		// Filter with smoke tag
-		opt.Tags += smokeTag
+		appendTag(smokeTag)
+	} else if !strings.Contains(opt.Tags, performanceTag) {
+		if config.IsPerformanceTests() {
+			// Turn on performance tests
+			appendTag(performanceTag)
+		} else {
+			// Turn off performance tests
+			appendTag("~" + performanceTag)
+		}
 	}
 
 	if !strings.Contains(opt.Tags, disabledTag) {
-		if len(opt.Tags) > 0 {
-			opt.Tags += " && "
-		}
 		// Ignore disabled tag
-		opt.Tags += "~" + disabledTag
+		appendTag("~" + disabledTag)
 	}
+}
+
+func appendTag(tag string) {
+	if len(opt.Tags) > 0 {
+		opt.Tags += " && "
+	}
+	opt.Tags += tag
 }
 
 func configureTestOutput() {

--- a/test/steps/data.go
+++ b/test/steps/data.go
@@ -30,6 +30,7 @@ type Data struct {
 	Namespace              string
 	StartTime              time.Time
 	KogitoExamplesLocation string
+	ScenarioName           string
 }
 
 // RegisterAllSteps register all steps available to the test suite
@@ -56,6 +57,7 @@ func (data *Data) BeforeScenario(s interface{}) {
 	data.StartTime = time.Now()
 	data.Namespace = getNamespaceName()
 	data.KogitoExamplesLocation = createTemporaryFolder()
+	data.ScenarioName = framework.GetScenarioName(s)
 
 	framework.GetLogger(data.Namespace).Info(fmt.Sprintf("Scenario %s", framework.GetScenarioName(s)))
 	go framework.StartPodLogCollector(data.Namespace)


### PR DESCRIPTION
So guys,

it's finally here. A couple of things to be noted about the reporting:

* The metric which I am measuring now (create a given number of processes) is measured in the `executePostRequestsWithOptionalReportingUsingThreadsOnServiceWithPathAndBody` step function which calls `ExecuteHTTPRequestsInThreads` from the framework. At first, I tried to measure just the loop where requests are made inside the `ExecuteHTTPRequestsInThreads` function, but that would mean to push the `report` parameter and also the name of the metric into that function, so it wouldn't be as general as it is now. And when I measured it, the difference when measuring just requests and requests also with other nearby code was less than 1 ms, which is something I think we can live with as results are in seconds. Also the step for execution of many requests is available without reporting so if somebody in the future wants to create for example 10 process instances but doesn't care about the duration of it, they might find it helpful. Right now it's just me and I use the step with reporting.

* Anyway, I left included a log message with time measurement of the threads in the `ExecuteHTTPRequestsInThreads` so even if it is not used for performance reason, it is there as an additional information. Or maybe I should just print that threads have finished but duration won't be displayed? Wdyt?

* The metric name contains also the namespace and the scenario name so I know which scenario I am measuring. The only exception is that I cannot now distinguish between Native and Non Native (this is the name of the Examples table) as in the beforeScenario method Godog is passing whole ScenarioOutline with all examples tables. But so far it's OK as I can determine it by different times and also by order.

Currently, anything above 80k processes and with persistence is failing for 2 reasons, so these scenarios are commented out:

1. If I try more than 80k processes without persistence, I run out of heap as by default it is 1/4 of available memory, which is unrestricted for a project/pod so it seems that I am topping 4 GB as a node memory is 16 GB, which makes sense. So I will need to implement a way to specify it when deploying a service.

1. If I run anything with 80k processes or more with persistence, Infinispan runs out of heap as its heap is desperately low at 200 MB. These are the JVM options it is starting with: 
`JVM arguments = -Xmx200M -Xms200M -XX:MaxRAM=420M -Dsun.zip.disableMemoryMapping=true -XX:+UseSerialGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:+ExitOnOutOfMemoryError -XX:MetaspaceSize=32m -XX:MaxMetaspaceSize=96m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dinfinispan.server.home.path=/opt/infinispan`

    So we have a couple of options:

    1. Leave it as it is because it is a default and I will somehow deploy my own Infinispan which has `extraJvmOpts` under `spec.container` in their CR. This will append -Xmx custom setting and since the last one wins, it will override the default. Already tried it manually on OpenShift.
    2. Increase the default deployed by Kogito Operator (KogitoInfra) to 1 GB for example. If it is sufficient for the performance tests I don't have to manually increase it afterwards.
    3. Provide a super cool way for configuring it via our Kogito Operator, so it will be configurable the same way we now configure for example the build images of services or the services themselves.

    I would personally go the way of the point ii. or iii. as I really believe 200 MB is too small for everything other than an example. Moreover, if we want to have our getting started experience as good as possible, it would be good to have at least 1 GB for storage by default so users can also try some real use cases out of the box and not just running 1 process instance.

1. Human tasks bulk completion step is currently commented as well. I have this on my list, it is there just as a note.