### PR TITLE
[KOGITO-675] Add NAMESPACE env var to facilitate service discovery in…

### DIFF
--- a/deploy/examples/onboarding-example.yaml
+++ b/deploy/examples/onboarding-example.yaml
@@ -1,14 +1,20 @@
 apiVersion: app.kiegroup.org/v1alpha1
 kind: KogitoApp
 metadata:
-  name: onboarding-service
+  name: onboarding
 spec:
+  # uncomment to enable persistence
+  #enablePersistence: true
   build:
+    # uncomment to enable persistence
+    #envs:
+    #  - name: MAVEN_ARGS_APPEND
+    #    value: "-Ppersistence"
     gitSource:
       uri: https://github.com/kiegroup/kogito-examples
       contextDir: onboarding-example/onboarding
-    # set your maven nexus repository
-    #mavenMirrorURL: http://nexus3-nexus.apps-crc.testing/repository/maven-public/
+    # set your maven nexus repository to speed up the build time
+    #mavenMirrorURL:
   service:
     labels:
       onboarding: process
@@ -20,32 +26,32 @@ spec:
 apiVersion: app.kiegroup.org/v1alpha1
 kind: KogitoApp
 metadata:
-  name: hr-service
+  name: hr
 spec:
   build:
     gitSource:
       uri: https://github.com/kiegroup/kogito-examples
       contextDir: onboarding-example/hr
-    # set your maven nexus repository
-    #mavenMirrorURL: http://nexus3-nexus.apps-crc.testing/repository/maven-public/
+    # set your maven nexus repository to speed up the build time
+    #mavenMirrorURL:
   service:
     labels:
-      department: process
+      department/first: process
       id: process
-      employeeValidation: process
+      employee-validation/first: process
 
 ---
 apiVersion: app.kiegroup.org/v1alpha1
 kind: KogitoApp
 metadata:
-  name: payroll-service
+  name: payroll
 spec:
   build:
     gitSource:
       uri: https://github.com/kiegroup/kogito-examples
       contextDir: onboarding-example/payroll
-    # set your maven nexus repository
-    #mavenMirrorURL: http://nexus3-nexus.apps-crc.testing/repository/maven-public/
+    # set your maven nexus repository to speed up the build time
+    #mavenMirrorURL:
   service:
     labels:
       taxes/rate: process

--- a/pkg/controller/kogitoapp/resource/deployment_config.go
+++ b/pkg/controller/kogitoapp/resource/deployment_config.go
@@ -55,6 +55,8 @@ const (
 	downwardAPIProtoBufCMKey = "protobufcm"
 
 	postHookPersistenceScript = kogitoHome + "/launch/post-hook-persistence.sh"
+
+	envVarNamespace = "NAMESPACE"
 )
 
 var (
@@ -111,10 +113,8 @@ func newDeploymentConfig(kogitoApp *v1alpha1.KogitoApp, runnerBC *buildv1.BuildC
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: kogitoApp.Name,
-							// this conversion will be removed in future versions
-							Env: kogitoApp.Spec.KogitoServiceSpec.Envs,
-							// this conversion will be removed in future versions
+							Name:            kogitoApp.Name,
+							Env:             kogitoApp.Spec.KogitoServiceSpec.Envs,
 							Resources:       kogitoApp.Spec.KogitoServiceSpec.Resources,
 							Image:           runnerBC.Spec.Output.To.Name,
 							ImagePullPolicy: corev1.PullAlways,
@@ -176,8 +176,13 @@ func newDeploymentConfig(kogitoApp *v1alpha1.KogitoApp, runnerBC *buildv1.BuildC
 	}
 
 	setReplicas(kogitoApp, dc)
+	setNamespaceEnvVars(kogitoApp, dc)
 
 	return dc, nil
+}
+
+func setNamespaceEnvVars(kogitoApp *v1alpha1.KogitoApp, dc *appsv1.DeploymentConfig) {
+	framework.SetEnvVar(envVarNamespace, kogitoApp.Namespace, &dc.Spec.Template.Spec.Containers[0])
 }
 
 // setReplicas defines the number of container replicas that this DeploymentConfig will have

--- a/test/framework/kogitoapp.go
+++ b/test/framework/kogitoapp.go
@@ -190,10 +190,6 @@ func GetKogitoAppStub(namespace, appName string) *v1alpha1.KogitoApp {
 		},
 	}
 
-	// Add namespace for service discovery
-	// Can be removed once https://issues.redhat.com/browse/KOGITO-675 is done
-	kogitoApp.Spec.KogitoServiceSpec.AddEnvironmentVariable("NAMESPACE", namespace)
-
 	setupBuildImageStreams(kogitoApp)
 
 	return kogitoApp

--- a/test/steps/utils.go
+++ b/test/steps/utils.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package steps
 
 import (


### PR DESCRIPTION
…tegration

See: https://issues.redhat.com/browse/KOGITO-675

Small enhancement to enable service discovery with ease. Tested with CRC using the onboarding example:

```yaml
apiVersion: app.kiegroup.org/v1alpha1
kind: KogitoApp
metadata:
  name: onboarding
spec:
  build:
    gitSource:
      contextDir: onboarding-example/onboarding
      reference: master
      uri: https://github.com/kiegroup/kogito-examples
    imageVersion: 0.9.0
    resources: {}
  image:
    tag: 0.9.0
  replicas: 1
  resources: {}
  runtime: quarkus
  service:
    labels:
      onboarding: process
```

Note the absence of the `envs` definition.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster