### PR TITLE
KOGITO-1699 - Unify configuration for KogitoApp deployments in BDD tests

### DIFF
--- a/pkg/apis/app/v1alpha1/kogitoapp_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoapp_types.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -140,6 +141,24 @@ func (k *KogitoAppBuildObject) AddEnvironmentVariable(name, value string) {
 	}
 	k.Envs = append(k.Envs, env)
 	return
+}
+
+// AddResourceRequest adds new resource request. Works also on an uninitialized Requests field.
+func (k *KogitoAppBuildObject) AddResourceRequest(name, value string) {
+	if k.Resources.Requests == nil {
+		k.Resources.Requests = corev1.ResourceList{}
+	}
+
+	k.Resources.Requests[corev1.ResourceName(name)] = resource.MustParse(value)
+}
+
+// AddResourceLimit adds new resource limit. Works also on an uninitialized Limits field.
+func (k *KogitoAppBuildObject) AddResourceLimit(name, value string) {
+	if k.Resources.Limits == nil {
+		k.Resources.Limits = corev1.ResourceList{}
+	}
+
+	k.Resources.Limits[corev1.ResourceName(name)] = resource.MustParse(value)
 }
 
 // KogitoAppServiceObject Data to define the service of the Kogito application

--- a/pkg/apis/app/v1alpha1/kogitoservices_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoservices_types.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -166,4 +167,22 @@ func (k *KogitoServiceSpec) AddEnvironmentVariable(name, value string) {
 	}
 	k.Envs = append(k.Envs, env)
 	return
+}
+
+// AddResourceRequest adds new resource request. Works also on uninitialized Requests field.
+func (k *KogitoServiceSpec) AddResourceRequest(name, value string) {
+	if k.Resources.Requests == nil {
+		k.Resources.Requests = corev1.ResourceList{}
+	}
+
+	k.Resources.Requests[corev1.ResourceName(name)] = resource.MustParse(value)
+}
+
+// AddResourceLimit adds new resource limit. Works also on uninitialized Limits field.
+func (k *KogitoServiceSpec) AddResourceLimit(name, value string) {
+	if k.Resources.Limits == nil {
+		k.Resources.Limits = corev1.ResourceList{}
+	}
+
+	k.Resources.Limits[corev1.ResourceName(name)] = resource.MustParse(value)
 }

--- a/test/features/deploy_quarkus_service.feature
+++ b/test/features/deploy_quarkus_service.feature
@@ -6,9 +6,8 @@ Feature: Deploy quarkus service
 
   Scenario Outline: Deploy drools-quarkus-example service without persistence
     Given Kogito Operator is deployed
-    
-    When Deploy quarkus example service "ruleunit-quarkus-example" with native <native>
-
+    When Deploy quarkus example service "ruleunit-quarkus-example" with configuration:
+      | config | native | <native> |
     Then Kogito application "ruleunit-quarkus-example" has 1 pods running within <minutes> minutes
     And HTTP POST request on service "ruleunit-quarkus-example" is successful within 2 minutes with path "find-approved" and body:
        """json
@@ -57,7 +56,9 @@ Feature: Deploy quarkus service
   @persistence
   Scenario Outline: Deploy process-quarkus-example service with persistence
     Given Kogito Operator is deployed with Infinispan operator
-    And Deploy quarkus example service "process-quarkus-example" with native <native> and persistence
+    And Deploy quarkus example service "process-quarkus-example" with configuration:
+      | config | native      | <native> |
+      | config | persistence | enabled  |
     And Kogito application "process-quarkus-example" has 1 pods running within <minutes> minutes
     And HTTP GET request on service "process-quarkus-example" with path "orders" is successful within 3 minutes
     And HTTP POST request on service "process-quarkus-example" with path "orders" and body:
@@ -94,7 +95,8 @@ Feature: Deploy quarkus service
   Scenario Outline: Deploy process-timer-quarkus service with Jobs service
     Given Kogito Operator is deployed
     And Install Kogito Jobs Service with 1 replicas
-    And Deploy quarkus example service "process-timer-quarkus" with native <native>
+    And Deploy quarkus example service "process-timer-quarkus" with configuration:
+      | config | native | <native> |
     And Kogito application "process-timer-quarkus" has 1 pods running within <minutes> minutes
 
     When HTTP POST request on service "process-timer-quarkus" is successful within 2 minutes with path "timer" and body:

--- a/test/features/deploy_service_resources.feature
+++ b/test/features/deploy_service_resources.feature
@@ -11,32 +11,40 @@ Feature: Deploy the service by configuring the resource requests and limits
     Given Clone Kogito examples into local directory
     And Local example service "ruleunit-quarkus-example" is built by Maven
 
-    When Create service "ruleunit-quarkus-example" with runtime resources:
-      | requests  | <requests> |
-      | limits    | <limits>   |
+    When Create service "ruleunit-quarkus-example" with configuration:
+      | runtime-request | cpu    | <runtime-cpu-request>    |
+      | runtime-request | memory | <runtime-memory-request> |
+      | runtime-limit   | cpu    | <runtime-cpu-limit>      |
+      | runtime-limit   | memory | <runtime-memory-limit>   |
     And BuildConfig "ruleunit-quarkus-example-binary" is created after 1 minutes
     And Start build with name "ruleunit-quarkus-example-binary" from local example service path "ruleunit-quarkus-example/target"
 
     Then Kogito application "ruleunit-quarkus-example" has 1 pods running within 10 minutes
     And Kogito application "ruleunit-quarkus-example" has pods with runtime resources within 2 minutes:
-      | requests  | <requests> |
-      | limits    | <limits>   |
+      | runtime-request | cpu    | <runtime-cpu-request>    |
+      | runtime-request | memory | <runtime-memory-request> |
+      | runtime-limit   | cpu    | <runtime-cpu-limit>      |
+      | runtime-limit   | memory | <runtime-memory-limit>   |
 
     Examples: Requests and Limits
-      | requests             | limits                |
-      | cpu=500m,memory=1Gi  | cpu=1000m,memory=2Gi  |
+      | runtime-cpu-request | runtime-memory-request | runtime-cpu-limit | runtime-memory-limit |
+      | 500m                | 1Gi                    | 1000m             | 2Gi                  |
 
 
   @buildresources 
   @buildlimits 
   Scenario Outline: Setting build resource "requests" and "limits"
-    When Deploy quarkus example service "ruleunit-quarkus-example" with build resources:
-      | requests  | <requests> |
-      | limits    | <limits>   |
+    When Deploy quarkus example service "ruleunit-quarkus-example" with configuration:
+      | build-request | cpu    | <build-cpu-request>    |
+      | build-request | memory | <build-memory-request> |
+      | build-limit   | cpu    | <build-cpu-limit>      |
+      | build-limit   | memory | <build-memory-limit>   |
     Then BuildConfig "ruleunit-quarkus-example-builder" is created with build resources within 2 minutes:
-      | requests  | <requests> |
-      | limits    | <limits>   |
+      | build-request | cpu    | <build-cpu-request>    |
+      | build-request | memory | <build-memory-request> |
+      | build-limit   | cpu    | <build-cpu-limit>      |
+      | build-limit   | memory | <build-memory-limit>   |
 
     Examples: Requests and Limits
-      | requests             | limits                |
-      | cpu=500m,memory=1Gi  | cpu=1000m,memory=2Gi  |
+      | build-cpu-request | build-memory-request | build-cpu-limit | build-memory-limit |
+      | 500m              | 1Gi                  | 1000m           | 2Gi                |

--- a/test/features/deploy_springboot_service.feature
+++ b/test/features/deploy_springboot_service.feature
@@ -7,9 +7,9 @@ Feature: Deploy spring boot service
   @smoke
   Scenario: Deploy process-springboot-example service without persistence
     Given Kogito Operator is deployed
-    
-    When Deploy spring boot example service "process-springboot-example"
 
+    When Deploy spring boot example service "process-springboot-example" with configuration:
+      | config | persistence | disabled |
     Then Kogito application "process-springboot-example" has 1 pods running within 10 minutes
     And HTTP GET request on service "process-springboot-example" with path "orders" is successful within 2 minutes
 
@@ -18,7 +18,8 @@ Feature: Deploy spring boot service
   @persistence
   Scenario: Deploy process-springboot-example service with persistence
     Given Kogito Operator is deployed with Infinispan operator
-    And Deploy spring boot example service "process-springboot-example" with persistence
+    And Deploy spring boot example service "process-springboot-example" with configuration:
+      | config | persistence | enabled |
     And Kogito application "process-springboot-example" has 1 pods running within 10 minutes
     And HTTP GET request on service "process-springboot-example" with path "orders" is successful within 3 minutes
     And HTTP POST request on service "process-springboot-example" with path "orders" and body:
@@ -46,7 +47,8 @@ Feature: Deploy spring boot service
   Scenario: Deploy process-timer-springboot service with Jobs service
     Given Kogito Operator is deployed
     And Install Kogito Jobs Service with 1 replicas
-    And Deploy spring boot example service "process-timer-springboot"
+    And Deploy spring boot example service "process-timer-springboot" with configuration:
+      | config | persistence | disabled |
     And Kogito application "process-timer-springboot" has 1 pods running within 10 minutes
 
     When HTTP POST request on service "process-timer-springboot" is successful within 2 minutes with path "timer" and body:

--- a/test/features/install_dataindex.feature
+++ b/test/features/install_dataindex.feature
@@ -24,7 +24,10 @@ Feature: Kogito Data Index
   @persistence
   Scenario Outline: Process instance events are stored in Data Index
     Given Install Kogito Data Index with 1 replicas
-    And Deploy quarkus example service "process-quarkus-example" with native <native> and persistence and events
+    And Deploy quarkus example service "process-quarkus-example" with configuration:
+      | config | native      | <native> |
+      | config | persistence | enabled  |
+      | config | events      | enabled  |
     And Kogito application "process-quarkus-example" has 1 pods running within <minutes> minutes
     And HTTP GET request on service "process-quarkus-example" with path "orders" is successful within 3 minutes
 

--- a/test/features/kogito_service_performance.feature
+++ b/test/features/kogito_service_performance.feature
@@ -12,7 +12,9 @@ Feature: Kogito Service Performance
   @quarkus
   Scenario Outline: Quarkus Kogito Service Performance without persistence
     Given Kogito Operator is deployed
-    And Deploy quarkus example service "process-quarkus-example" with native <native>
+    And Deploy quarkus example service "process-quarkus-example" with configuration:
+      | config      | native       | <native> |
+      | runtime-env | JAVA_OPTIONS | -Xmx8G   |
     And Kogito application "process-quarkus-example" has 1 pods running within <minutes> minutes
     And HTTP GET request on service "process-quarkus-example" with path "orders" is successful within 3 minutes
 
@@ -53,7 +55,10 @@ Feature: Kogito Service Performance
   @persistence
   Scenario Outline: Quarkus Kogito Service Performance with persistence
     Given Kogito Operator is deployed with Infinispan operator
-    And Deploy quarkus example service "process-quarkus-example" with native <native> and persistence
+    And Deploy quarkus example service "process-quarkus-example" with configuration:
+      | config      | native       | <native> |
+      | config      | persistence  | enabled  |
+      | runtime-env | JAVA_OPTIONS | -Xmx8G   |
     And Kogito application "process-quarkus-example" has 1 pods running within <minutes> minutes
     And HTTP GET request on service "process-quarkus-example" with path "orders" is successful within 3 minutes
 
@@ -93,7 +98,8 @@ Feature: Kogito Service Performance
   @springboot
   Scenario Outline: Spring Boot Kogito Service Performance without persistence
     Given Kogito Operator is deployed
-    And Deploy spring boot example service "process-springboot-example"
+    And Deploy spring boot example service "process-springboot-example" with configuration:
+      | runtime-env | JAVA_OPTIONS | -Xmx8G |
     And Kogito application "process-springboot-example" has 1 pods running within <minutes> minutes
     And HTTP GET request on service "process-springboot-example" with path "orders" is successful within 3 minutes
 
@@ -125,7 +131,9 @@ Feature: Kogito Service Performance
   @persistence
   Scenario Outline: Spring Boot Kogito Service Performance with persistence
     Given Kogito Operator is deployed with Infinispan operator
-    And Deploy spring boot example service "process-springboot-example" with persistence
+    And Deploy spring boot example service "process-springboot-example" with configuration:
+      | config      | persistence  | enabled |
+      | runtime-env | JAVA_OPTIONS | -Xmx8G  |
     And Kogito application "process-springboot-example" has 1 pods running within <minutes> minutes
     And HTTP GET request on service "process-springboot-example" with path "orders" is successful within 3 minutes
 

--- a/test/features/prometheus.feature
+++ b/test/features/prometheus.feature
@@ -9,7 +9,8 @@ Feature: Service Deployment: Prometheus
 
   Scenario: Deploy hr service and verify that it successfully connects to Prometheus
     Given Prometheus instance is deployed, monitoring services with label name "app" and value "hr"
-    And Deploy quarkus example service "onboarding-example/hr" with native disabled
+    And Deploy quarkus example service "onboarding-example/hr" with configuration:
+      | config | native | disabled |
     And Kogito application "hr" has 1 pods running within 10 minutes
 
     When HTTP POST request on service "hr" is successful within 2 minutes with path "id" and body:

--- a/test/features/service_discovery.feature
+++ b/test/features/service_discovery.feature
@@ -7,18 +7,21 @@ Feature: Discovery with onboarding
   Scenario Outline: Deploy onboarding example
     Given Kogito Operator is deployed
     
-    When Deploy quarkus example service "onboarding-example/hr" with native <native> and labels 
-      | department/first          | process |
-      | id                        | process |
-      | employee-validation/first | process |
+    When Deploy quarkus example service "onboarding-example/hr" with configuration:
+      | config | native                    | <native> |
+      | label  | department/first          | process  |
+      | label  | id                        | process  |
+      | label  | employee-validation/first | process  |
 
-    And Deploy quarkus example service "onboarding-example/payroll" with native <native> and labels
-      | taxes/rate         | process |
-      | vacations/days     | process |
-      | payments/date      | process |
+    And Deploy quarkus example service "onboarding-example/payroll" with configuration:
+      | config | native         | <native> |
+      | label  | taxes/rate     | process  |
+      | label  | vacations/days | process  |
+      | label  | payments/date  | process  |
 
-    And Deploy quarkus example service "onboarding-example/onboarding" with native <native> and labels
-      | onboarding         | process |
+    And Deploy quarkus example service "onboarding-example/onboarding" with configuration:
+      | config | native     | <native> |
+      | label  | onboarding | process  |
 
     And Kogito application "hr" has 1 pods running within <minutes> minutes
     And Kogito application "payroll" has 1 pods running within <minutes> minutes

--- a/test/framework/kogitoapp.go
+++ b/test/framework/kogitoapp.go
@@ -184,6 +184,9 @@ func GetKogitoAppStub(namespace, appName string) *v1alpha1.KogitoApp {
 				GitSource:      v1alpha1.GitSource{},
 				MavenMirrorURL: config.GetMavenMirrorURL(),
 			},
+			Service: v1alpha1.KogitoAppServiceObject{
+				Labels: map[string]string{},
+			},
 		},
 	}
 

--- a/test/steps/openshift.go
+++ b/test/steps/openshift.go
@@ -46,11 +46,11 @@ func (data *Data) buildConfigIsCreatedAfterMinutes(buildConfigName string, timeo
 }
 
 func (data *Data) buildConfigHasResourcesWithinMinutes(buildConfigName string, timeoutInMin int, dt *gherkin.DataTable) error {
-	resources, err := assist.ParseMap(dt)
+	requirements, _, err := parseResourceRequirementsTable(dt)
+
 	if err != nil {
 		return err
 	}
 
-	requirements := framework.ToResourceRequirements(resources["requests"], resources["limits"])
-	return framework.WaitForBuildConfigToHaveResources(data.Namespace, buildConfigName, requirements, timeoutInMin)
+	return framework.WaitForBuildConfigToHaveResources(data.Namespace, buildConfigName, *requirements, timeoutInMin)
 }

--- a/test/steps/utils.go
+++ b/test/steps/utils.go
@@ -1,0 +1,165 @@
+package steps
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog/gherkin"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"github.com/kiegroup/kogito-cloud-operator/test/framework"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	//DataTable first column
+	Config         = "config"
+	BuildEnv       = "build-env"
+	RuntimeEnv     = "runtime-env"
+	Label          = "label"
+	BuildRequest   = "build-request"
+	BuildLimit     = "build-limit"
+	RuntimeRequest = "runtime-request"
+	RuntimeLimit   = "runtime-limit"
+
+	//DataTable second column
+	Native      = "native"
+	Persistence = "persistence"
+	Events      = "events"
+)
+
+func configureKogitoAppFromTable(table *gherkin.DataTable, kogitoApp *v1alpha1.KogitoApp) error {
+	if len(table.Rows) == 0 { // Using default configuration
+		return nil
+	}
+
+	if len(table.Rows[0].Cells) != 3 {
+		return fmt.Errorf("expected table to have exactly three columns")
+	}
+
+	var profiles []string
+
+	for _, row := range table.Rows {
+		firstColumn := getFirstColumn(row)
+		switch firstColumn {
+		case Config:
+			parseConfigRow(row, kogitoApp, &profiles)
+
+		case BuildEnv:
+			kogitoApp.Spec.Build.AddEnvironmentVariable(getSecondColumn(row), getThirdColumn(row))
+
+		case RuntimeEnv:
+			kogitoApp.Spec.AddEnvironmentVariable(getSecondColumn(row), getThirdColumn(row))
+
+		case Label:
+			kogitoApp.Spec.Service.Labels[getSecondColumn(row)] = getThirdColumn(row)
+
+		case BuildRequest:
+			kogitoApp.Spec.Build.AddResourceRequest(getSecondColumn(row), getThirdColumn(row))
+
+		case BuildLimit:
+			kogitoApp.Spec.Build.AddResourceLimit(getSecondColumn(row), getThirdColumn(row))
+
+		case RuntimeRequest:
+			kogitoApp.Spec.AddResourceRequest(getSecondColumn(row), getThirdColumn(row))
+
+		case RuntimeLimit:
+			kogitoApp.Spec.AddResourceLimit(getSecondColumn(row), getThirdColumn(row))
+
+		default:
+			return fmt.Errorf("Unrecognized configuration option: %s", firstColumn)
+		}
+	}
+
+	if len(profiles) > 0 {
+		kogitoApp.Spec.Build.AddEnvironmentVariable(MavenArgsAppendEnvVar, "-P" + strings.Join(profiles, ","))
+	}
+
+	addDefaultJavaOptionsIfNotProvided(kogitoApp)
+
+	return nil
+}
+
+func parseConfigRow(row *gherkin.TableRow, kogitoApp *v1alpha1.KogitoApp, profilesPtr *[]string) {
+	secondColumn := getSecondColumn(row)
+
+	switch secondColumn {
+	case Native:
+		native := framework.MustParseEnabledDisabled(getThirdColumn(row))
+		if native {
+			kogitoApp.Spec.Build.Native = native
+			// Make sure that enough memory is allocated for builder pod in case of native build
+			kogitoApp.Spec.Build.AddResourceRequest("memory", "4Gi")
+		}
+
+	case Persistence:
+		persistence := framework.MustParseEnabledDisabled(getThirdColumn(row))
+		if persistence {
+			*profilesPtr = append(*profilesPtr, "persistence")
+			kogitoApp.Spec.EnablePersistence = true
+		}
+
+	case Events:
+		events := framework.MustParseEnabledDisabled(getThirdColumn(row))
+		if events {
+			*profilesPtr = append(*profilesPtr, "events")
+			kogitoApp.Spec.EnableEvents = true
+			kogitoApp.Spec.KogitoServiceSpec.AddEnvironmentVariable("MP_MESSAGING_OUTGOING_KOGITO_PROCESSINSTANCES_EVENTS_BOOTSTRAP_SERVERS", "")
+			kogitoApp.Spec.KogitoServiceSpec.AddEnvironmentVariable("MP_MESSAGING_OUTGOING_KOGITO_USERTASKINSTANCES_EVENTS_BOOTSTRAP_SERVERS", "")
+		}
+	}
+}
+
+func addDefaultJavaOptionsIfNotProvided(kogitoApp *v1alpha1.KogitoApp) {
+	javaOptionsProvided := false
+	for _, env := range kogitoApp.Spec.Envs {
+		if env.Name == JavaOptionsEnvVar {
+			javaOptionsProvided = true
+		}
+	}
+
+	if !javaOptionsProvided {
+		kogitoApp.Spec.AddEnvironmentVariable(JavaOptionsEnvVar, "-Xmx2G")
+	}
+}
+
+func getFirstColumn(row *gherkin.TableRow) string {
+	return row.Cells[0].Value
+}
+
+func getSecondColumn(row *gherkin.TableRow) string {
+	return row.Cells[1].Value
+}
+
+func getThirdColumn(row *gherkin.TableRow) string {
+	return row.Cells[2].Value
+}
+
+// parseResourceRequirementsTable is useful for steps that check resource requirements, table is a subset of KogitoApp
+// configuration table
+func parseResourceRequirementsTable(table *gherkin.DataTable) (build, runtime *v1.ResourceRequirements, err error) {
+	build = &v1.ResourceRequirements{Limits: v1.ResourceList{}, Requests: v1.ResourceList{}}
+	runtime = &v1.ResourceRequirements{Limits: v1.ResourceList{}, Requests: v1.ResourceList{}}
+
+	for _, row := range table.Rows {
+		firstColumn := getFirstColumn(row)
+		switch firstColumn {
+		case BuildRequest:
+			build.Requests[v1.ResourceName(getSecondColumn(row))] = resource.MustParse(getThirdColumn(row))
+
+		case BuildLimit:
+			build.Limits[v1.ResourceName(getSecondColumn(row))] = resource.MustParse(getThirdColumn(row))
+
+		case RuntimeRequest:
+			runtime.Requests[v1.ResourceName(getSecondColumn(row))] = resource.MustParse(getThirdColumn(row))
+
+		case RuntimeLimit:
+			runtime.Limits[v1.ResourceName(getSecondColumn(row))] = resource.MustParse(getThirdColumn(row))
+
+		default:
+			return build, runtime, fmt.Errorf("Unrecognized resource option: %s", firstColumn)
+		}
+
+	}
+	return
+}


### PR DESCRIPTION
Configuration table for KogitoApp:
|first column|second column|third column|
|------|------|------|
|config|native|enabled/disabled|
|config|persistence|enabled/disabled|
|config|events|enabled/disabled|
|build-env|\<name>|\<value>|
|runtime-env|\<name>|\<value>|
|label|\<name>|\<value>|
|build-request|\<name>|\<value>|
|build-limit|\<name>|\<value>|
|runtime-request|\<name>|\<value>|
|runtime-limit|\<name>|\<value>|

Steps added by @Sgitario which need to check requests and limits will use the subset of that table.

By default, if `JAVA_OPTIONS` env variable is not set, it will be set to `-Xmx2G` so we have more stable resources assignment to test with.

Let me know what you think about it.