### PR TITLE
KOGITO-1959: BDD tests: add possibility to check for errors in the wa…

### DIFF
--- a/test/framework/openshift.go
+++ b/test/framework/openshift.go
@@ -88,7 +88,7 @@ func WaitForDeploymentConfigRunning(namespace, dcName string, podNb int, timeout
 				GetLogger(namespace).Debugf("Deployment config has %d available replicas\n", dc.Status.AvailableReplicas)
 				return dc.Status.AvailableReplicas == int32(podNb), nil
 			}
-		})
+		}, CheckPodsByDeploymentConfigInError(namespace, dcName))
 }
 
 // GetDeploymentConfig retrieves a deployment config
@@ -183,9 +183,9 @@ func WaitAndRetrieveRouteURI(namespace, serviceName string) (string, error) {
 	return routeURI, nil
 }
 
-// WaitForOnOpenshift is a specific method
-func WaitForOnOpenshift(namespace, display string, timeoutInMin int, condition func() (bool, error)) error {
-	return WaitFor(namespace, display, GetOpenshiftDurationFromTimeInMin(timeoutInMin), condition)
+// WaitForOnOpenshift waits for a specification condition
+func WaitForOnOpenshift(namespace, display string, timeoutInMin int, condition func() (bool, error), errorConditions ...func() (bool, error)) error {
+	return WaitFor(namespace, display, GetOpenshiftDurationFromTimeInMin(timeoutInMin), condition, errorConditions...)
 }
 
 // GetOpenshiftDurationFromTimeInMin will calculate the time depending on the configured cluster load factor

--- a/test/framework/openshift_resources.go
+++ b/test/framework/openshift_resources.go
@@ -29,7 +29,7 @@ func WaitForPodsToHaveResources(namespace, dcName string, expected v1.ResourceRe
 	return WaitForOnOpenshift(namespace, fmt.Sprintf("Pods for deployment config '%s' to have resources", dcName), timeoutInMin,
 		func() (bool, error) {
 			return checkResourcesInPods(namespace, dcName, expected)
-		})
+		}, CheckPodsByDeploymentConfigInError(namespace, dcName))
 }
 
 // WaitForBuildConfigToHaveResources waits for build config to have the expected resources

--- a/test/framework/operator.go
+++ b/test/framework/operator.go
@@ -84,7 +84,7 @@ func DeployKogitoOperatorFromYaml(namespace string) error {
 	// Wait for docker pulling secret available for kogito-operator serviceaccount
 	// This is needed if images are stored into local Openshift registry
 	// Note that this is specific to Openshift
-	err := WaitFor(namespace, "image pulling secret", GetOpenshiftDurationFromTimeInMin(2), func() (bool, error) {
+	err := WaitForOnOpenshift(namespace, "image pulling secret", 2, func() (bool, error) {
 		// unfortunately the SecretList is buggy, so we have to fetch it manually: https://github.com/kubernetes-sigs/controller-runtime/issues/362
 		// so use direct command to look for specific secret
 		output, err := CreateCommand("oc", "get", "secrets", "-o", "name", "-n", namespace).WithLoggerContext(namespace).Execute()
@@ -95,6 +95,7 @@ func DeployKogitoOperatorFromYaml(namespace string) error {
 		GetLogger(namespace).Info(output)
 		return strings.Contains(output, "secret/"+kogitoOperatorPullImageSecretPrefix), nil
 	})
+
 	if err != nil {
 		return err
 	}
@@ -117,6 +118,7 @@ func IsKogitoOperatorRunning(namespace string) (bool, error) {
 		}
 		return false, err
 	}
+
 	return exists, nil
 }
 


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/KOGITO-1959
Description: Add a new errorCondition closure to the WaitFor utility in order to define when to stop waiting for a condition.

As golang does not support having the same method with different arguments, we provide default methods to add the error condition (at the moment, only two):
- NoErrorCondition: when we don't want any error condition
- CheckPodsByDeploymentConfigInError: check whether pods under one deployment config is in error state (at the moment, only checks whether is ErrImagePull - the image can't be found
- CheckPodsWithLabelConfigInError: same as above but using one label

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster