### PR TITLE
[KOGITO-2358] Add a scenario for optaplanner-quarkus on OpenShift

### DIFF
--- a/test/features/deploy_kogito_runtime.feature
+++ b/test/features/deploy_kogito_runtime.feature
@@ -14,7 +14,7 @@ Feature: Deploy Kogito Runtime
 
     When Deploy <runtime> example service using image in variable "built-image" with configuration:
       | config | persistence | disabled |
-    
+
     Then Kogito Runtime "<example-service>" has 1 pods running within 10 minutes
     And Service "<example-service>" with process name "orders" is available within 2 minutes
 
@@ -49,14 +49,14 @@ Feature: Deploy Kogito Runtime
     And Start "orders" process on service "<example-service>" within 3 minutes with body:
       """json
       {
-        "approver" : "john", 
+        "approver" : "john",
         "order" : {
-          "orderNumber" : "12345", 
+          "orderNumber" : "12345",
           "shipped" : false
         }
       }
       """
-    
+
     Then Service "<example-service>" contains 1 instances of process with name "orders"
 
     When Scale Kogito Runtime "<example-service>" to 0 pods within 2 minutes
@@ -97,14 +97,14 @@ Feature: Deploy Kogito Runtime
     And Start "orders" process on service "<example-service>" within 3 minutes with body:
       """json
       {
-        "approver" : "john", 
+        "approver" : "john",
         "order" : {
-          "orderNumber" : "12345", 
+          "orderNumber" : "12345",
           "shipped" : false
         }
       }
       """
-    
+
     Then GraphQL request on Data Index service returns ProcessInstances processName "orders" within 2 minutes
 
     @springboot
@@ -122,3 +122,39 @@ Feature: Deploy Kogito Runtime
     Examples:
       | runtime    | example-service         | profile                   |
       | quarkus    | process-quarkus-example | native,persistence,events |
+
+#####
+
+  Scenario Outline: Deploy process-optaplanner-quarkus service without persistence
+    Given Kogito Operator is deployed
+    And Clone Kogito examples into local directory
+    And Local example service "<example-service>" is built by Maven using profile "<profile>"
+    And Local example service "<example-service>" is deployed to image registry, image tag stored as variable "built-image"
+
+    When Deploy <runtime> example service using image in variable "built-image" with configuration:
+      | config | persistence | disabled |
+
+    Then Kogito Runtime "<example-service>" has 1 pods running within 10 minutes
+    And HTTP POST request on service "<example-service>" is successful within 2 minutes with path "rest/flights" and body:
+      """json
+      {
+        "params" : {
+          "origin" : "A",
+          "destination" : "B",
+          "departureDateTime" : "2020-05-30T17:30:43.873968",
+          "seatRowSize" : 6,
+          "seatColumnSize" : 10
+        }
+      }
+      """
+
+    @quarkus
+    Examples:
+      | runtime    | example-service             | profile |
+      | quarkus    | process-optaplanner-quarkus | default |
+
+    @quarkus
+    @native
+    Examples:
+      | runtime    | example-service             | profile |
+      | quarkus    | process-optaplanner-quarkus | native  |


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2358

Adds a new scenario that deploys the optaplanner-quarkus example to OpenShift via the operator and checks the application is responding. 

Motivation: we have similar scenarios for a couple of other examples, but until now any automated end-to-end check for OptaPlanner has been missing.

Sorry for the extra changes due to formatting (automatic removal of trailing spaces done by IDE).

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster


