### PR TITLE
KOGITO-1700 - Add optional configuration of Infinispan in BDD

### DIFF
--- a/pkg/apis/app/v1alpha1/kogitoservices_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoservices_types.go
@@ -169,6 +169,23 @@ func (k *KogitoServiceSpec) AddEnvironmentVariable(name, value string) {
 	return
 }
 
+// AddEnvironmentVariableFromSecret adds a new environment variable from the secret under the key
+func (k *KogitoServiceSpec) AddEnvironmentVariableFromSecret(variableName, secretName, secretKey string) {
+	env := corev1.EnvVar{
+		Name: variableName,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key: secretKey,
+			},
+		},
+	}
+	k.Envs = append(k.Envs, env)
+	return
+}
+
 // AddResourceRequest adds new resource request. Works also on uninitialized Requests field.
 func (k *KogitoServiceSpec) AddResourceRequest(name, value string) {
 	if k.Resources.Requests == nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -219,9 +219,9 @@ func newControllerCliOptions() controllercli.Options {
 	mapper.Add(olmapiv1alpha1.SchemeGroupVersion.WithKind(meta.KindSubscription.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
 	mapper.Add(monv1.SchemeGroupVersion.WithKind(meta.KindPrometheus.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
 	mapper.Add(corev1.SchemeGroupVersion.WithKind(meta.KindPod.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
-	mapper.Add(apibuildv1.SchemeGroupVersion.WithKind(meta.KindBuildConfig.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
-	mapper.Add(infinispanv1.SchemeGroupVersion.WithKind(meta.KindInfinispan.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
+	mapper.Add(apibuildv1.GroupVersion.WithKind(meta.KindBuildConfig.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
 	mapper.Add(corev1.SchemeGroupVersion.WithKind(meta.KindSecret.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
+	mapper.Add(infinispanv1.SchemeGroupVersion.WithKind(meta.KindInfinispan.Name), &restScope{name: apimeta.RESTScopeNameNamespace})
 
 	// the kube client is having problems with plural: kogitodataindexs :(
 	mapper.AddSpecific(v1alpha1.SchemeGroupVersion.WithKind(meta.KindKogitoDataIndex.Name),

--- a/pkg/client/meta/meta.go
+++ b/pkg/client/meta/meta.go
@@ -107,12 +107,12 @@ var (
 	KindSubscription = DefinitionKind{"Subscription", false, olmapiv1alpha1.SchemeGroupVersion}
 	// KindPrometheus ...
 	KindPrometheus = DefinitionKind{"Prometheus", false, monv1.SchemeGroupVersion}
-	// KindInfinispan ...
-	KindInfinispan = DefinitionKind{"Infinispan", false, infinispanv1.SchemeGroupVersion}
 	// KindPod for a Pod
 	KindPod = DefinitionKind{"Pod", false, corev1.SchemeGroupVersion}
 	// KindSecret ...
 	KindSecret = DefinitionKind{"Secret", false, corev1.SchemeGroupVersion}
+	// KindInfinispan ...
+	KindInfinispan = DefinitionKind{"Infinispan", false, infinispanv1.SchemeGroupVersion}
 )
 
 // SetGroupVersionKind sets the group, version and kind for the resource

--- a/test/features/kogito_service_performance.feature
+++ b/test/features/kogito_service_performance.feature
@@ -1,7 +1,6 @@
 # Commented code will be addressed by further enhancements:
-# https://issues.redhat.com/browse/KOGITO-1699
-# https://issues.redhat.com/browse/KOGITO-1700
 # https://issues.redhat.com/browse/KOGITO-1701
+# https://issues.redhat.com/browse/KOGITO-1888
 
 @performance
 Feature: Kogito Service Performance
@@ -10,11 +9,11 @@ Feature: Kogito Service Performance
     Given Namespace is created
 
   @quarkus
-  Scenario Outline: Quarkus Kogito Service Performance with requests <requests>, native <native> but without persistence
+  Scenario Outline: Quarkus Kogito Service Performance with native <native>, without persistence and with requests <requests>
     Given Kogito Operator is deployed
     And Deploy quarkus example service "process-quarkus-example" with configuration:
       | config      | native       | <native> |
-      | runtime-env | JAVA_OPTIONS | -Xmx8G   |
+      | runtime-env | JAVA_OPTIONS | -Xmx10G  |
     And Kogito application "process-quarkus-example" has 1 pods running within <minutes> minutes
     And Service "process-quarkus-example" with process name "orders" is available within 3 minutes
 
@@ -53,12 +52,17 @@ Feature: Kogito Service Performance
 
   @quarkus
   @persistence
-  Scenario Outline: Quarkus Kogito Service Performance with requests <requests>, native <native> and persistence
+  Scenario Outline: Quarkus Kogito Service Performance with native <native>, with persistence and with requests <requests>
     Given Kogito Operator is deployed with Infinispan operator
+    And Infinispan instance "external-infinispan" is deployed for performance within 5 minute(s) with configuration:
+      | username | developer |
+      | password | mypass    |
     And Deploy quarkus example service "process-quarkus-example" with configuration:
-      | config      | native       | <native> |
-      | config      | persistence  | enabled  |
-      | runtime-env | JAVA_OPTIONS | -Xmx8G   |
+      | config      | native       | <native>                  |
+      | runtime-env | JAVA_OPTIONS | -Xmx10G                   |
+      | infinispan  | username     | developer                 |
+      | infinispan  | password     | mypass                    |
+      | infinispan  | uri          | external-infinispan:11222 |
     And Kogito application "process-quarkus-example" has 1 pods running within <minutes> minutes
     And Service "process-quarkus-example" with process name "orders" is available within 3 minutes
 
@@ -73,8 +77,8 @@ Feature: Kogito Service Performance
       }
       """
 
-    Then Service "process-quarkus-example" contains <requests> instances of process with name "orders" within 1 minutes
-    And Service "process-quarkus-example" contains <requests> instances of process with name "orderItems" within 1 minutes
+    #Then Service "process-quarkus-example" contains <requests> instances of process with name "orders" within 1 minutes
+    #And Service "process-quarkus-example" contains <requests> instances of process with name "orderItems" within 1 minutes
     #And All human tasks on path "orderItems" with path task name "Verify_order" are successfully "completed" with timing "true"
 
 
@@ -96,10 +100,10 @@ Feature: Kogito Service Performance
 #####
 
   @springboot
-  Scenario Outline: Spring Boot Kogito Service Performance with requests <requests> but without persistence
+  Scenario Outline: Spring Boot Kogito Service Performance without persistence and with requests <requests>
     Given Kogito Operator is deployed
     And Deploy springboot example service "process-springboot-example" with configuration:
-      | runtime-env | JAVA_OPTIONS | -Xmx8G |
+      | runtime-env | JAVA_OPTIONS | -Xmx10G |
     And Kogito application "process-springboot-example" has 1 pods running within <minutes> minutes
     And Service "process-springboot-example" with process name "orders" is available within 3 minutes
 
@@ -129,11 +133,16 @@ Feature: Kogito Service Performance
 
   @springboot
   @persistence
-  Scenario Outline: Spring Boot Kogito Service Performance with requests <requests> and persistence
+  Scenario Outline: Spring Boot Kogito Service Performance with persistence and with requests <requests>
     Given Kogito Operator is deployed with Infinispan operator
+    And Infinispan instance "external-infinispan" is deployed for performance within 5 minute(s) with configuration:
+      | username | developer |
+      | password | mypass    |
     And Deploy springboot example service "process-springboot-example" with configuration:
-      | config      | persistence  | enabled |
-      | runtime-env | JAVA_OPTIONS | -Xmx8G  |
+      | runtime-env | JAVA_OPTIONS | -Xmx10G                   |
+      | infinispan  | username     | developer                 |
+      | infinispan  | password     | mypass                    |
+      | infinispan  | uri          | external-infinispan:11222 |
     And Kogito application "process-springboot-example" has 1 pods running within <minutes> minutes
     And Service "process-springboot-example" with process name "orders" is available within 3 minutes
 
@@ -148,8 +157,8 @@ Feature: Kogito Service Performance
       }
       """
 
-    Then Service "process-springboot-example" contains <requests> instances of process with name "orders" within 1 minutes
-    And Service "process-springboot-example" contains <requests> instances of process with name "orderItems" within 1 minutes
+    #Then Service "process-springboot-example" contains <requests> instances of process with name "orders" within 1 minutes
+    #And Service "process-springboot-example" contains <requests> instances of process with name "orderItems" within 1 minutes
     #And All human tasks on path "orderItems" with path task name "Verify_order" are successfully "completed" with timing "true"
 
     Examples:

--- a/test/framework/kogitoapp.go
+++ b/test/framework/kogitoapp.go
@@ -36,6 +36,15 @@ const (
 	boxExamplesPath = "../../deploy/examples"
 )
 
+// KogitoAppHolder Helper structure holding information which are not available in KogitoApp
+type KogitoAppHolder struct {
+	* v1alpha1.KogitoApp
+	Infinispan struct {
+		Username string
+		Password string
+	}
+}
+
 // DeployService deploy a Kogito service
 func DeployService(namespace string, installerType InstallerType, kogitoApp *v1alpha1.KogitoApp) error {
 	GetLogger(namespace).Infof("%s deploy %s example %s with name %s, native %v, persistence %v, events %v and labels %v", installerType, kogitoApp.Spec.Runtime, kogitoApp.Spec.Build.GitSource.ContextDir, kogitoApp.Name, kogitoApp.Spec.Build.Native, kogitoApp.Spec.EnablePersistence, kogitoApp.Spec.EnableEvents, kogitoApp.Spec.Service.Labels)
@@ -274,4 +283,9 @@ func getBuildImage(imageName string) string {
 	}
 
 	return framework.ConvertImageToImageTag(image)
+}
+
+// IsInfinispanUsernameSpecified Returns true if Infinispan username is specified
+func (serviceHolder *KogitoAppHolder) IsInfinispanUsernameSpecified() bool {
+	return len(serviceHolder.Infinispan.Username) > 0
 }

--- a/test/framework/kubernetes.go
+++ b/test/framework/kubernetes.go
@@ -100,7 +100,7 @@ func WaitForPodsWithLabel(namespace, labelName, labelValue string, numberOfPods,
 				return false, err
 			}
 
-			return CheckPodsAreRunning(pods), nil
+			return CheckPodsAreReady(pods), nil
 		}, CheckPodsWithLabelInError(namespace, labelName, labelValue))
 }
 
@@ -127,10 +127,10 @@ func GetPodsWithLabels(namespace string, labels map[string]string) (*corev1.PodL
 	return pods, nil
 }
 
-// CheckPodsAreRunning returns true if all pods are running
-func CheckPodsAreRunning(pods *corev1.PodList) bool {
+// CheckPodsAreReady returns true if all pods are ready
+func CheckPodsAreReady(pods *corev1.PodList) bool {
 	for _, pod := range pods.Items {
-		if !IsPodRunning(&pod) {
+		if !IsPodStatusConditionReady(&pod) {
 			return false
 		}
 	}
@@ -140,6 +140,16 @@ func CheckPodsAreRunning(pods *corev1.PodList) bool {
 // IsPodRunning returns true if pod is running
 func IsPodRunning(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodRunning
+}
+
+// IsPodStatusConditionReady returns true if all pod's containers are ready (really running)
+func IsPodStatusConditionReady(pod *corev1.Pod) bool{
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.ContainersReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // GetDeployment retrieves deployment with specified name in namespace
@@ -281,4 +291,17 @@ func isPodInError(pod *corev1.Pod) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func checkPodContainerHasEnvVariableWithValue(pod *corev1.Pod, containerName, envVarName, envVarValue string) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Name == containerName {
+			for _, env := range container.Env {
+				if env.Name == envVarName {
+					return env.Value == envVarValue
+				}
+			}
+		}
+	}
+	return false
 }

--- a/test/framework/openshift_resources.go
+++ b/test/framework/openshift_resources.go
@@ -56,6 +56,13 @@ func toResourceList(resources string) corev1.ResourceList {
 	return resourceList
 }
 
+func getResourceRequirements(cpu, memory string) corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{"cpu": resource.MustParse(cpu), "memory":resource.MustParse(memory)},
+		Requests: corev1.ResourceList{"cpu": resource.MustParse(cpu), "memory":resource.MustParse(memory)},
+	}
+}
+
 func checkResourcesInBuildConfig(namespace string, buildConfigName string, expected corev1.ResourceRequirements) (bool, error) {
 	bc, err := getBuildConfig(namespace, buildConfigName)
 	if err != nil {

--- a/test/steps/infinispan.go
+++ b/test/steps/infinispan.go
@@ -22,38 +22,43 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+/*
+	DataTable for Infinispan:
+	| username | developer |
+	| password | mypass    |
+*/
+
 const (
-	//DataTable first column
-	infinispanUsernameKey     = "username"
-	infinispanPasswordNameKey = "password"
+	// DataTable first column
+	infinispanUsernameKey = "username"
+	infinispanPasswordKey = "password"
+
+	externalInfinispanSecret       = "external-infinispan-secret"
+	kogitoExternalInfinispanSecret = "kogito-external-infinispan-secret"
+	usernameSecretKey              = "user"
+	passwordSecretKey              = "pass"
 )
+
+var performanceInfinispanContainerSpec = infinispan.InfinispanContainerSpec{
+	ExtraJvmOpts: "-Xmx2G",
+	Memory:       "3Gi",
+	CPU:          "1",
+}
 
 func registerInfinispanSteps(s *godog.Suite, data *Data) {
 	s.Step(`^Infinispan instance "([^"]*)" is deployed with configuration:$`, data.infinispanInstanceIsDeployedWithConfiguration)
+	s.Step(`^Infinispan instance "([^"]*)" is deployed for performance within (\d+) minute\(s\) with configuration:$`, data.infinispanInstanceIsDeployedForPerformanceWithinMinutesWithConfiguration)
 }
 
 func (data *Data) infinispanInstanceIsDeployedWithConfiguration(name string, table *messages.PickleStepArgument_PickleTable) error {
-	infinispanSecret := "external-infinispan-secret"
-
-	if err := data.createInfinispanSecret(infinispanSecret, table); err != nil {
+	if err := createInfinispanSecret(data.Namespace, externalInfinispanSecret, table); err != nil {
 		return err
 	}
 
-	infinispan := &infinispan.Infinispan{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: data.Namespace,
-			Name:      name,
-		},
-		Spec: infinispan.InfinispanSpec{
-			Replicas: 1,
-			Security: infinispan.InfinispanSecurity{
-				EndpointSecretName: infinispanSecret,
-			},
-		},
-	}
+	infinispan := framework.GetInfinispanStub(data.Namespace, name, externalInfinispanSecret)
+
 	if err := framework.DeployInfinispanInstance(data.Namespace, infinispan); err != nil {
 		return err
 	}
@@ -61,7 +66,25 @@ func (data *Data) infinispanInstanceIsDeployedWithConfiguration(name string, tab
 	return framework.WaitForPodsWithLabel(data.Namespace, "app", "infinispan-pod", 1, 3)
 }
 
-func (data *Data) createInfinispanSecret(name string, table *messages.PickleStepArgument_PickleTable) error {
+func (data *Data) infinispanInstanceIsDeployedForPerformanceWithinMinutesWithConfiguration(name string, timeOutInMin int, table *messages.PickleStepArgument_PickleTable) error {
+	if err := createInfinispanSecret(data.Namespace, externalInfinispanSecret, table); err != nil {
+		return err
+	}
+
+	infinispan := framework.GetInfinispanStub(data.Namespace, name, externalInfinispanSecret)
+	// Add performance-specific container spec
+	infinispan.Spec.Container = performanceInfinispanContainerSpec
+
+	if err := framework.DeployInfinispanInstance(data.Namespace, infinispan); err != nil {
+		return err
+	}
+
+	return framework.WaitForInfinispanPodsToBeRunningWithConfig(data.Namespace, performanceInfinispanContainerSpec, 1, timeOutInMin)
+}
+
+// Misc methods
+
+func createInfinispanSecret(namespace, secretName string, table *messages.PickleStepArgument_PickleTable) error {
 	credentials := make(map[string]string)
 	credentials["operator"] = "supersecretoperatorpassword" // Credentials required by Infinispan operator
 
@@ -72,7 +95,7 @@ func (data *Data) createInfinispanSecret(name string, table *messages.PickleStep
 		credentials[username] = password
 	}
 
-	return framework.CreateInfinispanSecret(data.Namespace, name, credentials)
+	return framework.CreateInfinispanSecret(namespace, secretName, credentials)
 }
 
 // Table parsing
@@ -92,7 +115,7 @@ func getInfinispanCredentialsFromTable(table *messages.PickleStepArgument_Pickle
 		switch firstColumn {
 		case infinispanUsernameKey:
 			username = getSecondColumn(row)
-		case infinispanPasswordNameKey:
+		case infinispanPasswordKey:
 			password = getSecondColumn(row)
 
 		default:

--- a/test/steps/kogitodataindex.go
+++ b/test/steps/kogitodataindex.go
@@ -23,14 +23,27 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 )
 
-const (
-	//DataTable first column
-	infinispanKey = "infinispan"
+/*
+	DataTable for Data Index:
+	| infinispan      | username   | developer                 |
+	| infinispan      | password   | mypass                    |
+	| infinispan      | uri        | external-infinispan:11222 |
+	| runtime-request | cpu/memory | value                     |
+	| runtime-limit   | cpu/memory | value                     |
+	| runtime-env     | varName    | varValue                  |
+*/
 
-	//DataTable second column
+const (
+	// DataTable first column
+	dataIndexInfinispanKey     = "infinispan"
+	dataIndexRuntimeRequestKey = "runtime-request"
+	dataIndexRuntimeLimitKey   = "runtime-limit"
+	dataIndexRuntimeEnvKey     = "runtime-env"
+
+	// DataTable second column
 	dataIndexInfinispanUsernameKey = "username"
 	dataIndexInfinispanPasswordKey = "password"
-	uriKey                         = "uri"
+	dataIndexURIKey                = "uri"
 )
 
 func registerKogitoDataIndexServiceSteps(s *godog.Suite, data *Data) {
@@ -55,12 +68,8 @@ func (data *Data) installKogitoDataIndexServiceWithReplicasWithConfiguration(rep
 
 	if dataIndex.IsInfinispanUsernameSpecified() && framework.GetDefaultInstallerType() == framework.CRInstallerType {
 		// If Infinispan authentication is set and CR installer is used, the Secret holding Infinispan credentials needs to be created and passed to Data index CR.
-		secretName := "kogito-external-infinispan-secret"
-		usernameSecretKey := "user"
-		passwordSecretKey := "pass"
-
-		framework.CreateSecret(data.Namespace, secretName, map[string]string{usernameSecretKey: dataIndex.Infinispan.Username, passwordSecretKey: dataIndex.Infinispan.Password})
-		dataIndex.KogitoService.(*v1alpha1.KogitoDataIndex).Spec.InfinispanProperties.Credentials.SecretName = secretName
+		framework.CreateSecret(data.Namespace, kogitoExternalInfinispanSecret, map[string]string{usernameSecretKey: dataIndex.Infinispan.Username, passwordSecretKey: dataIndex.Infinispan.Password})
+		dataIndex.KogitoService.(*v1alpha1.KogitoDataIndex).Spec.InfinispanProperties.Credentials.SecretName = kogitoExternalInfinispanSecret
 		dataIndex.KogitoService.(*v1alpha1.KogitoDataIndex).Spec.InfinispanProperties.Credentials.UsernameKey = usernameSecretKey
 		dataIndex.KogitoService.(*v1alpha1.KogitoDataIndex).Spec.InfinispanProperties.Credentials.PasswordKey = passwordSecretKey
 	}
@@ -86,16 +95,16 @@ func configureDataIndexFromTable(table *messages.PickleStepArgument_PickleTable,
 	for _, row := range table.Rows {
 		firstColumn := getFirstColumn(row)
 		switch firstColumn {
-		case infinispanKey:
+		case dataIndexInfinispanKey:
 			parseDataIndexInfinispanRow(row, dataIndex)
 
-		case runtimeEnvKey:
+		case dataIndexRuntimeEnvKey:
 			dataIndex.KogitoService.(*v1alpha1.KogitoDataIndex).Spec.AddEnvironmentVariable(getSecondColumn(row), getThirdColumn(row))
 
-		case runtimeRequestKey:
+		case dataIndexRuntimeRequestKey:
 			dataIndex.KogitoService.(*v1alpha1.KogitoDataIndex).Spec.AddResourceRequest(getSecondColumn(row), getThirdColumn(row))
 
-		case runtimeLimitKey:
+		case dataIndexRuntimeLimitKey:
 			dataIndex.KogitoService.(*v1alpha1.KogitoDataIndex).Spec.AddResourceLimit(getSecondColumn(row), getThirdColumn(row))
 
 		default:
@@ -116,7 +125,7 @@ func parseDataIndexInfinispanRow(row *messages.PickleStepArgument_PickleTable_Pi
 	case dataIndexInfinispanPasswordKey:
 		dataIndex.Infinispan.Password = getThirdColumn(row)
 
-	case uriKey:
+	case dataIndexURIKey:
 		dataIndex.KogitoService.(*v1alpha1.KogitoDataIndex).Spec.InfinispanProperties.URI = getThirdColumn(row)
 	}
 }

--- a/test/steps/utils.go
+++ b/test/steps/utils.go
@@ -16,127 +16,18 @@ package steps
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/cucumber/messages-go/v10"
-	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
-	"github.com/kiegroup/kogito-cloud-operator/test/framework"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
-	mavenArgsAppendEnvVar = "MAVEN_ARGS_APPEND"
-	javaOptionsEnvVar     = "JAVA_OPTIONS"
-
-	//DataTable first column
-	configKey         = "config"
-	buildEnvKey       = "build-env"
-	runtimeEnvKey     = "runtime-env"
-	labelKey          = "label"
 	buildRequestKey   = "build-request"
 	buildLimitKey     = "build-limit"
 	runtimeRequestKey = "runtime-request"
 	runtimeLimitKey   = "runtime-limit"
-
-	//DataTable second column
-	nativeKey      = "native"
-	persistenceKey = "persistence"
-	eventsKey      = "events"
 )
-
-func configureKogitoAppFromTable(table *messages.PickleStepArgument_PickleTable, kogitoApp *v1alpha1.KogitoApp) error {
-	if len(table.Rows) == 0 { // Using default configuration
-		return nil
-	}
-
-	if len(table.Rows[0].Cells) != 3 {
-		return fmt.Errorf("expected table to have exactly three columns")
-	}
-
-	var profiles []string
-
-	for _, row := range table.Rows {
-		firstColumn := getFirstColumn(row)
-		switch firstColumn {
-		case configKey:
-			parseConfigRow(row, kogitoApp, &profiles)
-
-		case buildEnvKey:
-			kogitoApp.Spec.Build.AddEnvironmentVariable(getSecondColumn(row), getThirdColumn(row))
-
-		case runtimeEnvKey:
-			kogitoApp.Spec.AddEnvironmentVariable(getSecondColumn(row), getThirdColumn(row))
-
-		case labelKey:
-			kogitoApp.Spec.Service.Labels[getSecondColumn(row)] = getThirdColumn(row)
-
-		case buildRequestKey:
-			kogitoApp.Spec.Build.AddResourceRequest(getSecondColumn(row), getThirdColumn(row))
-
-		case buildLimitKey:
-			kogitoApp.Spec.Build.AddResourceLimit(getSecondColumn(row), getThirdColumn(row))
-
-		case runtimeRequestKey:
-			kogitoApp.Spec.AddResourceRequest(getSecondColumn(row), getThirdColumn(row))
-
-		case runtimeLimitKey:
-			kogitoApp.Spec.AddResourceLimit(getSecondColumn(row), getThirdColumn(row))
-
-		default:
-			return fmt.Errorf("Unrecognized configuration option: %s", firstColumn)
-		}
-	}
-
-	if len(profiles) > 0 {
-		kogitoApp.Spec.Build.AddEnvironmentVariable(mavenArgsAppendEnvVar, "-P"+strings.Join(profiles, ","))
-	}
-
-	addDefaultJavaOptionsIfNotProvided(kogitoApp)
-
-	return nil
-}
-
-func parseConfigRow(row *messages.PickleStepArgument_PickleTable_PickleTableRow, kogitoApp *v1alpha1.KogitoApp, profilesPtr *[]string) {
-	secondColumn := getSecondColumn(row)
-
-	switch secondColumn {
-	case nativeKey:
-		native := framework.MustParseEnabledDisabled(getThirdColumn(row))
-		if native {
-			kogitoApp.Spec.Build.Native = native
-			// Make sure that enough memory is allocated for builder pod in case of native build
-			kogitoApp.Spec.Build.AddResourceRequest("memory", "4Gi")
-		}
-
-	case persistenceKey:
-		persistence := framework.MustParseEnabledDisabled(getThirdColumn(row))
-		if persistence {
-			*profilesPtr = append(*profilesPtr, "persistence")
-			kogitoApp.Spec.EnablePersistence = true
-		}
-
-	case eventsKey:
-		events := framework.MustParseEnabledDisabled(getThirdColumn(row))
-		if events {
-			*profilesPtr = append(*profilesPtr, "events")
-			kogitoApp.Spec.EnableEvents = true
-		}
-	}
-}
-
-func addDefaultJavaOptionsIfNotProvided(kogitoApp *v1alpha1.KogitoApp) {
-	javaOptionsProvided := false
-	for _, env := range kogitoApp.Spec.Envs {
-		if env.Name == javaOptionsEnvVar {
-			javaOptionsProvided = true
-		}
-	}
-
-	if !javaOptionsProvided {
-		kogitoApp.Spec.AddEnvironmentVariable(javaOptionsEnvVar, "-Xmx2G")
-	}
-}
 
 func getFirstColumn(row *messages.PickleStepArgument_PickleTable_PickleTableRow) string {
 	return row.Cells[0].Value


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-1700

Things to discuss:

1. I found that for Infinispan env vars we use 2 maps (Quarkus/Spring Boot) in the operator framework:
https://github.com/kiegroup/kogito-cloud-operator/blob/d967c4f6331ab79d4ee71906058dd1bad2035bce/pkg/controller/kogitoapp/resource/deployment_config.go#L69-L82
But they are not public, so I cannot use them and have to use my own, see the `addInfinispanEnvVars` method. Basically I have to use if now. Can we make them public so they can be used in the test framework, wdyt?

2. I created the `KogitoAppHolder` to follow the pattern of `KogitoServiceHolder` in the framework. For KogitoApp it is not needed on the framework side right now (not used in the framework at all, just in the steps) but I wanted to be consistent with KogitoService.

3. First time, I tried to use the secrets but then found out that you cannot set an environment variable value from secret using Kogito CLI - maybe a proposal for a new feature? You can set just an environment variable name and its value. So right now I have fallen back to using plaintext passwords and it works :+1: 

4. Commented out steps like `Then Service "process-quarkus-example" contains <requests> instances of process` because of currently not having a viable solution to properly fetch a large number of processes, i.e. using pagination. The list of features which belong to these commented steps is provided at the beginning of the performance feature file.

5. Of course, KogitoApp can now be configured for external Infinispan using:
```
| infinispan      | username | developer                 |
| infinispan      | password | mypass                    |
| infinispan      | uri      | external-infinispan:11222 |
```

Many thanks for submiting your Pull Request :heart: :racing_car:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster