### PR TITLE
KOGITO-2438: Cover Port changes configuration for Kogito services

### DIFF
--- a/pkg/apis/app/v1alpha1/kogitoservices_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoservices_types.go
@@ -112,6 +112,7 @@ type KogitoServiceSpecInterface interface {
 	GetRuntime() RuntimeType
 	//Define port on which service will listen internally
 	GetHTTPPort() int32
+	SetHTTPPort(httpPort int32)
 	IsInsecureImageRegistry() bool
 }
 
@@ -195,6 +196,9 @@ func (k *KogitoServiceSpec) SetResources(resources corev1.ResourceRequirements) 
 
 // GetHTTPPort ...
 func (k *KogitoServiceSpec) GetHTTPPort() int32 { return k.HTTPPort }
+
+// SetHTTPPort ...
+func (k *KogitoServiceSpec) SetHTTPPort(httpPort int32) { k.HTTPPort = httpPort }
 
 // AddEnvironmentVariable adds new environment variable to service environment variables.
 func (k *KogitoServiceSpec) AddEnvironmentVariable(name, value string) {

--- a/test/features/update_httpport.feature
+++ b/test/features/update_httpport.feature
@@ -1,0 +1,57 @@
+Feature: Update the HTTP Port field in Kogito Services
+
+  Background:
+    Given Namespace is created
+
+  @jobsservice
+  Scenario: Update HTTP Port for Jobs Service
+    Given Kogito Operator is deployed
+    When Install Kogito Jobs Service with 1 replicas with configuration:
+      | config | httpPort | 9081 |
+    Then Kogito Jobs Service has 1 pods running within 10 minutes
+
+  @dataindex
+  @infinispan
+  @kafka
+  Scenario: Update HTTP Port for Data Index Service
+    Given Kogito Operator is deployed with Infinispan and Kafka operators
+    When Install Kogito Data Index with 1 replicas with configuration:
+      | config | httpPort | 9082 |
+    Then Kogito Data Index has 1 pods running within 10 minutes
+
+  @managementconsole
+  @infinispan
+  @kafka
+  Scenario: Update HTTP Port for Management Console
+    Given Kogito Operator is deployed with Infinispan and Kafka operators
+    And Kogito Data Index has 1 pods running within 10 minutes
+    When Install Kogito Management Console with 1 replicas with configuration:
+      | config | httpPort | 9082 |
+    Then Kogito Management Console has 1 pods running within 10 minutes
+
+  Scenario Outline: Update HTTP Port for Kogito Runtime
+    Given Kogito Operator is deployed
+    And Clone Kogito examples into local directory
+    And Local example service "<example-service>" is built by Maven using profile "<profile>" and deployed to runtime registry
+
+    When Deploy <runtime> example service "<example-service>" from runtime registry with configuration:
+      | infinispan | useKogitoInfra | disabled |
+      | config     | httpPort       | 9082     |
+
+    Then Kogito Runtime "<example-service>" has 1 pods running within 10 minutes
+
+    @springboot
+    Examples:
+      | runtime    | example-service            | profile |
+      | springboot | process-springboot-example | default |
+
+    @quarkus
+    Examples:
+      | runtime    | example-service            | profile |
+      | quarkus    | process-quarkus-example    | default |
+
+    @quarkus
+    @native
+    Examples:
+      | runtime    | example-service            | profile |
+      | quarkus    | process-quarkus-example    | native  |

--- a/test/framework/kogitoserviceutils.go
+++ b/test/framework/kogitoserviceutils.go
@@ -192,6 +192,10 @@ func cliInstall(serviceHolder *KogitoServiceHolder, cliName string) error {
 		}
 	}
 
+	if httpPort := serviceHolder.GetSpec().GetHTTPPort(); httpPort > 0 {
+		cmd = append(cmd, "--http-port", strconv.Itoa(int(httpPort)))
+	}
+
 	_, err := ExecuteCliCommandInNamespace(serviceHolder.GetNamespace(), cmd...)
 	return err
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-2438
Description: All the Kogito Services (Data Index, Jobs Service, Management and runtimes) now includes a new field in KogitoServiceSpec to specify the HTTP port to use.

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster