### PR TITLE
[KOGITO-2917] Update contributors' guide link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Many thanks for submiting your Pull Request :heart:!
 
 Please make sure that your PR meets the following requirements:
 
-- [ ] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
+- [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
 - [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
 - [ ] Pull Request contains link to the JIRA issue
 - [ ] Pull Request contains description of the issue


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-2917

## Can't Use Relative Links
I put a direct link instead of a relative link because they don't seem to work properly as a template. If you play around with the [preview in a PR](https://github.com/kiegroup/kogito-cloud-operator/compare/master...Kevin-Mok:KOGITO-2917?expand=1), you can see that no relative links work properly.

### Linking to Base Directory
Using the relative link `../` so that it links to the project base directory produces the link: https://github.com/kiegroup/kogito-cloud-operator/README.md#contributing-to-the-kogito-operator. However, you need the `blob/master` to produce a valid link: https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator.

### Linking to Header Directly
Trying to link to the header directly (`(#contributing-to-the-kogito-operator)`) to try to get https://github.com/kiegroup/kogito-cloud-operator#contributing-to-the-kogito-operator produces another incorrect link: https://github.com/kiegroup/kogito-cloud-operator/compare/master...Kevin-Mok:KOGITO-2917?expand=1#contributing-to-the-kogito-operator.

## Requirements
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.MD#sending-a-pull-request)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
