### PR TITLE
[master][KOGITO-1258] - Adding 'remove' CLI commands to runtime support services

### DIFF
--- a/cmd/kogito/command/completion/completion.go
+++ b/cmd/kogito/command/completion/completion.go
@@ -27,8 +27,8 @@ type completionCommand struct {
 	Parent  *cobra.Command
 }
 
-// newCompletionCommand is the constructor for the completion command
-func newCompletionCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+// initCompletionCommand is the constructor for the completion command
+func initCompletionCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := &completionCommand{CommandContext: *ctx, Parent: parent}
 	cmd.RegisterHook()
 	cmd.InitHook()

--- a/cmd/kogito/command/completion/factory.go
+++ b/cmd/kogito/command/completion/factory.go
@@ -20,8 +20,6 @@ import (
 )
 
 // BuildCommands creates the commands available in this package
-func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) (commands []context.KogitoCommand) {
-	return []context.KogitoCommand{
-		newCompletionCommand(ctx, rootCommand),
-	}
+func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) {
+	initCompletionCommand(ctx, rootCommand)
 }

--- a/cmd/kogito/command/context/command_context.go
+++ b/cmd/kogito/command/context/command_context.go
@@ -39,5 +39,5 @@ type KogitoCommand interface {
 // CommandFactory supports inner commands creation
 type CommandFactory struct {
 	// BuildCommands creates the command hierarchy for a given feature
-	BuildCommands func(ctx *CommandContext, rootCommand *cobra.Command) (commands []KogitoCommand)
+	BuildCommands func(ctx *CommandContext, rootCommand *cobra.Command)
 }

--- a/cmd/kogito/command/deploy/delete_service.go
+++ b/cmd/kogito/command/deploy/delete_service.go
@@ -30,7 +30,7 @@ type deleteServiceFlags struct {
 	project string
 }
 
-func newDeleteServiceCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initDeleteServiceCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := &deleteServiceCommand{CommandContext: *ctx, Parent: parent}
 	cmd.RegisterHook()
 	cmd.InitHook()

--- a/cmd/kogito/command/deploy/deploy_service.go
+++ b/cmd/kogito/command/deploy/deploy_service.go
@@ -64,8 +64,8 @@ type deployCommand struct {
 	Parent  *cobra.Command
 }
 
-// newDeployCommand is the constructor for the deploy command
-func newDeployCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+// initDeployCommand is the constructor for the deploy command
+func initDeployCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := &deployCommand{CommandContext: *ctx, Parent: parent}
 	cmd.RegisterHook()
 	cmd.InitHook()

--- a/cmd/kogito/command/deploy/factory.go
+++ b/cmd/kogito/command/deploy/factory.go
@@ -20,9 +20,7 @@ import (
 )
 
 // BuildCommands creates the commands available in this package
-func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) (commands []context.KogitoCommand) {
-	return []context.KogitoCommand{
-		newDeleteServiceCommand(ctx, rootCommand),
-		newDeployCommand(ctx, rootCommand),
-	}
+func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) {
+	initDeleteServiceCommand(ctx, rootCommand)
+	initDeployCommand(ctx, rootCommand)
 }

--- a/cmd/kogito/command/install/data_index.go
+++ b/cmd/kogito/command/install/data_index.go
@@ -55,7 +55,7 @@ type installDataIndexCommand struct {
 	Parent  *cobra.Command
 }
 
-func newInstallDataIndexCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initInstallDataIndexCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := &installDataIndexCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/install/factory.go
+++ b/cmd/kogito/command/install/factory.go
@@ -20,16 +20,13 @@ import (
 )
 
 // BuildCommands creates the commands available in this package
-func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) []context.KogitoCommand {
-	installCmd := newInstallCommand(ctx, rootCommand)
-	return []context.KogitoCommand{
-		installCmd,
-		newInstallKogitoOperatorCommand(ctx, installCmd.Command()),
-		newInstallDataIndexCommand(ctx, installCmd.Command()),
-		newInstallJobsServiceCommand(ctx, installCmd.Command()),
-		newInstallInfinispanCommand(ctx, installCmd.Command()),
-		newInstallKeycloakCommand(ctx, installCmd.Command()),
-		newInstallKafkaCommand(ctx, installCmd.Command()),
-		newInstallMgmtConsoleCommand(ctx, installCmd.Command()),
-	}
+func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) {
+	installCmd := initInstallCommand(ctx, rootCommand)
+	initInstallKogitoOperatorCommand(ctx, installCmd.Command())
+	initInstallDataIndexCommand(ctx, installCmd.Command())
+	initInstallJobsServiceCommand(ctx, installCmd.Command())
+	initInstallInfinispanCommand(ctx, installCmd.Command())
+	initInstallKeycloakCommand(ctx, installCmd.Command())
+	initInstallKafkaCommand(ctx, installCmd.Command())
+	initInstallMgmtConsoleCommand(ctx, installCmd.Command())
 }

--- a/cmd/kogito/command/install/infinispan.go
+++ b/cmd/kogito/command/install/infinispan.go
@@ -31,7 +31,7 @@ type installInfinispanCommand struct {
 	Parent  *cobra.Command
 }
 
-func newInstallInfinispanCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initInstallInfinispanCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	command := installInfinispanCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/install/install.go
+++ b/cmd/kogito/command/install/install.go
@@ -25,7 +25,7 @@ type installCommand struct {
 	Parent  *cobra.Command
 }
 
-func newInstallCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initInstallCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := installCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/install/jobs_service.go
+++ b/cmd/kogito/command/install/jobs_service.go
@@ -54,7 +54,7 @@ type installJobsServiceCommand struct {
 	Parent  *cobra.Command
 }
 
-func newInstallJobsServiceCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initInstallJobsServiceCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := &installJobsServiceCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/install/kafka.go
+++ b/cmd/kogito/command/install/kafka.go
@@ -31,7 +31,7 @@ type installKafkaCommand struct {
 	Parent  *cobra.Command
 }
 
-func newInstallKafkaCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initInstallKafkaCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	command := installKafkaCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/install/keycloak.go
+++ b/cmd/kogito/command/install/keycloak.go
@@ -31,7 +31,7 @@ type installKeycloakCommand struct {
 	Parent  *cobra.Command
 }
 
-func newInstallKeycloakCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initInstallKeycloakCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	command := installKeycloakCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/install/kogito_operator.go
+++ b/cmd/kogito/command/install/kogito_operator.go
@@ -35,7 +35,7 @@ type installKogitoOperatorCommand struct {
 	Parent  *cobra.Command
 }
 
-func newInstallKogitoOperatorCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initInstallKogitoOperatorCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	command := installKogitoOperatorCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/install/mgmt_console.go
+++ b/cmd/kogito/command/install/mgmt_console.go
@@ -41,7 +41,7 @@ type installMgmtConsoleCommand struct {
 	Parent  *cobra.Command
 }
 
-func newInstallMgmtConsoleCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initInstallMgmtConsoleCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := &installMgmtConsoleCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/project/delete_project.go
+++ b/cmd/kogito/command/project/delete_project.go
@@ -36,7 +36,7 @@ type deleteProjectCommand struct {
 	Parent  *cobra.Command
 }
 
-func newDeleteProjectCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initDeleteProjectCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := deleteProjectCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/project/display_project.go
+++ b/cmd/kogito/command/project/display_project.go
@@ -30,7 +30,7 @@ type displayProjectCommand struct {
 	Parent  *cobra.Command
 }
 
-func newDisplayProjectCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initDisplayProjectCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := displayProjectCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/project/factory.go
+++ b/cmd/kogito/command/project/factory.go
@@ -20,11 +20,9 @@ import (
 )
 
 // BuildCommands creates the commands available in this package
-func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) []context.KogitoCommand {
-	return []context.KogitoCommand{
-		newDeleteProjectCommand(ctx, rootCommand),
-		newNewProjectCommand(ctx, rootCommand),
-		newUseProjectCommand(ctx, rootCommand),
-		newDisplayProjectCommand(ctx, rootCommand),
-	}
+func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) {
+	initDeleteProjectCommand(ctx, rootCommand)
+	initNewProjectCommand(ctx, rootCommand)
+	initUseProjectCommand(ctx, rootCommand)
+	initDisplayProjectCommand(ctx, rootCommand)
 }

--- a/cmd/kogito/command/project/new_project.go
+++ b/cmd/kogito/command/project/new_project.go
@@ -34,7 +34,7 @@ type newProjectCommand struct {
 	Parent  *cobra.Command
 }
 
-func newNewProjectCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initNewProjectCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := newProjectCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/project/use_project.go
+++ b/cmd/kogito/command/project/use_project.go
@@ -35,7 +35,7 @@ type useProjectCommand struct {
 	Parent  *cobra.Command
 }
 
-func newUseProjectCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initUseProjectCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := useProjectCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/remove/factory.go
+++ b/cmd/kogito/command/remove/factory.go
@@ -20,12 +20,10 @@ import (
 )
 
 // BuildCommands creates the commands available in this package
-func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) []context.KogitoCommand {
-	removeCmd := newRemoveCommand(ctx, rootCommand)
-	return []context.KogitoCommand{
-		removeCmd,
-		newRemoveInfinispanCommand(ctx, removeCmd.Command()),
-		newRemoveKeycloakCommand(ctx, removeCmd.Command()),
-		newRemoveKafkaCommand(ctx, removeCmd.Command()),
-	}
+func BuildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) {
+	removeCmd := initRemoveCommand(ctx, rootCommand)
+	initRemoveInfinispanCommand(ctx, removeCmd.Command())
+	initRemoveKeycloakCommand(ctx, removeCmd.Command())
+	initRemoveKafkaCommand(ctx, removeCmd.Command())
+	initRemoveRuntimeServiceCommands(ctx, removeCmd.Command())
 }

--- a/cmd/kogito/command/remove/infinispan.go
+++ b/cmd/kogito/command/remove/infinispan.go
@@ -31,7 +31,7 @@ type removeInfinispanCommand struct {
 	Parent  *cobra.Command
 }
 
-func newRemoveInfinispanCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initRemoveInfinispanCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	command := removeInfinispanCommand{
 		CommandContext: *ctx,
 		Parent:         parent,
@@ -50,7 +50,7 @@ func (i *removeInfinispanCommand) Command() *cobra.Command {
 func (i *removeInfinispanCommand) RegisterHook() {
 	i.command = &cobra.Command{
 		Use:     "infinispan",
-		Short:   "removes installed infinispan instance into the OpenShift/Kubernetes cluster",
+		Short:   "removes installed infinispan instance from the OpenShift/Kubernetes cluster",
 		Example: "remove infinispan -p my-project",
 		Long:    `removes installed infinispan instance via custom Kubernetes resources.`,
 		RunE:    i.Exec,
@@ -65,7 +65,7 @@ func (i *removeInfinispanCommand) RegisterHook() {
 func (i *removeInfinispanCommand) InitHook() {
 	i.flags = removeInfinispanFlags{}
 	i.Parent.AddCommand(i.command)
-	i.command.Flags().StringVarP(&i.flags.namespace, "project", "p", "", "The project name where the operator will be deployed")
+	i.command.Flags().StringVarP(&i.flags.namespace, "project", "p", "", "The project name where is the Infinispan instance to remove")
 }
 
 func (i *removeInfinispanCommand) Exec(cmd *cobra.Command, args []string) error {

--- a/cmd/kogito/command/remove/kafka.go
+++ b/cmd/kogito/command/remove/kafka.go
@@ -31,7 +31,7 @@ type removeKafkaCommand struct {
 	Parent  *cobra.Command
 }
 
-func newRemoveKafkaCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initRemoveKafkaCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	command := removeKafkaCommand{
 		CommandContext: *ctx,
 		Parent:         parent,
@@ -65,7 +65,7 @@ func (i *removeKafkaCommand) RegisterHook() {
 func (i *removeKafkaCommand) InitHook() {
 	i.flags = removeKafkaFlags{}
 	i.Parent.AddCommand(i.command)
-	i.command.Flags().StringVarP(&i.flags.namespace, "project", "p", "", "The project name where the operator will be deployed")
+	i.command.Flags().StringVarP(&i.flags.namespace, "project", "p", "", "The project name where is the Kafka instance to remove")
 }
 
 func (i *removeKafkaCommand) Exec(cmd *cobra.Command, args []string) error {

--- a/cmd/kogito/command/remove/keycloak.go
+++ b/cmd/kogito/command/remove/keycloak.go
@@ -31,7 +31,7 @@ type removeKeycloakCommand struct {
 	Parent  *cobra.Command
 }
 
-func newRemoveKeycloakCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initRemoveKeycloakCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	command := removeKeycloakCommand{
 		CommandContext: *ctx,
 		Parent:         parent,
@@ -50,7 +50,7 @@ func (i *removeKeycloakCommand) Command() *cobra.Command {
 func (i *removeKeycloakCommand) RegisterHook() {
 	i.command = &cobra.Command{
 		Use:     "keycloak",
-		Short:   "removes installed keycloak instance into the OpenShift/Kubernetes cluster",
+		Short:   "removes installed keycloak instance from the OpenShift/Kubernetes cluster",
 		Example: "remove keycloak -p my-project",
 		Long:    `removes installed keycloak instance via custom Kubernetes resources.`,
 		RunE:    i.Exec,
@@ -65,7 +65,7 @@ func (i *removeKeycloakCommand) RegisterHook() {
 func (i *removeKeycloakCommand) InitHook() {
 	i.flags = removeKeycloakFlags{}
 	i.Parent.AddCommand(i.command)
-	i.command.Flags().StringVarP(&i.flags.namespace, "project", "p", "", "The project name where the operator will be deployed")
+	i.command.Flags().StringVarP(&i.flags.namespace, "project", "p", "", "The project name where is the Keycloak instance to remove")
 }
 
 func (i *removeKeycloakCommand) Exec(cmd *cobra.Command, args []string) error {

--- a/cmd/kogito/command/remove/remove.go
+++ b/cmd/kogito/command/remove/remove.go
@@ -25,7 +25,7 @@ type removeCommand struct {
 	Parent  *cobra.Command
 }
 
-func newRemoveCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
+func initRemoveCommand(ctx *context.CommandContext, parent *cobra.Command) context.KogitoCommand {
 	cmd := removeCommand{
 		CommandContext: *ctx,
 		Parent:         parent,

--- a/cmd/kogito/command/remove/runtime_services.go
+++ b/cmd/kogito/command/remove/runtime_services.go
@@ -1,0 +1,123 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remove
+
+import (
+	"fmt"
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/shared"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	"github.com/spf13/cobra"
+)
+
+type removeRuntimeServiceFlags struct {
+	namespace string
+}
+
+type removableRuntimeService struct {
+	name    string
+	list    v1alpha1.KogitoServiceList
+	aliases []string
+}
+
+type removeRuntimeServiceCommand struct {
+	context.CommandContext
+	flags          removeRuntimeServiceFlags
+	command        *cobra.Command
+	runtimeService removableRuntimeService
+	Parent         *cobra.Command
+}
+
+var removableRuntimeServices = []removableRuntimeService{
+	{
+		name: "data-index",
+		list: &v1alpha1.KogitoDataIndexList{},
+	},
+	{
+		name:    "mgmt-console",
+		list:    &v1alpha1.KogitoMgmtConsoleList{},
+		aliases: []string{"management-console"},
+	},
+	{
+		name: "jobs-service",
+		list: &v1alpha1.KogitoJobsServiceList{},
+	},
+}
+
+func initRemoveRuntimeServiceCommands(ctx *context.CommandContext, parent *cobra.Command) []context.KogitoCommand {
+	var commands []context.KogitoCommand
+	for _, removable := range removableRuntimeServices {
+		cmd := &removeRuntimeServiceCommand{
+			CommandContext: *ctx,
+			runtimeService: removable,
+			Parent:         parent,
+		}
+		cmd.RegisterHook()
+		cmd.InitHook()
+		commands = append(commands, cmd)
+	}
+	return commands
+}
+
+func (r *removeRuntimeServiceCommand) RegisterHook() {
+	r.command = &cobra.Command{
+		Use:     r.runtimeService.name,
+		Aliases: r.runtimeService.aliases,
+		Short:   fmt.Sprintf("removes installed %s instance from the OpenShift/Kubernetes cluster", r.runtimeService.name),
+		Example: fmt.Sprintf("remove %s -p my-project", r.runtimeService.name),
+		Long:    fmt.Sprintf(`removes installed %s instance via custom Kubernetes resources.`, r.runtimeService.name),
+		RunE:    r.Exec,
+		PreRun:  r.CommonPreRun,
+		PostRun: r.CommonPostRun,
+		Args: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+}
+
+func (r *removeRuntimeServiceCommand) InitHook() {
+	r.flags = removeRuntimeServiceFlags{}
+	r.Parent.AddCommand(r.command)
+	r.command.Flags().StringVarP(&r.flags.namespace, "project", "p", "", fmt.Sprintf("The project name where the %s service is deployed", r.runtimeService.name))
+}
+
+func (r *removeRuntimeServiceCommand) Command() *cobra.Command {
+	return r.command
+}
+
+func (r *removeRuntimeServiceCommand) Exec(cmd *cobra.Command, args []string) error {
+	log := context.GetDefaultLogger()
+	var err error
+	if r.flags.namespace, err = shared.EnsureProject(r.Client, r.flags.namespace); err != nil {
+		return err
+	}
+	err = kubernetes.ResourceC(r.Client).ListWithNamespace(r.flags.namespace, r.runtimeService.list)
+	if err != nil {
+		return err
+	}
+	if r.runtimeService.list.GetItemsCount() == 0 {
+		log.Warnf("There's no service %s in the namespace %s", r.runtimeService.name, r.flags.namespace)
+		return nil
+	}
+	for i := 0; i < r.runtimeService.list.GetItemsCount(); i++ {
+		serviceName := r.runtimeService.list.GetItemAt(i).GetName()
+		if err = kubernetes.ResourceC(r.Client).Delete(r.runtimeService.list.GetItemAt(i)); err != nil {
+			return err
+		}
+		log.Infof("Service %s named %s from namespace %s has been successfully removed", r.runtimeService.name, serviceName, r.flags.namespace)
+	}
+	return nil
+}

--- a/cmd/kogito/command/remove/runtime_services_test.go
+++ b/cmd/kogito/command/remove/runtime_services_test.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remove
+
+import (
+	"fmt"
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/test"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func Test_removeRuntimeServiceCommand_NoServiceThere(t *testing.T) {
+	ns := t.Name()
+	cli := fmt.Sprintf("remove data-index -p %s", ns)
+	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+
+	lines, _, err := test.ExecuteCli()
+	assert.NoError(t, err)
+	assert.Contains(t, lines, "There's no service data-index")
+}
+
+func Test_removeRuntimeServiceCommand_NoServiceThereWithAlias(t *testing.T) {
+	ns := t.Name()
+	cli := fmt.Sprintf("remove management-console -p %s", ns)
+	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+
+	lines, _, err := test.ExecuteCli()
+	assert.NoError(t, err)
+	assert.Contains(t, lines, "There's no service mgmt-console")
+}
+
+func Test_removeRuntimeServiceCommand_SingletonService(t *testing.T) {
+	ns := t.Name()
+	cli := fmt.Sprintf("remove jobs-service -p %s", ns)
+	jobsService := &v1alpha1.KogitoJobsService{
+		ObjectMeta: metav1.ObjectMeta{Name: infrastructure.DefaultJobsServiceName, Namespace: ns},
+		Spec:       v1alpha1.KogitoJobsServiceSpec{},
+	}
+	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, jobsService)
+
+	lines, _, err := test.ExecuteCli()
+	assert.NoError(t, err)
+	assert.NotContains(t, lines, "There's no service jobs-service")
+	assert.Contains(t, lines, infrastructure.DefaultJobsServiceName)
+	assert.Contains(t, lines, "has been successfully removed")
+}
+
+func Test_removeRuntimeServiceCommand_MultipleServices(t *testing.T) {
+	ns := t.Name()
+	cli := fmt.Sprintf("remove jobs-service -p %s", ns)
+	jobs1 := &v1alpha1.KogitoJobsService{
+		ObjectMeta: metav1.ObjectMeta{Name: "jobs1", Namespace: ns},
+		Spec:       v1alpha1.KogitoJobsServiceSpec{},
+	}
+	jobs2 := &v1alpha1.KogitoJobsService{
+		ObjectMeta: metav1.ObjectMeta{Name: "jobs2", Namespace: ns},
+		Spec:       v1alpha1.KogitoJobsServiceSpec{},
+	}
+	test.SetupCliTest(cli, context.CommandFactory{BuildCommands: BuildCommands}, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, jobs1, jobs2)
+
+	lines, _, err := test.ExecuteCli()
+	assert.NoError(t, err)
+	assert.NotContains(t, lines, "There's no service jobs-service")
+	assert.Contains(t, lines, "jobs1")
+	assert.Contains(t, lines, "jobs2")
+	assert.Contains(t, lines, "has been successfully removed")
+}

--- a/cmd/kogito/command/test/common.go
+++ b/cmd/kogito/command/test/common.go
@@ -86,12 +86,8 @@ func ExecuteCli() (string, string, error) {
 
 // InitConfigWithTestConfigFile setup CLI Test and init config in context
 func InitConfigWithTestConfigFile() {
-	SetupCliTest("", context.CommandFactory{BuildCommands: buildCommands})
+	SetupCliTest("", context.CommandFactory{BuildCommands: func(ctx *context.CommandContext, rootCommand *cobra.Command) {}})
 	context.InitConfig()
-}
-
-func buildCommands(ctx *context.CommandContext, rootCommand *cobra.Command) []context.KogitoCommand {
-	return []context.KogitoCommand{}
 }
 
 // GetTestConfigFilePath returns the full config file path for tests


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See:
https://issues.redhat.com/browse/KOGITO-1258

In this PR we introduce a way to remove kogito services via command line.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster