### PR TITLE
KOGITO-1877: Cucumber tests should allow to change registry/namespace…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,12 +96,16 @@ deploy_uri=
 cli_path=
 # runtime
 services_image_version=
+services_image_namespace=
+services_image_registry=
 data_index_image_tag=
 jobs_service_image_tag=
 management_console_image_tag=
 # build
 maven_mirror=
 build_image_version=
+build_image_namespace=
+build_image_registry=
 build_s2i_image_tag=
 build_runtime_image_tag=
 # examples repository
@@ -139,11 +143,15 @@ run-tests:
 		--deploy_uri ${deploy_uri} \
 		--cli_path ${cli_path} \
 		--services_image_version ${services_image_version} \
+		--services_image_namespace ${services_image_namespace} \
+		--services_image_registry ${services_image_registry} \
 		--data_index_image_tag ${data_index_image_tag} \
 		--jobs_service_image_tag ${jobs_service_image_tag} \
 		--management_console_image_tag ${management_console_image_tag} \
 		--maven_mirror $(maven_mirror) \
 		--build_image_version ${build_image_version} \
+		--build_image_namespace ${build_image_namespace} \
+		--build_image_registry ${build_image_registry} \
 		--build_s2i_image_tag ${build_s2i_image_tag} \
 		--build_runtime_image_tag ${build_runtime_image_tag} \
 		--examples_uri ${examples_uri} \

--- a/README.md
+++ b/README.md
@@ -1107,14 +1107,18 @@ You can set those optional keys:
 - `cli_path` set the built CLI path.  
   *Default is ./build/_output/bin/kogito*.
 <!--- runtime -->
-- `services_image_version` sets the services (jobs-service, data-index, ...) image version. Default is current operator version.
+- `services_image_version` sets the services (jobs-service, data-index, ...) image version.
+- `services_image_namespace` sets the services (jobs-service, data-index, ...) image namespace.
+- `services_image_registry` sets the services (jobs-service, data-index, ...) image registry.
 - `data_index_image_tag` sets the Kogito Data Index image tag ('services_image_version' is ignored)
 - `jobs_service_image_tag` sets the Kogito Jobs Service image tag ('services_image_version' is ignored)
 - `management_console_image_tag` sets the Kogito Management Console image tag ('services_image_version' is ignored)
 <!--- build -->
 - `maven_mirror` is the Maven mirror URL.  
   This is helpful when you need to speed up the build time by referring to a closer Maven repository.
-- `build_image_version` sets the build image version. Default is current operator version.
+- `build_image_version` sets the build image version.
+- `build_image_namespace` sets the build image namespace.
+- `build_image_registry` sets the build image registry.
 - `build_s2i_image_tag` sets the build S2I image full tag.
 - `build_runtime_image_tag` sets the build Runtime image full tag.
 <!--- examples repository -->

--- a/cmd/kogito/command/install/data_index.go
+++ b/cmd/kogito/command/install/data_index.go
@@ -16,6 +16,7 @@ package install
 
 import (
 	"fmt"
+
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/deploy"
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/shared"

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -57,14 +57,18 @@ function usage(){
   printf "\n--cli_path {PATH}\n\tPath to built CLI to test. Default is local built one."
 
   # runtime
-  printf "\n--services_image_version {VERSION}\n\tSet the services image version. Default to current operator version"
+  printf "\n--services_image_version {VERSION}\n\tSet the services image version."
+  printf "\n--services_image_namespace {NAMESPACE}\n\tSet the services image namespace."
+  printf "\n--services_image_registry {REGISTRY}\n\tSet the services image registry."
   printf "\n--data_index_image_tag {IMAGE_TAG}\n\tSet the Kogito Data Index image tag ('services_image_version' is ignored)"
   printf "\n--jobs_service_image_tag {IMAGE_TAG}\n\tSet the Kogito Jobs Service image tag ('services_image_version' is ignored)"
   printf "\n--management_console_image_tag {IMAGE_TAG}\n\tSet the Kogito Management Console image tag ('services_image_version' is ignored)"
 
   # build
   printf "\n--maven_mirror {URI}\n\tMaven mirror url to be used when building app in the tests."
-  printf "\n--build_image_version {VERSION}\n\tSet the build image version. Default to current operator version"
+  printf "\n--build_image_version {VERSION}\n\tSet the build image version."
+  printf "\n--build_image_namespace {NAMESPACE}\n\tSet the build image namespace."
+  printf "\n--build_image_registry {REGISTRY}\n\tSet the build image registry."
   printf "\n--build_image_tag {TAG}\n\tSet the build image full tag."
   printf "\n--build_s2i_image_tag {TAG}\n\tSet the S2I build image full tag."
   printf "\n--build_runtime_image_tag {NAME}\n\tSet the Runtime build image full tag."
@@ -215,6 +219,14 @@ case $1 in
     shift
     if addParamKeyValueIfAccepted "--tests.services-image-version" ${1}; then shift; fi
   ;;
+  --services_image_namespace)
+    shift
+    if addParamKeyValueIfAccepted "--tests.services-image-namespace" ${1}; then shift; fi
+  ;;
+  --services_image_registry)
+    shift
+    if addParamKeyValueIfAccepted "--tests.services-image-registry" ${1}; then shift; fi
+  ;;
   --data_index_image_tag)
     shift
     if addParamKeyValueIfAccepted "--tests.data-index-image-tag" ${1}; then shift; fi
@@ -236,6 +248,14 @@ case $1 in
   --build_image_version)
     shift
     if addParamKeyValueIfAccepted "--tests.build-image-version" ${1}; then shift; fi
+  ;;
+  --build_image_namespace)
+    shift
+    if addParamKeyValueIfAccepted "--tests.build-image-namespace" ${1}; then shift; fi
+  ;;
+  --build_image_registry)
+    shift
+    if addParamKeyValueIfAccepted "--tests.build-image-registry" ${1}; then shift; fi
   ;;
   --build_s2i_image_tag)
     shift

--- a/hack/run-tests.sh.bats
+++ b/hack/run-tests.sh.bats
@@ -296,6 +296,42 @@
     [[ "${output}" != *"--tests.services-image-version"* ]]
 }
 
+@test "invoke run-tests with services_image_namespace" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --services_image_namespace namespace --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "--tests.services-image-namespace=namespace" ]]
+}
+
+@test "invoke run-tests with services_image_namespace missing value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --services_image_namespace --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.services-image-namespace"* ]]
+}
+
+@test "invoke run-tests with services_image_namespace empty value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --services_image_namespace "" --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.services-image-namespace"* ]]
+}
+
+@test "invoke run-tests with services_image_registry" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --services_image_registry registry --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "--tests.services-image-registry=registry" ]]
+}
+
+@test "invoke run-tests with services_image_registry missing value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --services_image_registry --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.services-image-registry"* ]]
+}
+
+@test "invoke run-tests with services_image_registry empty value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --services_image_registry "" --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.services-image-registry"* ]]
+}
+
 @test "invoke run-tests with data_index_image_tag" {
     run ${BATS_TEST_DIRNAME}/run-tests.sh --data_index_image_tag tag --dry_run
     [ "$status" -eq 0 ]
@@ -386,6 +422,42 @@
     run ${BATS_TEST_DIRNAME}/run-tests.sh --build_image_version "" --dry_run
     [ "$status" -eq 0 ]
     [[ "${output}" != *"--tests.build-image-version"* ]]
+}
+
+@test "invoke run-tests with build_image_namespace" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --build_image_namespace namespace --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "--tests.build-image-namespace=namespace" ]]
+}
+
+@test "invoke run-tests with build_image_namespace missing value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --build_image_namespace --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.build-image-namespace"* ]]
+}
+
+@test "invoke run-tests with build_image_namespace empty value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --build_image_namespace "" --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.build-image-namespace"* ]]
+}
+
+@test "invoke run-tests with build_image_registry" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --build_image_registry registry --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "--tests.build-image-registry=registry" ]]
+}
+
+@test "invoke run-tests with build_image_registry missing value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --build_image_registry --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.build-image-registry"* ]]
+}
+
+@test "invoke run-tests with build_image_registry empty value" {
+    run ${BATS_TEST_DIRNAME}/run-tests.sh --build_image_registry "" --dry_run
+    [ "$status" -eq 0 ]
+    [[ "${output}" != *"--tests.build-image-registry"* ]]
 }
 
 @test "invoke run-tests with build_s2i_image_tag" {

--- a/pkg/infrastructure/data_index.go
+++ b/pkg/infrastructure/data_index.go
@@ -25,12 +25,8 @@ import (
 )
 
 const (
-	// DefaultDataIndexImageNoVersion is the default Data Index image name without version definition
-	DefaultDataIndexImageNoVersion = "quay.io/kiegroup/kogito-data-index:"
 	// DefaultDataIndexImageName is just the image name for the Data Index Service
 	DefaultDataIndexImageName = "kogito-data-index"
-	// DefaultDataIndexImageFullTag is the default image name for the Kogito Data Index Service
-	DefaultDataIndexImageFullTag = "quay.io/kiegroup/" + DefaultDataIndexImageName + ":latest"
 	// DefaultDataIndexName is the default name for the Data Index instance service
 	DefaultDataIndexName = "data-index"
 

--- a/pkg/infrastructure/jobs_service.go
+++ b/pkg/infrastructure/jobs_service.go
@@ -24,8 +24,6 @@ import (
 const (
 	// DefaultJobsServiceImageName is the default image name for the Jobs Service image
 	DefaultJobsServiceImageName = "kogito-jobs-service"
-	// DefaultJobsServiceImageNoVersion is the default Jobs Service image name without version definition
-	DefaultJobsServiceImageNoVersion = "quay.io/kiegroup/" + DefaultJobsServiceImageName + ":"
 	// DefaultJobsServiceName is the default name for the Jobs Services instance service
 	DefaultJobsServiceName = "jobs-service"
 

--- a/pkg/infrastructure/kogito_images.go
+++ b/pkg/infrastructure/kogito_images.go
@@ -16,14 +16,19 @@ package infrastructure
 
 import (
 	"fmt"
-	"github.com/kiegroup/kogito-cloud-operator/version"
 	"strings"
+
+	"github.com/kiegroup/kogito-cloud-operator/version"
 )
 
 const (
 	versionSeparator = "."
 	// LatestTag the default name for latest image tag
 	LatestTag = "latest"
+	// DefaultImageRegistry the default services image repository
+	DefaultImageRegistry = "quay.io"
+	// DefaultImageNamespace the default services image namespace
+	DefaultImageNamespace = "kiegroup"
 )
 
 // GetRuntimeImageVersion gets the Kogito Runtime latest micro version based on the Operator current version

--- a/pkg/infrastructure/mgmt_console.go
+++ b/pkg/infrastructure/mgmt_console.go
@@ -24,8 +24,6 @@ const (
 	DefaultMgmtConsoleName = "management-console"
 	// DefaultMgmtConsoleImageName ...
 	DefaultMgmtConsoleImageName = "kogito-management-console"
-	// DefaultMgmtConsoleImageNoVersion is the default Management Console image name without version definition
-	DefaultMgmtConsoleImageNoVersion = "quay.io/kiegroup/" + DefaultMgmtConsoleImageName + ":"
 )
 
 // GetManagementConsoleEndpoint gets the route for the Management Console deployed in the given namespace

--- a/pkg/infrastructure/services/deployment_test.go
+++ b/pkg/infrastructure/services/deployment_test.go
@@ -15,14 +15,15 @@
 package services
 
 import (
+	"testing"
+
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const defaultDataIndexImageFullTag = infrastructure.DefaultDataIndexImageNoVersion + "latest"
+var defaultDataIndexImageFullTag = infrastructure.GetRuntimeImageVersion() + ":latest"
 
 func Test_createRequiredDeployment_CheckQuarkusProbe(t *testing.T) {
 	kogitoService := &v1alpha1.KogitoDataIndex{

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -18,8 +18,6 @@ import (
 	"flag"
 	"path/filepath"
 
-	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
-
 	"github.com/kiegroup/kogito-cloud-operator/version"
 )
 
@@ -42,14 +40,18 @@ type TestConfig struct {
 	cliPath           string
 
 	// runtime
-	servicesImageVersion string
-	dataIndexImageTag    string
-	jobsServiceImageTag  string
-	mgmtConsoleImageTag  string
+	servicesImageVersion   string
+	servicesImageNamespace string
+	servicesImageRegistry  string
+	dataIndexImageTag      string
+	jobsServiceImageTag    string
+	mgmtConsoleImageTag    string
 
 	// build
 	mavenMirrorURL       string
 	buildImageVersion    string
+	buildImageNamespace  string
+	buildImageRegistry   string
 	buildS2iImageTag     string
 	buildRuntimeImageTag string
 
@@ -104,14 +106,18 @@ func BindFlags(set *flag.FlagSet) {
 	set.StringVar(&env.cliPath, prefix+"cli-path", defaultCliPath, "Path to built CLI to test")
 
 	// runtime
-	set.StringVar(&env.servicesImageVersion, prefix+"services-image-version", infrastructure.GetRuntimeImageVersion(), "Set the services (jobs-service, data-index) image version")
+	set.StringVar(&env.servicesImageVersion, prefix+"services-image-version", "", "Set the services (jobs-service, data-index) image version")
+	set.StringVar(&env.servicesImageNamespace, prefix+"services-image-namespace", "", "Set the services (jobs-service, data-index) image namespace")
+	set.StringVar(&env.servicesImageRegistry, prefix+"services-image-registry", "", "Set the services (jobs-service, data-index) image registry")
 	set.StringVar(&env.dataIndexImageTag, prefix+"data-index-image-tag", "", "Set the Kogito Data Index image tag ('services-image-version' is ignored)")
 	set.StringVar(&env.jobsServiceImageTag, prefix+"jobs-service-image-tag", "", "Set the Kogito Jobs Service image tag ('services-image-version' is ignored)")
 	set.StringVar(&env.mgmtConsoleImageTag, prefix+"management-console-image-tag", "", "Set the Kogito Management Console image tag ('services-image-version' is ignored)")
 
 	// build
 	set.StringVar(&env.mavenMirrorURL, prefix+"maven-mirror-url", "", "Maven mirror url to be used when building app in the tests")
-	set.StringVar(&env.buildImageVersion, prefix+"build-image-version", infrastructure.GetRuntimeImageVersion(), "Set the build image version")
+	set.StringVar(&env.buildImageVersion, prefix+"build-image-version", "", "Set the build image version")
+	set.StringVar(&env.buildImageNamespace, prefix+"build-image-namespace", "", "Set the build image namespace")
+	set.StringVar(&env.buildImageRegistry, prefix+"build-image-registry", "", "Set the build image registry")
 	set.StringVar(&env.buildS2iImageTag, prefix+"build-s2i-image-tag", "", "Set the S2I build image full tag")
 	set.StringVar(&env.buildRuntimeImageTag, prefix+"build-runtime-image-tag", "", "Set the Runtime build image full tag")
 
@@ -190,6 +196,16 @@ func GetServicesImageVersion() string {
 	return env.servicesImageVersion
 }
 
+// GetServicesImageRegistry return the registry for the services images
+func GetServicesImageRegistry() string {
+	return env.servicesImageRegistry
+}
+
+// GetServicesImageNamespace return the namespace for the services images
+func GetServicesImageNamespace() string {
+	return env.servicesImageNamespace
+}
+
 // GetDataIndexImageTag return the Kogito Data Index image tag
 func GetDataIndexImageTag() string {
 	return env.dataIndexImageTag
@@ -215,6 +231,16 @@ func GetMavenMirrorURL() string {
 // GetBuildImageVersion return the version for the build images
 func GetBuildImageVersion() string {
 	return env.buildImageVersion
+}
+
+// GetBuildImageNamespace return the namespace for the build images
+func GetBuildImageNamespace() string {
+	return env.buildImageNamespace
+}
+
+// GetBuildImageRegistry return the registry for the build images
+func GetBuildImageRegistry() string {
+	return env.buildImageRegistry
 }
 
 // GetBuildS2IImageStreamTag return the tag for the s2i build image

--- a/test/framework/kogitodataindex.go
+++ b/test/framework/kogitodataindex.go
@@ -40,7 +40,7 @@ func newKogitoDataIndexResource(namespace string, replicas int) *v1alpha1.Kogito
 	return &v1alpha1.KogitoDataIndex{
 		ObjectMeta: NewObjectMetadata(namespace, getDataIndexServiceName()),
 		Spec: v1alpha1.KogitoDataIndexSpec{
-			KogitoServiceSpec: NewKogitoServiceSpec(int32(replicas), config.GetDataIndexImageTag(), infrastructure.DefaultDataIndexImageNoVersion+infrastructure.GetRuntimeImageVersion()),
+			KogitoServiceSpec: NewKogitoServiceSpec(int32(replicas), config.GetDataIndexImageTag(), infrastructure.DefaultDataIndexImageName),
 		},
 		Status: v1alpha1.KogitoDataIndexStatus{
 			KogitoServiceStatus: NewKogitoServiceStatus(),

--- a/test/framework/kogitojobsservice.go
+++ b/test/framework/kogitojobsservice.go
@@ -85,7 +85,7 @@ func newKogitoJobsServiceResource(namespace string, replicas int) *v1alpha1.Kogi
 	return &v1alpha1.KogitoJobsService{
 		ObjectMeta: NewObjectMetadata(namespace, getJobsServiceName()),
 		Spec: v1alpha1.KogitoJobsServiceSpec{
-			KogitoServiceSpec: NewKogitoServiceSpec(int32(replicas), config.GetJobsServiceImageTag(), infrastructure.DefaultJobsServiceImageNoVersion+infrastructure.GetRuntimeImageVersion()),
+			KogitoServiceSpec: NewKogitoServiceSpec(int32(replicas), config.GetJobsServiceImageTag(), infrastructure.DefaultJobsServiceImageName),
 		},
 		Status: v1alpha1.KogitoJobsServiceStatus{
 			KogitoServiceStatus: NewKogitoServiceStatus(),

--- a/test/framework/kogitomgmtconsole.go
+++ b/test/framework/kogitomgmtconsole.go
@@ -39,7 +39,7 @@ func newManagementConsoleResource(namespace string, replicas int) *v1alpha1.Kogi
 	return &v1alpha1.KogitoMgmtConsole{
 		ObjectMeta: NewObjectMetadata(namespace, getManagementConsoleServiceName()),
 		Spec: v1alpha1.KogitoMgmtConsoleSpec{
-			KogitoServiceSpec: NewKogitoServiceSpec(int32(replicas), config.GetManagementConsoleImageTag(), infrastructure.DefaultMgmtConsoleImageNoVersion+infrastructure.GetRuntimeImageVersion()),
+			KogitoServiceSpec: NewKogitoServiceSpec(int32(replicas), config.GetManagementConsoleImageTag(), infrastructure.DefaultMgmtConsoleImageName),
 		},
 		Status: v1alpha1.KogitoMgmtConsoleStatus{
 			KogitoServiceStatus: NewKogitoServiceStatus(),


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/KOGITO-1877
Description: 
Added new attributes to allow share the images when running the pipelines:

- build_image_registry
- build_image_namespace
- services_image_registry
- services_image_namespace

We will remove the defaults in the services and images parameters (registry, namespace and version). If not set, the operator will deal with it using the defaults.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster