### PR TITLE
[KOGITO-2827] - Use environment variable when no Data Index route ava…

### DIFF
--- a/examples/kubernetes/travel-agency/deploy.sh
+++ b/examples/kubernetes/travel-agency/deploy.sh
@@ -16,6 +16,8 @@
 EXAMPLES_DIR=./deploy/examples
 TARGET_DIR="${EXAMPLES_DIR}/kubernetes/travel-agency"
 STRIMZI_VERSION=0.17.0
+INFINISPAN_VERSION=1.1.1.Final
+
 if [[ -z ${PROJECT_NAME} ]]; then
   PROJECT_NAME=kogito
 fi
@@ -24,9 +26,9 @@ echo "Deploying the Travel Agency Demo on ${PROJECT_NAME} namespace"
 kubectl create namespace "$PROJECT_NAME"
 
 echo "Installing Infinispan Operator"
-kubectl apply -f https://raw.githubusercontent.com/infinispan/infinispan-operator/1.1.1.Final/deploy/crd.yaml -n ${PROJECT_NAME}
-kubectl apply -f https://raw.githubusercontent.com/infinispan/infinispan-operator/1.1.1.Final/deploy/rbac.yaml -n ${PROJECT_NAME}
-kubectl apply -f https://raw.githubusercontent.com/infinispan/infinispan-operator/1.1.1.Final/deploy/operator.yaml -n ${PROJECT_NAME}
+kubectl apply -f "https://raw.githubusercontent.com/infinispan/infinispan-operator/${INFINISPAN_VERSION}/deploy/crd.yaml" -n ${PROJECT_NAME}
+kubectl apply -f "https://raw.githubusercontent.com/infinispan/infinispan-operator/${INFINISPAN_VERSION}/deploy/rbac.yaml" -n ${PROJECT_NAME}
+kubectl apply -f "https://raw.githubusercontent.com/infinispan/infinispan-operator/${INFINISPAN_VERSION}/deploy/operator.yaml" -n ${PROJECT_NAME}
 
 echo "Deploying Strimzi"
 wget "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${STRIMZI_VERSION}/strimzi-${STRIMZI_VERSION}.tar.gz" -P "$TARGET_DIR/"
@@ -37,6 +39,10 @@ kubectl apply -f ${TARGET_DIR}/strimzi-${STRIMZI_VERSION}/install/cluster-operat
 echo "Deploying Data Index"
 kubectl apply -f ${TARGET_DIR}/data-index.yaml -n ${PROJECT_NAME}
 kubectl apply -f ${TARGET_DIR}/data-index-ingress.yaml -n ${PROJECT_NAME}
+
+echo "Deploying Management Console"
+kubectl apply -f ${TARGET_DIR}/management-console.yaml -n ${PROJECT_NAME}
+kubectl apply -f ${TARGET_DIR}/management-console-ingress.yaml -n ${PROJECT_NAME}
 
 echo "Deploying Kogito Travels Application"
 kubectl apply -f ${TARGET_DIR}/kogito-travels.yaml -n ${PROJECT_NAME}

--- a/examples/kubernetes/travel-agency/management-console-ingress.yaml
+++ b/examples/kubernetes/travel-agency/management-console-ingress.yaml
@@ -1,0 +1,17 @@
+# Ref.: https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/#create-an-ingress-resource
+# don't forget to edit your /etc/hosts file!!
+apiVersion: networking.k8s.io/v1beta1 # for versions before 1.14 use extensions/v1beta1
+kind: Ingress
+metadata:
+  name: mgtm-console-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - host: mgmt-console.kogito
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: management-console
+              servicePort: 8080

--- a/examples/kubernetes/travel-agency/management-console.yaml
+++ b/examples/kubernetes/travel-agency/management-console.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoMgmtConsole
+metadata:
+  name: management-console
+spec:
+  replicas: 1
+  image:
+    tag: "0.12"
+  # we use environment variables to set the external data index URL
+  # this is needed for now since Management Console is a client application, we are working on having a local proxy to
+  # use the Kubernetes service instead
+  envs:
+    - name: KOGITO_DATAINDEX_HTTP_URL
+      value: http://data-index.kogito
+    - name: KOGITO_DATAINDEX_WS_URL
+      value: ws://data-index.kogito

--- a/pkg/infrastructure/services/resources_test.go
+++ b/pkg/infrastructure/services/resources_test.go
@@ -135,6 +135,7 @@ func Test_serviceDeployer_createRequiredResources_RequiresDataIndex(t *testing.T
 				NamespacedName: types.NamespacedName{Name: infrastructure.DefaultMgmtConsoleName, Namespace: t.Name()},
 			},
 		},
+		recorder: newRecorder(meta.GetRegisteredSchema(), infrastructure.DefaultMgmtConsoleName),
 	}
 	resources, reconcileAfter, err := deployer.createRequiredResources()
 	assert.NoError(t, err)


### PR DESCRIPTION
…ilable

See: https://issues.redhat.com/browse/KOGITO-2827

In this PR we fallback to image environment variables if no Data Index route is found for a given KogitoService that depends on Data Index. This way is up to the user to expose the Data Index and fill the external endpoint directly in the target CR. Would be better to use Kubernetes svc instead, but for this to work applications that depends on querying Data Index should implement an internal proxy to properly do the redirects.

@cristianonicolai are you guys have any plans to add this feature to Management Console? I mean, to not depend on an external endpoint to do the client queries to the API?

If not set, an user can directly spot the problem via Events:

```
$ kubectl describe kogitomgmtconsole

(...)
Spec:
  Envs:
    Name:   HTTP_PORT
    Value:  8080
    Name:   KOGITO_DATAINDEX_HTTP_URL
    Value:  http://data-index.kogito
    Name:   KOGITO_DATAINDEX_WS_URL
    Value:  ws://data-index.kogito
  Image:
    Name:    kogito-management-console
    Tag:     0.12
  Replicas:  1
  Resources:
Status:
  Conditions:
    Last Transition Time:  2020-07-23T17:39:43Z
    Status:                True
    Type:                  Provisioning
    Last Transition Time:  2020-07-23T17:44:29Z
    Status:                True
    Type:                  Deployed
    Last Transition Time:  2020-07-23T18:00:55Z
    Status:                True
    Type:                  Provisioning
  Deployment Conditions:
    Last Transition Time:  2020-07-23T18:01:31Z
    Last Update Time:      2020-07-23T18:01:31Z
    Message:               Deployment does not have minimum availability.
    Reason:                MinimumReplicasUnavailable
    Status:                False
    Type:                  Available
    Last Transition Time:  2020-07-23T17:39:43Z
    Last Update Time:      2020-07-23T18:01:31Z
    Message:               ReplicaSet "management-console-7d6d97bd4d" is progressing.
    Reason:                ReplicaSetUpdated
    Status:                True
    Type:                  Progressing
  Image:                   quay.io/kiegroup/kogito-management-console:0.12
Events:
  Type     Reason   Age   From                           Message
  ----     ------   ----  ----                           -------
(...)
  Warning  Failure  42s   management-console, skywalker  Not found Data Index external URL set on KOGITO_DATAINDEX_HTTP_URL environment variable. Try setting the env var in 'management-console' manually using the Kogito service Custom Resource (CR)
  Normal   Updated  6s    management-console, skywalker  Updated Deployment: management-console
```

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster