### PR TITLE
[KOGITO-1729] Consolidate HTTP Request parameters into one struct type

### DIFF
--- a/test/framework/process.go
+++ b/test/framework/process.go
@@ -16,12 +16,14 @@ package framework
 
 // StartProcess starts new process instance
 func StartProcess(namespace, routeURI, processName, bodyFormat, bodyContent string) (err error) {
-	_, err = ExecuteHTTPRequest(namespace, "POST", routeURI, processName, bodyFormat, bodyContent)
+	requestInfo := NewPOSTHTTPRequestInfo(routeURI, processName, bodyFormat, bodyContent)
+	_, err = ExecuteHTTPRequest(namespace, requestInfo)
 	return
 }
 
 // GetProcessInstances retrieves process instance of process name
 func GetProcessInstances(namespace, routeURI, processName string) (foundProcessInstances []map[string]interface{}, err error) {
-	err = ExecuteHTTPRequestWithUnmarshalledResponse(namespace, "GET", routeURI, processName, "", "", &foundProcessInstances)
+	requestInfo := NewGETHTTPRequestInfo(routeURI, processName)
+	err = ExecuteHTTPRequestWithUnmarshalledResponse(namespace, requestInfo, &foundProcessInstances)
 	return
 }

--- a/test/framework/task.go
+++ b/test/framework/task.go
@@ -22,14 +22,16 @@ import (
 // GetTasks retrieves tasks of specific process instance
 func GetTasks(namespace, routeURI, processName, processInstanceID string) (foundTasks map[string]string, err error) {
 	tasksEndpointPath := getTasksEndpointPath(processName, processInstanceID)
-	err = ExecuteHTTPRequestWithUnmarshalledResponse(namespace, "GET", routeURI, tasksEndpointPath, "", "", &foundTasks)
+	requestInfo := NewGETHTTPRequestInfo(routeURI, tasksEndpointPath)
+	err = ExecuteHTTPRequestWithUnmarshalledResponse(namespace, requestInfo, &foundTasks)
 	return
 }
 
 // GetTasksByUser retrieves tasks of specific process instance and user
 func GetTasksByUser(namespace, routeURI, processName, processInstanceID, user string) (foundTasks map[string]string, err error) {
 	tasksEndpointPath := getTasksEndpointPath(processName, processInstanceID) + "?user=" + user
-	err = ExecuteHTTPRequestWithUnmarshalledResponse(namespace, "GET", routeURI, tasksEndpointPath, "", "", &foundTasks)
+	requestInfo := NewGETHTTPRequestInfo(routeURI, tasksEndpointPath)
+	err = ExecuteHTTPRequestWithUnmarshalledResponse(namespace, requestInfo, &foundTasks)
 	return
 }
 
@@ -46,7 +48,8 @@ func CompleteTaskByUser(namespace, routeURI, processName, processInstanceID, tas
 }
 
 func completeTask(namespace, routeURI, taskEndpointPath, bodyFormat, bodyContent string) (err error) {
-	_, err = ExecuteHTTPRequest(namespace, "POST", routeURI, taskEndpointPath, bodyFormat, bodyContent)
+	requestInfo := NewPOSTHTTPRequestInfo(routeURI, taskEndpointPath, bodyFormat, bodyContent)
+	_, err = ExecuteHTTPRequest(namespace, requestInfo)
 	return
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-1729

JIRA was created as a result of the feedback in https://github.com/kiegroup/kogito-cloud-operator/pull/257#discussion_r403309366.

Things to discuss:

1. Name of the struct is `HTTPRequestInfo`.
I didn't want to name it `HTTPRequest` as then the parameter name, e.g. `request`, would clash with the actual request from Go's http package and it would be confusing in methods like for example here:
https://github.com/kiegroup/kogito-cloud-operator/blob/e9069757dcc2fa0068019cc3a76d49a90719f139/test/framework/http.go#L53-L56 I was also considering `HTTPRequestData` but this isn't just data and `HTTPRequestMetaData` but that's too long. The parameter would then need to be something like `requestMetaData` etc.

1. I think the goal of the JIRA was achieved, HTTP methods have much shorter signatures now, but now we need to call the constructor to create an `HTTPRequestInfo` struct each time we want to issue a request. Also some logging methods are now longer as struct fields needs to be accessed using the prefix.

1. I have also found a small bug, so I decided to fix that:
https://github.com/kiegroup/kogito-cloud-operator/blob/e9069757dcc2fa0068019cc3a76d49a90719f139/test/steps/http.go#L91-L92

Many thanks for submiting your Pull Request :heart: :racing_car:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster