### PR TITLE
[KOGITO-2428] clean-stuck-namespaces.sh script not compatible with Ku…

### DIFF
--- a/hack/clean-stuck-namespaces.sh
+++ b/hack/clean-stuck-namespaces.sh
@@ -16,7 +16,7 @@
 
 DIR=$(mktemp -d)
 
-oc get projects | grep "Terminating" | awk -F " " '{print $1}' > ${DIR}/projects
+oc get namespaces | grep "Terminating" | awk -F " " '{print $1}' > ${DIR}/projects
 
 while read project
 do 


### PR DESCRIPTION
…bernetes

https://issues.redhat.com/browse/KOGITO-2428

Signed-off-by: Karel Suta <ksuta@redhat.com>

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster