### PR TITLE
[KOGITO-2524] - Renaming install script command to fit k8s docs 

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -16,13 +16,15 @@
 EXIT=0
 FILE_FOUND=0
 
+if [ -z "${NAMESPACE}" ]; then
+  NAMESPACE="kogito"
+fi
+
 shopt -s nullglob
-for file in deploy/{crds/*_crd.yaml,*.yaml}
-do
+for file in deploy/{crds/*_crd.yaml,*.yaml}; do
   FILE_FOUND=1
-  oc apply -f "$file"
-  if [[ $? -gt 0 ]]; then
-    EXIT=$?
+  if ! kubectl apply -f "$file" -n "${NAMESPACE}"; then
+    EXIT=1
     break # Don't try other files if one fails
   fi
 done


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-2524

Small renaming to fit the [docs description](https://docs.jboss.org/kogito/release/latest/html_single/#proc-kogito-deploying-on-kubernetes_kogito-deploying-on-openshift).

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster