### PR TITLE
[KOGITO-2404] Fix WARN when registering OpenShift components on k8s

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -46,6 +46,11 @@ var (
 	log = logger.GetLogger("client_api")
 )
 
+const (
+	// OpenShiftGroupName name included in OpenShift APIs
+	OpenShiftGroupName = "openshift.io"
+)
+
 // Client wraps clients functions from controller-runtime, Kube and OpenShift cli for generic API calls to the cluster
 type Client struct {
 	// ControlCli is a reference for the controller-runtime client, normally built by a Manager inside the controller context.
@@ -79,7 +84,7 @@ func NewForController(config *restclient.Config, client controllercli.Client) *C
 
 // IsOpenshift detects if the application is running on OpenShift or not
 func (c *Client) IsOpenshift() bool {
-	return c.HasServerGroup("openshift.io")
+	return c.HasServerGroup(OpenShiftGroupName)
 }
 
 // HasServerGroup detects if the given api group is supported by the server

--- a/pkg/framework/controller_watcher.go
+++ b/pkg/framework/controller_watcher.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"strings"
 )
 
 // WatchedObjects objects that the controller supposed to watch for
@@ -98,7 +99,10 @@ func (c *controllerWatcher) Watch(watchedObjects ...WatchedObjects) (err error) 
 				delete(c.groupsNotWatched, object.GroupVersion.Group)
 			} else {
 				c.groupsNotWatched[object.GroupVersion.Group] = true
-				log.Warnf("Impossible to register GroupVersion %s. CRD not installed in the cluster, controller might not behave as expected", object.GroupVersion)
+				// warn only for CRDs that are not in the OpenShift group
+				if !strings.Contains(object.GroupVersion.Group, client.OpenShiftGroupName) {
+					log.Warnf("Impossible to register GroupVersion %s. CRD not installed in the cluster, controller might not behave as expected", object.GroupVersion)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-2404

Small fix to do not show WARN messages about OpenShift objects not being registered.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster