### PR TITLE
KOGITO-1613: Cucumber tests: Test upload source files (dmn, drl, bpmn…

### DIFF
--- a/pkg/client/openshift/buildconfig.go
+++ b/pkg/client/openshift/buildconfig.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	checkBcRetries         = 4
+	checkBcRetries         = 30
 	checkBcRetriesInterval = 2 * time.Second
 )
 

--- a/test/features/deploy_source_files.feature
+++ b/test/features/deploy_source_files.feature
@@ -1,0 +1,51 @@
+@cli
+Feature: Deploy source files (dmn, drl, bpmn, bpmn2, ...) with CLI
+
+  Background:
+    Given Namespace is created
+    And Kogito Operator is deployed
+
+  @smoke
+  Scenario: Deploy .dmn source files with CLI
+    Given Clone Kogito examples into local directory
+    
+    When Deploy file "Traffic Violation.dmn" from example service "dmn-quarkus-example"
+    And Build "dmn-quarkus-example-builder" is complete after 10 minutes
+
+    Then HTTP POST request on service "dmn-quarkus-example" is successful within 2 minutes with path "Traffic Violation" and body:
+      """json
+      {
+          "Driver":{"Points":2},
+          "Violation":{
+              "Type":"speed",
+              "Actual Speed":120,
+              "Speed Limit":100
+          }
+      }
+      """
+  
+  Scenario: Deploy .bpmn source files with CLI
+    Given Clone Kogito examples into local directory
+    
+    When Deploy file "org/acme/travels/scripts.bpmn" from example service "process-scripts-quarkus"
+    And Build "process-scripts-quarkus-builder" is complete after 10 minutes
+
+    Then HTTP POST request on service "process-scripts-quarkus" is successful within 2 minutes with path "scripts" and body:
+      """json
+      {
+          "name" : "john"
+      }
+      """
+
+  Scenario: Deploy source files in folder with CLI
+    Given Clone Kogito examples into local directory
+    
+    When Deploy folder from example service "process-timer-quarkus"
+    And Build "process-timer-quarkus-builder" is complete after 10 minutes
+
+    Then HTTP POST request on service "process-timer-quarkus" is successful within 2 minutes with path "timers" and body:
+      """json
+      {
+          "delay" : "PT30S"
+      }
+      """

--- a/test/framework/kogitodeployfiles.go
+++ b/test/framework/kogitodeployfiles.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/test/config"
+)
+
+// DeploySourceFilesFromPath deploys source files from a path
+func DeploySourceFilesFromPath(namespace, serviceName, path string) error {
+	GetLogger(namespace).Infof("Deploy example %s with source files in path %s", serviceName, path)
+
+	cmd := []string{"deploy-service", serviceName, path}
+
+	if buildImageVersion := config.GetBuildImageVersion(); len(buildImageVersion) > 0 {
+		cmd = append(cmd, "--image-version", buildImageVersion)
+	}
+
+	_, err := ExecuteCliCommandInNamespace(namespace, cmd...)
+	return err
+}

--- a/test/steps/data.go
+++ b/test/steps/data.go
@@ -53,6 +53,7 @@ func (data *Data) RegisterAllSteps(s *godog.Suite) {
 	registerPrometheusSteps(s, data)
 	registerProcessSteps(s, data)
 	registerTaskSteps(s, data)
+	registerKogitoDeployFilesSteps(s, data)
 }
 
 // BeforeScenario configure the data before a scenario is launched

--- a/test/steps/deploy_files.go
+++ b/test/steps/deploy_files.go
@@ -1,0 +1,42 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package steps
+
+import (
+	"fmt"
+
+	"github.com/cucumber/godog"
+	"github.com/kiegroup/kogito-cloud-operator/test/framework"
+)
+
+const sourceLocation = "src/main/resources"
+
+func registerKogitoDeployFilesSteps(s *godog.Suite, data *Data) {
+	// Deploy steps
+	s.Step(`^Deploy file "([^"]*)" from example service "([^"]*)"$`, data.deployFileFromExampleService)
+	s.Step(`^Deploy folder from example service "([^"]*)"$`, data.deployFolderFromExampleService)
+}
+
+// Deploy steps
+
+func (data *Data) deployFileFromExampleService(file, serviceName string) error {
+	sourceFilePath := fmt.Sprintf(`%s/%s/%s/%s`, data.KogitoExamplesLocation, serviceName, sourceLocation, file)
+	return framework.DeploySourceFilesFromPath(data.Namespace, serviceName, sourceFilePath)
+}
+
+func (data *Data) deployFolderFromExampleService(serviceName string) error {
+	sourceFolderPath := fmt.Sprintf(`%s/%s/%s`, data.KogitoExamplesLocation, serviceName, sourceLocation)
+	return framework.DeploySourceFilesFromPath(data.Namespace, serviceName, sourceFolderPath)
+}


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/KOGITO-1613
Description: With https://issues.redhat.com/browse/KOGITO-256, new functionality has been introduced to upload application from source files (dmn, drl, bpmn, bpmn2) with CLI

Covered:
- Test with DMN
- Test with BPMN
- Test with folders that contain properties and bpmn files altogether

In order to also cover DRL and/or BPMN2, we would need to create a new kogito example that does not require any Java sources.

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster