### PR TITLE
[KOGITO-2012] - Impossible to configure external Kafka for Data index using kafka-instance CLI parameter

### DIFF
--- a/cmd/kogito/command/install/data_index.go
+++ b/cmd/kogito/command/install/data_index.go
@@ -112,8 +112,10 @@ For more information on Kogito Data Index Service see: https://github.com/kiegro
 				i.flags.infinispan.UseKogitoInfra = false
 			}
 			if len(i.flags.kafka.ExternalURI) > 0 {
+				i.flags.kafka.UseKogitoInfra = false
 				log.Infof("kafka-url informed. Kafka will NOT be provisioned for you. Make sure that %s url is accessible from the cluster", i.flags.kafka.ExternalURI)
 			} else if len(i.flags.kafka.Instance) > 0 {
+				i.flags.kafka.UseKogitoInfra = false
 				log.Infof("kafka-instance informed. Kafka will NOT be provisioned for you. Make sure Kafka instance %s is properly deployed in the project. If the Kafka instance is found, Kafka Topics for Data Index service will be deployed in the project if they don't exist already", i.flags.kafka.Instance)
 			} else {
 				i.flags.kafka.UseKogitoInfra = true

--- a/pkg/infrastructure/services/deployer.go
+++ b/pkg/infrastructure/services/deployer.go
@@ -260,8 +260,9 @@ func (s *serviceDeployer) deployKafka(instance v1alpha1.KogitoService) (requeueA
 	}
 	if s.definition.RequiresMessaging &&
 		!kafkaAware.GetKafkaProperties().UseKogitoInfra &&
-		len(kafkaAware.GetKafkaProperties().ExternalURI) == 0 {
-		log.Debugf("Service %s requires messaging and Kafka URL is empty, deploying Kogito Infrastructure", instance.GetName())
+		len(kafkaAware.GetKafkaProperties().ExternalURI) == 0 &&
+		len(kafkaAware.GetKafkaProperties().Instance) == 0 {
+		log.Debugf("Service %s requires messaging and Kafka URL is empty and kafka instance is not provided, deploying Kogito Infrastructure", instance.GetName())
 		kafkaAware.GetKafkaProperties().UseKogitoInfra = true
 	} else if !kafkaAware.GetKafkaProperties().UseKogitoInfra {
 		return


### PR DESCRIPTION
Currently the UseKogitoInfra flag is set to true even when external kafka is provided
See for more info - https://issues.redhat.com/browse/KOGITO-2012
Using external kafka instance or url when external kafka instance or url is provided

Signed-off-by: TARUN KHANDELWAL <tarkhand@redhat.com>

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster