### PR TITLE
[KOGITO-2611] BDD tests: `otherOptions` append corrected

### DIFF
--- a/test/framework/maven.go
+++ b/test/framework/maven.go
@@ -92,7 +92,7 @@ func (mvnCmd *mavenCommandStruct) Execute(targets ...string) (string, error) {
 		args = append(args, fmt.Sprintf("-P%s", strings.Join(mvnCmd.profiles, ",")))
 	}
 	if len(mvnCmd.otherOptions) > 0 {
-		args = append(args, strings.Join(mvnCmd.otherOptions, " "))
+		args = append(args, mvnCmd.otherOptions...)
 	}
 
 	cmd := CreateCommand(mavenCommandName, args...).InDirectory(mvnCmd.directory)


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2611

Happened indirectly by https://github.com/kiegroup/kogito-cloud-operator/commit/646502b97ec193bb17fe2b4f585b750dc34b6f2d solved the `skipTests` because the append of options should be done all separately and not in a string.
Do not affect PR check as it happens if many `otherOptions`, can be seen when using a specific repository

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster