### PR TITLE
[KOGITO-2350] Cleanup stuck namespaces (infinispan)

### DIFF
--- a/hack/clean-stuck-namespaces.sh
+++ b/hack/clean-stuck-namespaces.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+DIR=$(mktemp -d)
+
+oc get projects | grep "Terminating" | awk -F " " '{print $1}' > ${DIR}/projects
+
+while read project
+do 
+	echo "Stuck project ${project}"
+
+    oc get infinispan -n "${project}" | grep -v "NAME" | awk -F " " '{print $1}' > ${DIR}/infinispan-instances
+    while read infinispan
+    do
+        echo "Remove finalizer from infinispan ${infinispan} from project ${project}"
+
+        oc get infinispan ${infinispan} -o yaml -n ${project} | grep -v "finalizer" > ${DIR}/infinispan
+        oc replace -f ${DIR}/infinispan -n ${project}
+    done < ${DIR}/infinispan-instances
+done < ${DIR}/projects
+
+echo "Projects deleted:"
+cat ${DIR}/projects
+
+# Cleanup
+rm ${DIR}/projects
+rm ${DIR}/infinispan-instances
+rm ${DIR}/infinispan

--- a/hack/run-tests.sh
+++ b/hack/run-tests.sh
@@ -391,4 +391,7 @@ if [ "${KEEP_NAMESPACE}" = "false" ]; then
   cd -
 fi
 
+echo "-------- Delete stucked namespaces"
+${SCRIPT_DIR}/clean-stuck-namespaces.sh
+
 exit ${exit_code}


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2350

Script is called after tests are run and namespaces are pruned

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster