### PR TITLE
[KOGITO-2795] Update bump-version.sh script

### DIFF
--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -13,39 +13,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source ./hack/export-version.sh
 
-old_version=$1
-new_version=$2
-
-if [ -z "$old_version" ]; then
-    echo "Please inform the old version. Use X.X.X"
-    exit 1
-fi
-
+old_version=${OP_VERSION}
+new_version=$1
+release=$2
+no_release_branch=$3
 
 if [ -z "$new_version" ]; then
     echo "Please inform the new version. Use X.X.X"
     exit 1
 fi
 
-sed -i "s/$old_version/$new_version/g" cmd/kogito/version/version.go README.md version/version.go deploy/operator.yaml deploy/olm-catalog/kogito-operator/kogito-operator.package.yaml hack/go-build.sh hack/go-vet.sh .osdk-scorecard.yaml
-operator-sdk generate csv --apis-dir ./pkg/apis/apps/v1alpha1 --verbose --csv-version "$new_version" --from-version "$old_version"  --update-crds --operator-name kogito-operator
+sed -i "s/$old_version/$new_version/g" cmd/kogito/version/version.go README.md version/version.go deploy/operator.yaml deploy/olm-catalog/kogito-operator/kogito-operator.package.yaml deploy/olm-catalog/kogito-operator/custom-subscription-example.yaml hack/go-build.sh hack/go-vet.sh .osdk-scorecard.yaml
+operator-sdk generate csv --apis-dir ./pkg/apis/apps/v1alpha1 --verbose --csv-version "$new_version" --from-version "$old_version" --update-crds --operator-name kogito-operator
+sed -i "s|operated-by: kogito-operator.*|operated-by: kogito-operator.${new_version}|g" deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
 
 # rewrite test default config, all other configuration into the file will be overridden
 test_config_file="test/.default_config"
 current_branch=`git branch --show-current`
 
-if [ "${current_branch}" = "master" ]; then
-    image_version="latest"
-    branch="${current_branch}"
-else
+if [ "${release}" = "true" ]; then
     image_version=`echo "${new_version}" | awk -F. '{print \$1"."\$2}'`
-    branch="${image_version}.x"
+    if [ "${no_release_branch}" = "true" ]; then
+        branch="master"
+    else
+        branch="${image_version}.x"
+    fi
+else
+    image_version="latest"
+    branch="master"
 fi
 
-rm ${test_config_file}
-echo "tests.build-image-version=${image_version}" >> ${test_config_file}
-echo "tests.services-image-version=${image_version}" >> ${test_config_file}
-echo "tests.examples-ref=${branch}" >> ${test_config_file}
+sed -i "s|tests.build-image-version=.*|tests.build-image-version=${image_version}|g" ${test_config_file}
+sed -i "s|tests.services-image-version=.*|tests.services-image-version=${image_version}|g" ${test_config_file}
+sed -i "s|tests.runtime-application-image-version=.*|tests.runtime-application-image-version=${image_version}|g" ${test_config_file}
+sed -i "s|tests.examples-ref=.*|tests.examples-ref=${branch}|g" ${test_config_file}
 
 echo "Version bumped from $old_version to $new_version"


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2795

The script guess the `oldVersion` from `./hack/export-version.sh` script.
Also, test config is set depending on `release` parameter or not.

Normal change of version:
```
./hack/bump-version.sh 0.14.0
```
It should set test config to `latest` and `master`.

Release change of version:
```
./hack/bump-version.sh 0.14.0 true
```
It should set the test config according to the given version: branch `0.14.x` and version to `0.14.0`

If no release branch has been created, use:
```
./hack/bump-version.sh 0.14.0 true true
```
and it will keep the examples-ref on master

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster