### PR TITLE
[KOGITO-2688] Removing listType=map from non-required objects

### DIFF
--- a/deploy/crds/app.kiegroup.org_kogitoapps_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitoapps_crd.yaml
@@ -273,9 +273,7 @@ spec:
                         type: string
                     type: object
                   type: array
-                  x-kubernetes-list-map-keys:
-                  - type
-                  x-kubernetes-list-type: map
+                  x-kubernetes-list-type: atomic
               type: object
             deploymentLabels:
               additionalProperties:

--- a/deploy/crds/app.kiegroup.org_kogitobuilds_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitobuilds_crd.yaml
@@ -326,9 +326,7 @@ spec:
                     type: string
                 type: object
               type: array
-              x-kubernetes-list-map-keys:
-              - type
-              x-kubernetes-list-type: map
+              x-kubernetes-list-type: atomic
           required:
           - type
           type: object

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoapps_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoapps_crd.yaml
@@ -273,9 +273,7 @@ spec:
                         type: string
                     type: object
                   type: array
-                  x-kubernetes-list-map-keys:
-                  - type
-                  x-kubernetes-list-type: map
+                  x-kubernetes-list-type: atomic
               type: object
             deploymentLabels:
               additionalProperties:

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitobuilds_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitobuilds_crd.yaml
@@ -326,9 +326,7 @@ spec:
                     type: string
                 type: object
               type: array
-              x-kubernetes-list-map-keys:
-              - type
-              x-kubernetes-list-type: map
+              x-kubernetes-list-type: atomic
           required:
           - type
           type: object

--- a/examples/process-quarkus-example-runtime-build-webhook.yaml
+++ b/examples/process-quarkus-example-runtime-build-webhook.yaml
@@ -1,0 +1,27 @@
+# In this example we create a KogitoBuild responsible to build our service from source and then deploy it as
+# a KogitoRuntime reference. Since they have the same name, they will be bound together through the built image.
+# the WebHook was added as an example
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoBuild
+metadata:
+  name: process-quarkus-example
+spec:
+  buildImage:
+    tag: "0.11"
+  gitSource:
+    contextDir: process-quarkus-example
+    uri: https://github.com/kiegroup/kogito-examples
+  runtime: quarkus
+  runtimeImage:
+    tag: "0.11"
+  type: RemoteSource
+  webHooks:
+    - type: "GitHub"
+      secret: "test123"
+---
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoRuntime
+metadata:
+  name: process-quarkus-example
+spec:
+  replicas: 1

--- a/examples/process-quarkus-example-runtime-build.yaml
+++ b/examples/process-quarkus-example-runtime-build.yaml
@@ -1,4 +1,4 @@
-# In this example we create a KogitoBuild responsible to build our service from service and then deploy it as
+# In this example we create a KogitoBuild responsible to build our service from source and then deploy it as
 # a KogitoRuntime reference. Since they have the same name, they will be bound together through the built image.
 apiVersion: app.kiegroup.org/v1alpha1
 kind: KogitoBuild

--- a/pkg/apis/app/v1alpha1/kogitoapp_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoapp_types.go
@@ -109,8 +109,8 @@ type KogitoAppBuildObject struct {
 	// +optional
 	GitSource GitSource `json:"gitSource,omitempty"`
 	// WebHook secrets for build configs.
-	// +listType=map
-	// +listMapKey=type
+	// +listType=atomic
+	// +optional
 	Webhooks []WebhookSecret `json:"webhooks,omitempty"`
 	// + optional
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true

--- a/pkg/apis/app/v1alpha1/kogitobuild_types.go
+++ b/pkg/apis/app/v1alpha1/kogitobuild_types.go
@@ -73,8 +73,7 @@ type KogitoBuildSpec struct {
 	Runtime RuntimeType `json:"runtime,omitempty"`
 
 	// WebHooks secrets for source to image builds based on Git repositories (Remote Sources).
-	// +listType=map
-	// +listMapKey=type
+	// +listType=atomic
 	// +optional
 	WebHooks []WebhookSecret `json:"webHooks,omitempty"`
 

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -507,10 +507,7 @@ func schema_pkg_apis_app_v1alpha1_KogitoAppBuildObject(ref common.ReferenceCallb
 					"webhooks": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-map-keys": []interface{}{
-									"type",
-								},
-								"x-kubernetes-list-type": "map",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See:
https://issues.redhat.com/browse/KOGITO-2688

This needs to be on 0.12.0, otherwise users will fail to install all the CRDs in Kubernetes 1.18, like the newer minikube.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster