### PR TITLE
[KOGITO-2813] - Renaming KogitoApp description to KogitoService, Fixes #462

### DIFF
--- a/deploy/crds/app.kiegroup.org_kogitoapps_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitoapps_crd.yaml
@@ -38,7 +38,10 @@ spec:
   subresources: {}
   validation:
     openAPIV3Schema:
-      description: KogitoApp is a project prescription running a Kogito service.
+      description: 'KogitoApp is a project prescription running a Kogito service (it''s
+        meant to be used to Build and Deploy the application at the same time). KogitoApp
+        is under deprecation, please use a combination of KogitoRuntime and KogitoBuild
+        instead. See: https://issues.redhat.com/browse/KOGITO-1998'
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/deploy/olm-catalog/kogito-operator/0.13.0/app.kiegroup.org_kogitoapps_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/0.13.0/app.kiegroup.org_kogitoapps_crd.yaml
@@ -38,7 +38,10 @@ spec:
   subresources: {}
   validation:
     openAPIV3Schema:
-      description: KogitoApp is a project prescription running a Kogito service.
+      description: 'KogitoApp is a project prescription running a Kogito service (it''s
+        meant to be used to Build and Deploy the application at the same time). KogitoApp
+        is under deprecation, please use a combination of KogitoRuntime and KogitoBuild
+        instead. See: https://issues.redhat.com/browse/KOGITO-1998'
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoapps_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoapps_crd.yaml
@@ -38,7 +38,10 @@ spec:
   subresources: {}
   validation:
     openAPIV3Schema:
-      description: KogitoApp is a project prescription running a Kogito service.
+      description: 'KogitoApp is a project prescription running a Kogito service (it''s
+        meant to be used to Build and Deploy the application at the same time). KogitoApp
+        is under deprecation, please use a combination of KogitoRuntime and KogitoBuild
+        instead. See: https://issues.redhat.com/browse/KOGITO-1998'
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
@@ -115,8 +115,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: KogitoApp is a project prescription running a Kogito service.
-      displayName: Kogito Service
+    - description: 'KogitoApp is a project prescription running a Kogito service (it''s
+        meant to be used to Build and Deploy the application at the same time). KogitoApp
+        is under deprecation, please use a combination of KogitoRuntime and KogitoBuild
+        instead. See: https://issues.redhat.com/browse/KOGITO-1998'
+      displayName: Kogito Application
       kind: KogitoApp
       name: kogitoapps.app.kiegroup.org
       resources:

--- a/pkg/apis/app/v1alpha1/kogitoapp_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoapp_types.go
@@ -295,7 +295,8 @@ type Builds struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// KogitoApp is a project prescription running a Kogito service.
+// KogitoApp is a project prescription running a Kogito service (it's meant to be used to Build and Deploy the application at the same time).
+// KogitoApp is under deprecation, please use a combination of KogitoRuntime and KogitoBuild instead. See: https://issues.redhat.com/browse/KOGITO-1998
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=kogitoapps,scope=Namespaced
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="Number of replicas set for this service"
@@ -304,7 +305,7 @@ type Builds struct {
 // +kubebuilder:printcolumn:name="Enable Events",type="boolean",JSONPath=".spec.enableEvents",description="Indicates if events is enabled"
 // +kubebuilder:printcolumn:name="Image Version",type="string",JSONPath=".spec.build.imageVersion",description="Build image version"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.route",description="External URI to access this service"
-// +operator-sdk:gen-csv:customresourcedefinitions.displayName="Kogito Service"
+// +operator-sdk:gen-csv:customresourcedefinitions.displayName="Kogito Application"
 // +operator-sdk:gen-csv:customresourcedefinitions.resources="DeploymentConfigs,apps.openshift.io/v1"
 // +operator-sdk:gen-csv:customresourcedefinitions.resources="ImageStreams,image.openshift.io/v1"
 // +operator-sdk:gen-csv:customresourcedefinitions.resources="BuildConfigs,build.openshift.io/v1"

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -427,7 +427,7 @@ func schema_pkg_apis_app_v1alpha1_KogitoApp(ref common.ReferenceCallback) common
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "KogitoApp is a project prescription running a Kogito service.",
+				Description: "KogitoApp is a project prescription running a Kogito service (it's meant to be used to Build and Deploy the application at the same time). KogitoApp is under deprecation, please use a combination of KogitoRuntime and KogitoBuild instead. See: https://issues.redhat.com/browse/KOGITO-1998",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-2813

Minor change to not distinguish between `KogitoApp` and a custom Kogito sevice represented by a `KogitoRuntime` CR. 

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster