### PR TITLE
[KOGITO-2872] BuildConfig comparator to handle empty and nil Triggers

### DIFF
--- a/hack/install-manifests.sh
+++ b/hack/install-manifests.sh
@@ -13,6 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source ./hack/install-manifests.sh
+EXIT=0
+FILE_FOUND=0
 
-kubectl apply -f deploy/operator.yaml -n "${NAMESPACE}";
+if [ -z "${NAMESPACE}" ]; then
+  NAMESPACE="kogito"
+fi
+
+shopt -s nullglob
+for file in deploy/{crds/*_crd.yaml,role*.yaml,service_account.yaml}; do
+  FILE_FOUND=1
+  if ! kubectl apply -f "$file" -n "${NAMESPACE}"; then
+    EXIT=1
+    break # Don't try other files if one fails
+  fi
+done
+shopt -u nullglob
+
+if [[ FILE_FOUND -eq 0 ]]; then
+  echo "No deployment files found" >&2
+  EXIT=3
+fi
+
+exit ${EXIT}

--- a/pkg/apis/app/v1alpha1/conditions_test.go
+++ b/pkg/apis/app/v1alpha1/conditions_test.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -81,6 +82,8 @@ func TestSetProvisioningAndThenDeployed(t *testing.T) {
 	assert.Equal(t, 2, len(conditionsMeta.Conditions))
 	assert.Equal(t, ProvisioningConditionType, condition.Type)
 	assert.Equal(t, corev1.ConditionTrue, condition.Status)
+	// we set a sleep to not conflict the time
+	time.Sleep(1 * time.Second)
 	assert.True(t, now.Before(&condition.LastTransitionTime))
 
 	assert.Equal(t, DeployedConditionType, conditionsMeta.Conditions[1].Type)

--- a/pkg/framework/comparator.go
+++ b/pkg/framework/comparator.go
@@ -179,6 +179,14 @@ func CreateBuildConfigComparator() func(deployed resource.KubernetesResource, re
 			//Triggers are generated based on provided github repo
 			bcDeployed.Spec.Triggers = bcRequested.Spec.Triggers
 		}
+		if len(bcRequested.Spec.Triggers) == 0 {
+			// see: https://issues.redhat.com/browse/KOGITO-2872
+			// setting both to nil for the sake of the comparator
+			// on OCP 4.5, empty triggers are set to nil
+			// on previous versions empty triggers were empty arrays. Yes, it's different.
+			requested.(*buildv1.BuildConfig).Spec.Triggers = nil
+			bcDeployed.Spec.Triggers = nil
+		}
 		return true
 	}
 }

--- a/pkg/framework/comparator_test.go
+++ b/pkg/framework/comparator_test.go
@@ -148,6 +148,32 @@ func Test_CreateBuildConfigComparator(t *testing.T) {
 			reflect.TypeOf(buildv1.BuildConfig{}),
 			false,
 		},
+		{
+			"With empty triggers KOGITO-2872",
+			args{
+				deployed: &buildv1.BuildConfig{
+					Spec: buildv1.BuildConfigSpec{Triggers: nil},
+				},
+				requested: &buildv1.BuildConfig{
+					Spec: buildv1.BuildConfigSpec{Triggers: []buildv1.BuildTriggerPolicy{}},
+				},
+			},
+			reflect.TypeOf(buildv1.BuildConfig{}),
+			true,
+		},
+		{
+			"With empty triggers reference",
+			args{
+				deployed: &buildv1.BuildConfig{
+					Spec: buildv1.BuildConfigSpec{Triggers: []buildv1.BuildTriggerPolicy{}},
+				},
+				requested: &buildv1.BuildConfig{
+					Spec: buildv1.BuildConfigSpec{Triggers: []buildv1.BuildTriggerPolicy{}},
+				},
+			},
+			reflect.TypeOf(buildv1.BuildConfig{}),
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-2872

In this PR we introduce a little fix to our comparators to relax Triggers equality on `BuildConfig` spec. On OCP 4.5 this field, when empty, is treated as a nil value. On former versions this attribute was an empty array. That was accusing our structure to be different from the requested and deployed ones.
 
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster