### PR TITLE
[master][KOGITO-1688] - Renaming Kogito Support Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ If you are running on OpenShift 4.x, you can use the OperatorHub user interface 
 apiVersion: app.kiegroup.org/v1alpha1
 kind: KogitoDataIndex
 metadata:
-  name: kogito-data-index
+  name: data-index
 spec:
   # Number of pods to be deployed
   replicas: 1
@@ -395,10 +395,10 @@ $ oc create -f deploy/crds/app.kiegroup.org_v1alpha1_kogitodataindex_cr.yaml -n 
 You can access the GraphQL interface through the route that was created for you:
 
 ```bash
-$ oc get routes -l app=kogito-data-index
+$ oc get routes -l app=data-index
 
-NAME                HOST/PORT                                                  PATH   SERVICES            PORT   TERMINATION   WILDCARD
-kogito-data-index   kogito-data-index-kogito.apps.mycluster.example.com               kogito-data-index   8080   None
+NAME         HOST/PORT                                        PATH   SERVICES     PORT   TERMINATION   WILDCARD
+data-index   data-index-kogito.apps.mycluster.example.com            data-index   8080   None
 ```
 
 ### Kogito Data Index Integration with persistent Kogito Services
@@ -444,7 +444,7 @@ The name of the `configMap` consists of the name of the Data Index and the suffi
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: kogito-data-index-properties
+  name: data-index-properties
 data:
   application.properties : |-
     dummy1=dummy1

--- a/cmd/kogito/command/install/jobs_service.go
+++ b/cmd/kogito/command/install/jobs_service.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultJobsServiceInfinispanSecretName = "kogito-jobs-service-infinispan-credentials"
+	defaultJobsServiceInfinispanSecretName = "jobs-service-infinispan-credentials"
 )
 
 type installJobsServiceFlags struct {

--- a/deploy/crds/app.kiegroup.org_v1alpha1_kogitodataindex_cr.yaml
+++ b/deploy/crds/app.kiegroup.org_v1alpha1_kogitodataindex_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: app.kiegroup.org/v1alpha1
 kind: KogitoDataIndex
 metadata:
-  name: kogito-data-index
+  name: data-index
 spec:
   # environment variables to set in the runtime container. Example: JAVAOPTS: "-Dquarkus.log.level=DEBUG"
   # env: {}
@@ -16,7 +16,7 @@ spec:
   infinispan:
     # let's leave this burden to KogitoInfra CR to deploy a new Infinispan instance for us
     useKogitoInfra: false
-    # name of the auth realm. "default" is the realm name for 
+    # name of the auth realm. "default" is the realm name for
     #authRealm: ""
     # default to PLAIN
     #saslMechanism: ""

--- a/deploy/examples/data-index.yaml
+++ b/deploy/examples/data-index.yaml
@@ -1,7 +1,7 @@
 apiVersion: app.kiegroup.org/v1alpha1
 kind: KogitoDataIndex
 metadata:
-  name: kogito-data-index
+  name: data-index
 spec:
   # environment variables to set in the runtime container. Example: JAVA_OPTIONS: "-Dquarkus.log.level=DEBUG"
   #env:

--- a/deploy/olm-catalog/kogito-operator/0.10.0/kogito-operator.v0.10.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/0.10.0/kogito-operator.v0.10.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
           "apiVersion": "app.kiegroup.org/v1alpha1",
           "kind": "KogitoDataIndex",
           "metadata": {
-            "name": "kogito-data-index"
+            "name": "data-index"
           },
           "spec": {
             "infinispan": {

--- a/pkg/controller/kogitomgmtconsole/kogitomgmtconsole_controller_test.go
+++ b/pkg/controller/kogitomgmtconsole/kogitomgmtconsole_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ import (
 func TestReconcileKogitoMgmtConsole_Reconcile(t *testing.T) {
 	replicas := int32(1)
 	instance := &v1alpha1.KogitoMgmtConsole{
-		ObjectMeta: v1.ObjectMeta{Name: "mgmt-console", Namespace: t.Name()},
+		ObjectMeta: v1.ObjectMeta{Name: infrastructure.DefaultMgmtConsoleName, Namespace: t.Name()},
 		Spec: v1alpha1.KogitoMgmtConsoleSpec{
 			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{Replicas: &replicas},
 		},

--- a/pkg/infrastructure/data_index.go
+++ b/pkg/infrastructure/data_index.go
@@ -25,12 +25,12 @@ import (
 )
 
 const (
-	// DefaultDataIndexImageFullTag is the default image name for the Kogito Data Index Service
-	DefaultDataIndexImageFullTag = "quay.io/kiegroup/kogito-data-index:latest"
 	// DefaultDataIndexImageName is just the image name for the Data Index Service
 	DefaultDataIndexImageName = "kogito-data-index"
+	// DefaultDataIndexImageFullTag is the default image name for the Kogito Data Index Service
+	DefaultDataIndexImageFullTag = "quay.io/kiegroup/" + DefaultDataIndexImageName + ":latest"
 	// DefaultDataIndexName is the default name for the Data Index instance service
-	DefaultDataIndexName = "kogito-data-index"
+	DefaultDataIndexName = "data-index"
 
 	dataIndexHTTPRouteEnv = "KOGITO_DATAINDEX_HTTP_URL"
 	dataIndexWSRouteEnv   = "KOGITO_DATAINDEX_WS_URL"

--- a/pkg/infrastructure/data_index_test.go
+++ b/pkg/infrastructure/data_index_test.go
@@ -52,7 +52,7 @@ func TestInjectDataIndexURLIntoKogitoApps(t *testing.T) {
 		Items: []v1alpha1.KogitoDataIndex{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kogito-data-index",
+					Name:      DefaultDataIndexName,
 					Namespace: ns,
 				},
 				Status: v1alpha1.KogitoDataIndexStatus{
@@ -80,11 +80,11 @@ func Test_getKogitoDataIndexURLs(t *testing.T) {
 	expectedHTTPSURL := "https://" + hostname
 	expectedWSSURL := "wss://" + hostname
 	insecureDI := &v1alpha1.KogitoDataIndex{
-		ObjectMeta: metav1.ObjectMeta{Name: "kogito-data-index", Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{Name: DefaultDataIndexName, Namespace: ns},
 		Status:     v1alpha1.KogitoDataIndexStatus{KogitoServiceStatus: v1alpha1.KogitoServiceStatus{ExternalURI: expectedHTTPURL}},
 	}
 	secureDI := &v1alpha1.KogitoDataIndex{
-		ObjectMeta: metav1.ObjectMeta{Name: "kogito-data-index", Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{Name: DefaultDataIndexName, Namespace: ns},
 		Status:     v1alpha1.KogitoDataIndexStatus{KogitoServiceStatus: v1alpha1.KogitoServiceStatus{ExternalURI: expectedHTTPSURL}},
 	}
 	cliInsecure := test.CreateFakeClient([]runtime.Object{insecureDI}, nil, nil)

--- a/pkg/infrastructure/integration_test.go
+++ b/pkg/infrastructure/integration_test.go
@@ -38,7 +38,7 @@ func Test_InjectEnvironmentVarsFromExternalServices(t *testing.T) {
 		Spec:       appsv1.DeploymentConfigSpec{Template: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: name}}}}},
 	}
 	dataIndexes := &v1alpha1.KogitoDataIndexList{Items: []v1alpha1.KogitoDataIndex{{
-		ObjectMeta: v1.ObjectMeta{Name: "kogito-data-index", Namespace: ns},
+		ObjectMeta: v1.ObjectMeta{Name: DefaultDataIndexName, Namespace: ns},
 		Status:     v1alpha1.KogitoDataIndexStatus{KogitoServiceStatus: v1alpha1.KogitoServiceStatus{ExternalURI: expectedRoute}}},
 	}}
 
@@ -75,7 +75,7 @@ func Test_InjectEnvironmentVarsFromExternalServices_NewRoute(t *testing.T) {
 		Items: []v1alpha1.KogitoDataIndex{
 			{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "kogito-data-index",
+					Name:      DefaultDataIndexName,
 					Namespace: ns,
 				},
 				Status: v1alpha1.KogitoDataIndexStatus{

--- a/pkg/infrastructure/jobs_service.go
+++ b/pkg/infrastructure/jobs_service.go
@@ -27,7 +27,7 @@ const (
 	// DefaultJobsServiceImageFullTag is the default full tag name for the Jobs Service image
 	DefaultJobsServiceImageFullTag = "quay.io/kiegroup/" + DefaultJobsServiceImageName + ":latest"
 	// DefaultJobsServiceName is the default name for the Jobs Services instance service
-	DefaultJobsServiceName = DefaultJobsServiceImageName
+	DefaultJobsServiceName = "jobs-service"
 
 	// kogito.jobs-service.url
 	jobsServicesHTTPURIEnv = "KOGITO_JOBS_SERVICE_URL"

--- a/pkg/infrastructure/kogito_service_test.go
+++ b/pkg/infrastructure/kogito_service_test.go
@@ -30,7 +30,7 @@ func Test_getKogitoDataIndexRoute(t *testing.T) {
 		Items: []v1alpha1.KogitoDataIndex{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kogito-data-index",
+					Name:      DefaultDataIndexName,
 					Namespace: ns,
 				},
 				Status: v1alpha1.KogitoDataIndexStatus{
@@ -39,7 +39,7 @@ func Test_getKogitoDataIndexRoute(t *testing.T) {
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kogito-data-index2",
+					Name:      DefaultDataIndexName + "2",
 					Namespace: ns,
 				},
 				Status: v1alpha1.KogitoDataIndexStatus{

--- a/pkg/infrastructure/services/deployer_test.go
+++ b/pkg/infrastructure/services/deployer_test.go
@@ -47,7 +47,7 @@ func Test_serviceDeployer_Deploy(t *testing.T) {
 	serviceList := &v1alpha1.KogitoJobsServiceList{}
 	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{service}, nil, nil)
 	definition := ServiceDefinition{
-		DefaultImageName: "kogito-jobs-service",
+		DefaultImageName: infrastructure.DefaultJobsServiceImageName,
 		Request:          GetRequest(t.Name()),
 	}
 	deployer := NewSingletonServiceDeployer(definition, serviceList, cli, meta.GetRegisteredSchema())

--- a/pkg/infrastructure/services/resources_test.go
+++ b/pkg/infrastructure/services/resources_test.go
@@ -109,28 +109,27 @@ func Test_serviceDeployer_createRequiredResources_OnOCPNoImageStreamCreated(t *t
 }
 
 func Test_serviceDeployer_createRequiredResources_RequiresDataIndex(t *testing.T) {
-	name := "kogito-management-console"
 	replicas := int32(1)
 	instance := &v1alpha1.KogitoMgmtConsole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      infrastructure.DefaultMgmtConsoleName,
 			Namespace: t.Name(),
 		},
 		Spec: v1alpha1.KogitoMgmtConsoleSpec{
 			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{Replicas: &replicas},
 		},
 	}
-	is, tag := test.GetImageStreams("kogito-management-console", instance.Namespace, instance.Name)
+	is, tag := test.GetImageStreams(infrastructure.DefaultMgmtConsoleImageName, instance.Namespace, instance.Name)
 	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{instance, is}, []runtime.Object{tag}, nil)
 	deployer := serviceDeployer{
 		client:       cli,
 		scheme:       meta.GetRegisteredSchema(),
 		instanceList: &v1alpha1.KogitoJobsServiceList{},
 		definition: ServiceDefinition{
-			DefaultImageName:  name,
+			DefaultImageName:  infrastructure.DefaultMgmtConsoleImageName,
 			RequiresDataIndex: true,
 			Request: reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: name, Namespace: t.Name()},
+				NamespacedName: types.NamespacedName{Name: infrastructure.DefaultMgmtConsoleName, Namespace: t.Name()},
 			},
 		},
 	}
@@ -144,27 +143,26 @@ func Test_serviceDeployer_createRequiredResources_RequiresDataIndex(t *testing.T
 }
 
 func Test_serviceDeployer_createRequiredResources_CreateNewAppPropConfigMap(t *testing.T) {
-	name := "kogito-data-index"
 	replicas := int32(1)
 	instance := &v1alpha1.KogitoDataIndex{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      infrastructure.DefaultDataIndexName,
 			Namespace: t.Name(),
 		},
 		Spec: v1alpha1.KogitoDataIndexSpec{
 			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{Replicas: &replicas},
 		},
 	}
-	is, tag := test.GetImageStreams("kogito-data-index", instance.Namespace, instance.Name)
+	is, tag := test.GetImageStreams(infrastructure.DefaultDataIndexImageName, instance.Namespace, instance.Name)
 	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{instance, is}, []runtime.Object{tag}, nil)
 	deployer := serviceDeployer{
 		client:       cli,
 		scheme:       meta.GetRegisteredSchema(),
 		instanceList: &v1alpha1.KogitoDataIndexList{},
 		definition: ServiceDefinition{
-			DefaultImageName: name,
+			DefaultImageName: infrastructure.DefaultDataIndexImageName,
 			Request: reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: name, Namespace: t.Name()},
+				NamespacedName: types.NamespacedName{Name: infrastructure.DefaultDataIndexName, Namespace: t.Name()},
 			},
 		},
 	}
@@ -173,7 +171,7 @@ func Test_serviceDeployer_createRequiredResources_CreateNewAppPropConfigMap(t *t
 	assert.NotEmpty(t, resources)
 
 	assert.Equal(t, 1, len(resources[reflect.TypeOf(corev1.ConfigMap{})]))
-	assert.Equal(t, name+appPropConfigMapSuffix, resources[reflect.TypeOf(corev1.ConfigMap{})][0].GetName())
+	assert.Equal(t, infrastructure.DefaultDataIndexName+appPropConfigMapSuffix, resources[reflect.TypeOf(corev1.ConfigMap{})][0].GetName())
 
 	assert.Equal(t, 1, len(resources[reflect.TypeOf(appsv1.Deployment{})]))
 	deployment, ok := resources[reflect.TypeOf(appsv1.Deployment{})][0].(*appsv1.Deployment)
@@ -183,21 +181,20 @@ func Test_serviceDeployer_createRequiredResources_CreateNewAppPropConfigMap(t *t
 }
 
 func Test_serviceDeployer_createRequiredResources_CreateNoAppPropConfigMap(t *testing.T) {
-	name := "kogito-data-index"
 	replicas := int32(1)
 	instance := &v1alpha1.KogitoDataIndex{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      infrastructure.DefaultDataIndexName,
 			Namespace: t.Name(),
 		},
 		Spec: v1alpha1.KogitoDataIndexSpec{
 			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{Replicas: &replicas},
 		},
 	}
-	is, tag := test.GetImageStreams("kogito-data-index", instance.Namespace, instance.Name)
+	is, tag := test.GetImageStreams(infrastructure.DefaultDataIndexImageName, instance.Namespace, instance.Name)
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + appPropConfigMapSuffix,
+			Name:      infrastructure.DefaultDataIndexName + appPropConfigMapSuffix,
 			Namespace: instance.Namespace,
 		},
 		Data: map[string]string{
@@ -210,9 +207,9 @@ func Test_serviceDeployer_createRequiredResources_CreateNoAppPropConfigMap(t *te
 		scheme:       meta.GetRegisteredSchema(),
 		instanceList: &v1alpha1.KogitoDataIndexList{},
 		definition: ServiceDefinition{
-			DefaultImageName: name,
+			DefaultImageName: infrastructure.DefaultDataIndexImageName,
 			Request: reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: name, Namespace: t.Name()},
+				NamespacedName: types.NamespacedName{Name: infrastructure.DefaultDataIndexName, Namespace: t.Name()},
 			},
 		},
 	}

--- a/test/features/install_dataindex.feature
+++ b/test/features/install_dataindex.feature
@@ -9,7 +9,7 @@ Feature: Kogito Data Index
   Scenario: Install Kogito Data Index
     When Install Kogito Data Index with 1 replicas
     Then Kogito Data Index has 1 pods running within 10 minutes
-    And GraphQL request on service "kogito-data-index" is successful within 2 minutes with path "graphql" and query:
+    And GraphQL request on service "data-index" is successful within 2 minutes with path "graphql" and query:
     """
     {
       ProcessInstances{

--- a/test/features/install_jobs_service.feature
+++ b/test/features/install_jobs_service.feature
@@ -10,7 +10,7 @@ Feature: Install Kogito Jobs Service
 
     When Install Kogito Jobs Service with 1 replicas
     And Kogito Jobs Service has 1 pods running within 10 minutes
-    And HTTP POST request on service "kogito-jobs-service" is successful within 2 minutes with path "jobs" and body:
+    And HTTP POST request on service "jobs-service" is successful within 2 minutes with path "jobs" and body:
       """json
       {
         "id": "1",
@@ -20,7 +20,7 @@ Feature: Install Kogito Jobs Service
       }
       """
 
-    Then HTTP GET request on service "kogito-jobs-service" with path "jobs/1" is successful within 1 minutes
+    Then HTTP GET request on service "jobs-service" with path "jobs/1" is successful within 1 minutes
 
 #####
 
@@ -30,7 +30,7 @@ Feature: Install Kogito Jobs Service
     
     When Install Kogito Jobs Service with 1 replicas and persistence
     And Kogito Jobs Service has 1 pods running within 10 minutes
-    And HTTP POST request on service "kogito-jobs-service" is successful within 2 minutes with path "jobs" and body:
+    And HTTP POST request on service "jobs-service" is successful within 2 minutes with path "jobs" and body:
       """json
       {
         "id": "1",
@@ -39,8 +39,8 @@ Feature: Install Kogito Jobs Service
         "callbackEndpoint": "http://localhost:8080/callback"
       }
       """
-    And HTTP GET request on service "kogito-jobs-service" with path "jobs/1" is successful within 1 minutes
+    And HTTP GET request on service "jobs-service" with path "jobs/1" is successful within 1 minutes
     And Scale Kogito Jobs Service to 0 pods within 2 minutes
     And Scale Kogito Jobs Service to 1 pods within 2 minutes
 
-    Then HTTP GET request on service "kogito-jobs-service" with path "jobs/1" is successful within 1 minutes
+    Then HTTP GET request on service "jobs-service" with path "jobs/1" is successful within 1 minutes

--- a/test/features/olm/cli_install_operator.feature
+++ b/test/features/olm/cli_install_operator.feature
@@ -18,7 +18,7 @@ Feature: CLI: Install Kogito Operator
     When CLI install Kogito operator with Kogito Data Index
 
     Then Kogito Data Index has 1 pods running within 5 minutes
-    And GraphQL request on service "kogito-data-index" is successful within 2 minutes with path "graphql" and query:
+    And GraphQL request on service "data-index" is successful within 2 minutes with path "graphql" and query:
       """
       {
         ProcessInstances{
@@ -35,7 +35,7 @@ Feature: CLI: Install Kogito Operator
     When CLI install Kogito operator with Kogito Jobs Service
 
     Then Kogito Jobs Service has 1 pods running within 5 minutes
-    And HTTP POST request on service "kogito-jobs-service" is successful within 2 minutes with path "jobs" and body:
+    And HTTP POST request on service "jobs-service" is successful within 2 minutes with path "jobs" and body:
       """
       { 
         "id": "1",
@@ -45,4 +45,4 @@ Feature: CLI: Install Kogito Operator
       }
       """
 
-    Then HTTP GET request on service "kogito-jobs-service" with path "jobs/1" is successful within 1 minutes
+    Then HTTP GET request on service "jobs-service" with path "jobs/1" is successful within 1 minutes

--- a/test/features/olm/cli_new_project.feature
+++ b/test/features/olm/cli_new_project.feature
@@ -15,7 +15,7 @@ Feature: CLI: Project
     When CLI create namespace with Kogito Data Index
 
     Then Kogito Data Index has 1 pods running within 5 minutes
-    And GraphQL request on service "kogito-data-index" is successful within 2 minutes with path "graphql" and query:
+    And GraphQL request on service "data-index" is successful within 2 minutes with path "graphql" and query:
       """
       {
         ProcessInstances{
@@ -32,7 +32,7 @@ Feature: CLI: Project
     When CLI create namespace with Kogito Jobs Service
 
     Then Kogito Jobs Service has 1 pods running within 5 minutes
-    And HTTP POST request on service "kogito-jobs-service" is successful within 2 minutes with path "jobs" and body:
+    And HTTP POST request on service "jobs-service" is successful within 2 minutes with path "jobs" and body:
       """
       { 
         "id": "1",
@@ -42,4 +42,4 @@ Feature: CLI: Project
       }
       """
 
-    Then HTTP GET request on service "kogito-jobs-service" with path "jobs/1" is successful within 1 minutes
+    Then HTTP GET request on service "jobs-service" with path "jobs/1" is successful within 1 minutes

--- a/test/features/olm/cli_use_project.feature
+++ b/test/features/olm/cli_use_project.feature
@@ -18,7 +18,7 @@ Feature: CLI: Project
     When CLI use namespace with Kogito Data Index
 
     Then Kogito Data Index has 1 pods running within 5 minutes
-    And GraphQL request on service "kogito-data-index" is successful within 2 minutes with path "graphql" and query:
+    And GraphQL request on service "data-index" is successful within 2 minutes with path "graphql" and query:
       """
       {
         ProcessInstances{
@@ -35,7 +35,7 @@ Feature: CLI: Project
     When CLI use namespace with Kogito Jobs Service
 
     Then Kogito Jobs Service has 1 pods running within 5 minutes
-    And HTTP POST request on service "kogito-jobs-service" is successful within 2 minutes with path "jobs" and body:
+    And HTTP POST request on service "jobs-service" is successful within 2 minutes with path "jobs" and body:
       """
       { 
         "id": "1",
@@ -45,4 +45,4 @@ Feature: CLI: Project
       }
       """
 
-    Then HTTP GET request on service "kogito-jobs-service" with path "jobs/1" is successful within 1 minutes
+    Then HTTP GET request on service "jobs-service" with path "jobs/1" is successful within 1 minutes


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See:
https://issues.redhat.com/browse/KOGITO-1688

In this PR we reviewed the entire naming for Data Index, Management Console and Jobs Service used internally and for the default examples/CR.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster