### PR TITLE
KOGITO-2164: Cucumber Tests: Add workaround in tests to ignore pods w…

### DIFF
--- a/test/framework/kubernetes.go
+++ b/test/framework/kubernetes.go
@@ -118,6 +118,11 @@ func GetPodsByDeploymentConfig(namespace string, dcName string) (*corev1.PodList
 	return GetPodsWithLabels(namespace, map[string]string{"deploymentconfig": dcName})
 }
 
+// GetPodsByDeploymentConfigAndVersion retrieves pods with a deploymentconfig label set to <dcName> and version <version>
+func GetPodsByDeploymentConfigAndVersion(namespace string, dcName string, version int64) (*corev1.PodList, error) {
+	return GetPodsWithLabels(namespace, map[string]string{"deploymentconfig": dcName, "deployment": fmt.Sprintf("%s-%d", dcName, version)})
+}
+
 // GetPodsWithLabels retrieves pods based on label name and value
 func GetPodsWithLabels(namespace string, labels map[string]string) (*corev1.PodList, error) {
 	pods := &corev1.PodList{}

--- a/test/framework/openshift.go
+++ b/test/framework/openshift.go
@@ -85,8 +85,14 @@ func WaitForDeploymentConfigRunning(namespace, dcName string, podNb int, timeout
 			} else if dc == nil {
 				return false, nil
 			} else {
-				GetLogger(namespace).Debugf("Deployment config has %d available replicas\n", dc.Status.AvailableReplicas)
-				return dc.Status.AvailableReplicas == int32(podNb), nil
+				// Workaround for KOGITO-2162: DeploymentConfig is being rollout without any reason
+				pods, err := GetPodsByDeploymentConfigAndVersion(namespace, dcName, dc.Status.LatestVersion)
+				if err != nil {
+					return false, nil
+				}
+
+				GetLogger(namespace).Debugf("Deployment config has %d pods\n", len(pods.Items))
+				return len(pods.Items) == podNb && CheckPodsAreRunning(pods), nil
 			}
 		}, CheckPodsByDeploymentConfigInError(namespace, dcName))
 }


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/KOGITO-2164
Description: The issue KOGITO-2162 causes that the tests think a deployment config is ready when a pod is ready and a rollout is in progress. The problem is that this pod will be terminated because of the rollout leading the scenarios with the persistence disabled to randomly fail.

Solution: To check that the pods for the deployment config matches the latest version. 
Note that this is a workaround and it should be removed as soon as the issue is fixed.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster