### PR TITLE
KOGITO-2192: BDD tests: Should provide a file with created namespaces

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,7 @@ pipeline {
                     dir("${WORKING_DIR}") {
                         archiveArtifacts artifacts: 'test/logs/**/*.log', allowEmptyArchive: true
                         junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: true
+                        sh "cd test && go run scripts/prune_namespaces.go"
                     }
                 }
             }

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -83,6 +83,7 @@ pipeline {
                     dir("${WORKING_DIR}") {
                         archiveArtifacts artifacts: 'test/logs/**/*.log', allowEmptyArchive: true
                         junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: true
+                        sh "cd test && go run scripts/prune_namespaces.go"
                     }
                 }
             }

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -123,6 +123,7 @@ FEATURE=""
 TIMEOUT=240
 DEBUG=false
 CRDS_UPDATE=true
+KEEP_NAMESPACE=false
 LOAD_DEFAULT_CONFIG=false
 
 while (( $# ))
@@ -292,6 +293,7 @@ case $1 in
     shift
   ;;
   --keep_namespace)
+    KEEP_NAMESPACE=true
     addParam "--tests.keep-namespace"
     shift
   ;;
@@ -358,6 +360,14 @@ if ${CRDS_UPDATE}; then
   deploy_folder=`mktemp -d`
   download_remote_crds ${deploy_folder} ${MASTER_RAW_URL}
   apply_crds ${deploy_folder}
+fi
+
+if [ "${KEEP_NAMESPACE}" = "false" ]; then
+  echo "-------- Pruning namespaces"
+  cd ${SCRIPT_DIR}/../test
+  go run scripts/prune_namespaces.go
+  echo "Pruning namespaces done."
+  cd -
 fi
 
 exit ${exit_code}

--- a/test/README.md
+++ b/test/README.md
@@ -90,3 +90,12 @@ The program will wait until you launch the Debug mode from VS Code (next step).
 Launch debug session by selecting Run/Start Debugging from top menu.
 
 Further information [here](https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code).
+
+### Prune namespaces
+
+In case you stopped a test execution, the test framework won't delete the namespaces in the cluster. So to avoid waste of resources in the cluster, you need to manually delete these namespaces. In order to ease this, now we have a namespace history log and an utility to do this by running:
+
+```sh
+cd test
+go run scripts/prune_namespaces.go
+``` 

--- a/test/framework/kubernetes.go
+++ b/test/framework/kubernetes.go
@@ -51,46 +51,6 @@ func InitKubeClient() error {
 	return nil
 }
 
-// CreateNamespace creates a new namespace
-func CreateNamespace(namespace string) error {
-	GetLogger(namespace).Infof("Create namespace %s", namespace)
-	_, err := kubernetes.NamespaceC(kubeClient).Create(namespace)
-	if err != nil {
-		return fmt.Errorf("Cannot create namespace %s: %v", namespace, err)
-	}
-	return nil
-}
-
-// DeleteNamespace deletes a namespace
-func DeleteNamespace(namespace string) error {
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	GetLogger(namespace).Infof("Delete namespace %s", namespace)
-	err := kubernetes.ResourceC(kubeClient).Delete(ns)
-	if err != nil {
-		return fmt.Errorf("Cannot delete namespace %s: %v", namespace, err)
-	}
-	return nil
-}
-
-// IsNamespace checks wherher a namespace exists
-func IsNamespace(namespace string) (bool, error) {
-	ns, err := kubernetes.NamespaceC(kubeClient).Fetch(namespace)
-	if err != nil {
-		return false, fmt.Errorf("Cannot create namespace %s: %v", namespace, err)
-	}
-	return ns != nil, nil
-}
-
-// OperateOnNamespaceIfExists do some operations on the namespace if that one exists
-func OperateOnNamespaceIfExists(namespace string, operate func(namespace string) error) error {
-	if ok, er := IsNamespace(namespace); er != nil {
-		return fmt.Errorf("Error while checking namespace: %v", er)
-	} else if ok {
-		return operate(namespace)
-	}
-	return nil
-}
-
 // WaitForPodsWithLabel waits for pods with specific label to be available and running
 func WaitForPodsWithLabel(namespace, labelName, labelValue string, numberOfPods, timeoutInMin int) error {
 	return WaitForOnOpenshift(namespace, fmt.Sprintf("Pods with label name '%s' and value '%s' available and running", labelName, labelValue), timeoutInMin,
@@ -143,7 +103,7 @@ func IsPodRunning(pod *corev1.Pod) bool {
 }
 
 // IsPodStatusConditionReady returns true if all pod's containers are ready (really running)
-func IsPodStatusConditionReady(pod *corev1.Pod) bool{
+func IsPodStatusConditionReady(pod *corev1.Pod) bool {
 	for _, condition := range pod.Status.Conditions {
 		if condition.Type == corev1.ContainersReady {
 			return condition.Status == corev1.ConditionTrue

--- a/test/framework/namespace.go
+++ b/test/framework/namespace.go
@@ -1,0 +1,128 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	namespaceLogFile = "logs/namespace_history.log"
+	fileFlags        = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+	permissionMode   = 0666
+)
+
+// CreateNamespace creates a new namespace
+func CreateNamespace(namespace string) error {
+	GetLogger(namespace).Infof("Create namespace %s", namespace)
+	_, err := kubernetes.NamespaceC(kubeClient).Create(namespace)
+	if err != nil {
+		return fmt.Errorf("Cannot create namespace %s: %v", namespace, err)
+	}
+	onNamespacePostCreated(namespace)
+	return nil
+}
+
+// DeleteNamespace deletes a namespace
+func DeleteNamespace(namespace string) error {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	GetLogger(namespace).Infof("Delete namespace %s", namespace)
+	err := kubernetes.ResourceC(kubeClient).Delete(ns)
+	if err != nil {
+		return fmt.Errorf("Cannot delete namespace %s: %v", namespace, err)
+	}
+	onNamespacePostDeleted(namespace)
+	return nil
+}
+
+// IsNamespace checks wherher a namespace exists
+func IsNamespace(namespace string) (bool, error) {
+	ns, err := kubernetes.NamespaceC(kubeClient).Fetch(namespace)
+	if err != nil {
+		return false, fmt.Errorf("Cannot create namespace %s: %v", namespace, err)
+	}
+	return ns != nil, nil
+}
+
+// OperateOnNamespaceIfExists do some operations on the namespace if that one exists
+func OperateOnNamespaceIfExists(namespace string, operate func(namespace string) error) error {
+	if ok, er := IsNamespace(namespace); er != nil {
+		return fmt.Errorf("Error while checking namespace: %v", er)
+	} else if ok {
+		return operate(namespace)
+	}
+	return nil
+}
+
+// GetNamespacesInHistory retrieves all the namespaces in the history.
+func GetNamespacesInHistory() []string {
+	input, err := ioutil.ReadFile(namespaceLogFile)
+	if err != nil {
+		// file does not exist
+		return []string{}
+	}
+
+	return strings.Split(string(input), "\n")
+}
+
+// ClearNamespaceHistory clears all the namespace history content.
+func ClearNamespaceHistory() {
+	os.Remove(namespaceLogFile)
+}
+
+func onNamespacePostCreated(namespace string) {
+	if err := addNamespaceToHistory(namespace); err != nil {
+		GetLogger(namespace).Warnf("Error updating namespace history %v", err)
+	}
+}
+
+func onNamespacePostDeleted(namespace string) {
+	if err := removeNamespaceFromHistory(namespace); err != nil {
+		GetLogger(namespace).Warnf("Error removing namespace of history %v", err)
+	}
+}
+
+func addNamespaceToHistory(namespace string) error {
+	file, err := os.OpenFile(namespaceLogFile, fileFlags, permissionMode)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if _, err = file.WriteString(fmt.Sprintf("%s\n", namespace)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func removeNamespaceFromHistory(namespace string) error {
+	namespaces := GetNamespacesInHistory()
+	var newNamespaces []string
+	for _, oldNamespace := range namespaces {
+		if namespace != oldNamespace {
+			newNamespaces = append(newNamespaces, oldNamespace)
+		}
+	}
+
+	output := strings.Join(newNamespaces, "\n")
+	return ioutil.WriteFile(namespaceLogFile, []byte(output), permissionMode)
+}

--- a/test/scripts/prune_namespaces.go
+++ b/test/scripts/prune_namespaces.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/kiegroup/kogito-cloud-operator/test/framework"
+
+func main() {
+	namespaces := framework.GetNamespacesInHistory()
+	for _, namespace := range namespaces {
+		if len(namespace) > 0 {
+			framework.DeleteNamespace(namespace)
+		}
+	}
+
+	framework.ClearNamespaceHistory()
+}


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/KOGITO-2192
Description: Create a namespace history log to delete the namespaces in case of test framework didn't end well and therefore it could not delete it.

Requirements:
- Create history file
- Append the namespaces to the history file (for parallel test executions)
- Delete namespace from history in case of the test deleted the namespace
- Provide an utility go function to prune the rest of namespaces from history

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster