### PR TITLE
[KOGITO-2797] - Fixing Deployment comparator

### DIFF
--- a/pkg/framework/comparator.go
+++ b/pkg/framework/comparator.go
@@ -161,7 +161,7 @@ func sortVolumes(pod *v1.PodSpec) {
 	})
 	for _, c := range pod.Containers {
 		sort.SliceStable(c.VolumeMounts, func(i, j int) bool {
-			return c.VolumeMounts[i].Name < c.VolumeMounts[j].Name
+			return c.VolumeMounts[i].MountPath < c.VolumeMounts[j].MountPath
 		})
 	}
 }

--- a/pkg/framework/comparator.go
+++ b/pkg/framework/comparator.go
@@ -18,11 +18,12 @@ import (
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
-	imgv1 "github.com/openshift/api/image/v1"
-
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
+	imgv1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	apps "k8s.io/api/apps/v1"
+	"sort"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -117,6 +118,9 @@ func containAllLabels(deployed resource.KubernetesResource, requested resource.K
 // CreateDeploymentConfigComparator creates a new comparator for DeploymentConfig using Trigger and RollingParams
 func CreateDeploymentConfigComparator() func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
 	return func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+		sortVolumes(&deployed.(*appsv1.DeploymentConfig).Spec.Template.Spec)
+		sortVolumes(&requested.(*appsv1.DeploymentConfig).Spec.Template.Spec)
+
 		dcDeployed := deployed.(*appsv1.DeploymentConfig)
 		dcRequested := requested.(*appsv1.DeploymentConfig).DeepCopy()
 
@@ -136,6 +140,26 @@ func CreateDeploymentConfigComparator() func(deployed resource.KubernetesResourc
 			dcDeployed.Spec.Strategy.RollingParams = dcRequested.Spec.Strategy.RollingParams
 		}
 		return true
+	}
+}
+
+// CreateDeploymentComparator creates a new comparator for Deployment sorting volumes
+func CreateDeploymentComparator() func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	return func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+		sortVolumes(&deployed.(*apps.Deployment).Spec.Template.Spec)
+		sortVolumes(&requested.(*apps.Deployment).Spec.Template.Spec)
+
+		return true
+	}
+}
+
+// sortVolumes sorts the volumes of a given PodSpec (can be used either by a Deployment or DeploymentConfig objects)
+// TODO: open a PR to operatorutils fixing this once we verify KOGITO-2797
+func sortVolumes(pod *v1.PodSpec) {
+	for _, c := range pod.Containers {
+		sort.SliceStable(c.VolumeMounts, func(i, j int) bool {
+			return c.VolumeMounts[i].Name < c.VolumeMounts[j].Name
+		})
 	}
 }
 

--- a/pkg/framework/comparator.go
+++ b/pkg/framework/comparator.go
@@ -156,6 +156,9 @@ func CreateDeploymentComparator() func(deployed resource.KubernetesResource, req
 // sortVolumes sorts the volumes of a given PodSpec (can be used either by a Deployment or DeploymentConfig objects)
 // TODO: open a PR to operatorutils fixing this once we verify KOGITO-2797
 func sortVolumes(pod *v1.PodSpec) {
+	sort.SliceStable(pod.Volumes, func(i, j int) bool {
+		return pod.Volumes[i].Name < pod.Volumes[j].Name
+	})
 	for _, c := range pod.Containers {
 		sort.SliceStable(c.VolumeMounts, func(i, j int) bool {
 			return c.VolumeMounts[i].Name < c.VolumeMounts[j].Name

--- a/pkg/framework/comparator_test.go
+++ b/pkg/framework/comparator_test.go
@@ -450,6 +450,10 @@ func Test_CreateDeploymentComparator(t *testing.T) {
 					Spec: apps.DeploymentSpec{
 						Template: v1.PodTemplateSpec{
 							Spec: v1.PodSpec{
+								Volumes: []v1.Volume {
+									{Name: "volume1"},
+									{Name: "volume2"},
+								},
 								Containers: []v1.Container{
 									{
 										VolumeMounts: []v1.VolumeMount{
@@ -472,6 +476,10 @@ func Test_CreateDeploymentComparator(t *testing.T) {
 					Spec: apps.DeploymentSpec{
 						Template: v1.PodTemplateSpec{
 							Spec: v1.PodSpec{
+								Volumes: []v1.Volume {
+									{Name: "volume2"},
+									{Name: "volume1"},
+								},
 								Containers: []v1.Container{
 									{
 										// notice the array order, that matters

--- a/pkg/framework/comparator_test.go
+++ b/pkg/framework/comparator_test.go
@@ -450,7 +450,7 @@ func Test_CreateDeploymentComparator(t *testing.T) {
 					Spec: apps.DeploymentSpec{
 						Template: v1.PodTemplateSpec{
 							Spec: v1.PodSpec{
-								Volumes: []v1.Volume {
+								Volumes: []v1.Volume{
 									{Name: "volume1"},
 									{Name: "volume2"},
 								},
@@ -476,7 +476,7 @@ func Test_CreateDeploymentComparator(t *testing.T) {
 					Spec: apps.DeploymentSpec{
 						Template: v1.PodTemplateSpec{
 							Spec: v1.PodSpec{
-								Volumes: []v1.Volume {
+								Volumes: []v1.Volume{
 									{Name: "volume2"},
 									{Name: "volume1"},
 								},

--- a/pkg/framework/comparator_test.go
+++ b/pkg/framework/comparator_test.go
@@ -503,6 +503,82 @@ func Test_CreateDeploymentComparator(t *testing.T) {
 			reflect.TypeOf(apps.Deployment{}),
 			true,
 		},
+		{
+			"Equals Volumes Mount Path",
+			args{
+				deployed: &apps.Deployment{
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Volumes: []v1.Volume{
+									{Name: "app-prop-config"},
+									{Name: "process-quarkus-example-protobuf-files"},
+								},
+								Containers: []v1.Container{
+									{
+										VolumeMounts: []v1.VolumeMount{
+											{
+												Name:      "app-prop-config",
+												MountPath: "/home/kogito/config",
+											},
+											{
+												Name:      "process-quarkus-example-protobuf-files",
+												MountPath: "/home/kogito/data/protobufs/process-quarkus-example/demo.orders.proto",
+											},
+											{
+												Name:      "process-quarkus-example-protobuf-files",
+												MountPath: "/home/kogito/data/protobufs/process-quarkus-example/kogito-application.proto",
+											},
+											{
+												Name:      "process-quarkus-example-protobuf-files",
+												MountPath: "/home/kogito/data/protobufs/process-quarkus-example/persons.proto",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				requested: &apps.Deployment{
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Volumes: []v1.Volume{
+									{Name: "app-prop-config"},
+									{Name: "process-quarkus-example-protobuf-files"},
+								},
+								Containers: []v1.Container{
+									{
+										// notice the array order, that matters. using logs from KOGITO-2797 bug report
+										VolumeMounts: []v1.VolumeMount{
+											{
+												Name:      "app-prop-config",
+												MountPath: "/home/kogito/config",
+											},
+											{
+												Name:      "process-quarkus-example-protobuf-files",
+												MountPath: "/home/kogito/data/protobufs/process-quarkus-example/kogito-application.proto",
+											},
+											{
+												Name:      "process-quarkus-example-protobuf-files",
+												MountPath: "/home/kogito/data/protobufs/process-quarkus-example/persons.proto",
+											},
+											{
+												Name:      "process-quarkus-example-protobuf-files",
+												MountPath: "/home/kogito/data/protobufs/process-quarkus-example/demo.orders.proto",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reflect.TypeOf(apps.Deployment{}),
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/infrastructure/services/resources.go
+++ b/pkg/infrastructure/services/resources.go
@@ -296,6 +296,7 @@ func (s *serviceDeployer) getComparator() compare.MapComparator {
 		framework.NewComparatorBuilder().
 			WithType(reflect.TypeOf(appsv1.Deployment{})).
 			UseDefaultComparator().
+			WithCustomComparator(framework.CreateDeploymentComparator()).
 			Build())
 
 	resourceComparator.SetComparator(


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-2797

In this PR we introduce a fix to the `Deployment` and `DeploymentComparator` to avoid infinite reconciliation triggers when reading a given volume.

@sutaakar I wasn't able to test on a cluster yet, could you please give it a quick try? Also, do you think it's feasible to have a BDD test for this scenario as well? I think it's important. Thanks!

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster