### PR TITLE
[KOGITO-1925] CLI: force native build to use s2i

### DIFF
--- a/cmd/kogito/command/deploy/deploy_service.go
+++ b/cmd/kogito/command/deploy/deploy_service.go
@@ -86,6 +86,9 @@ func (i *deployCommand) RegisterHook() {
 			if len(args) == 0 {
 				return fmt.Errorf("the service requires a name ")
 			}
+			if len(args) == 1 && i.flags.BuildFlags.Native {
+				return fmt.Errorf("native builds currently only work with s2i. Please provide [SOURCE] argument")
+			}
 			if err := flag.CheckRuntimeTypeArgs(&i.flags.RuntimeTypeFlags); err != nil {
 				return err
 			}

--- a/cmd/kogito/command/deploy/deploy_service_test.go
+++ b/cmd/kogito/command/deploy/deploy_service_test.go
@@ -62,3 +62,14 @@ func Test_DeployServiceCmd_DefaultConfigurations(t *testing.T) {
 	assert.False(t, kogitoRuntime.Spec.InsecureImageRegistry)
 	assert.Equal(t, 2, len(kogitoRuntime.Spec.Envs))
 }
+
+func Test_DeployCmd_NativeBuildWithoutSource(t *testing.T) {
+	ns := t.Name()
+	cli := fmt.Sprintf(`deploy-service native-build --native --project %s`, ns)
+	test.SetupCliTest(cli,
+		context.CommandFactory{BuildCommands: BuildCommands},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	lines, _, err := test.ExecuteCli()
+	assert.Error(t, err)
+	assert.Contains(t, lines, "Error: native builds currently only work with s2i. Please provide [SOURCE] argument")
+}

--- a/cmd/kogito/command/flag/build_flag.go
+++ b/cmd/kogito/command/flag/build_flag.go
@@ -65,7 +65,7 @@ func AddBuildFlags(command *cobra.Command, flags *BuildFlags) {
 	AddWebHookFlags(command, &flags.WebHookFlags)
 	AddEnvVarFlags(command, &flags.EnvVarFlags, "build-env", "")
 	command.Flags().BoolVar(&flags.IncrementalBuild, "incremental-build", true, "Build should be incremental?")
-	command.Flags().BoolVar(&flags.Native, "native", false, "Use native builds? Be aware that native builds takes more time and consume much more resources from the cluster. Defaults to false")
+	command.Flags().BoolVar(&flags.Native, "native", false, "Use native builds? Be aware that native builds takes more time and consume much more resources from the cluster. Defaults to false. Currently only works with s2i (requires [SOURCE] argument).")
 	command.Flags().StringVar(&flags.MavenMirrorURL, "maven-mirror-url", "", "Internal Maven Mirror to be used during source-to-image builds to considerably increase build speed, e.g: https://my.internal.nexus/content/group/public")
 	command.Flags().StringVar(&flags.BuildImage, "image-s2i", "", "Custom image tag for the s2i build to build the application binaries, e.g: quay.io/mynamespace/myimage:latest")
 	command.Flags().StringVar(&flags.RuntimeImage, "image-runtime", "", "Custom image tag for the s2i build, e.g: quay.io/mynamespace/myimage:latest")


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-1925

## Don't Allow Native Without Source
The task description says to add a warning in the logs if the user tries to do a native build but ends up doing a binary build. I chose to just not allow the user to do the native build without specifying a source. This is because they specifically want a native build, so we should force the user to specify the source for in order for it to work; else, they can just remove the native flag and be aware they are doing a binary build.

## Unit Test
I accidentally initially did this task on my local repo that was 25 commits behind `master`...  :sweat_smile: But while I was doing that, I noticed that there were [way more tests in `cmd/kogito/command/deploy/deploy_service_test.go`](https://github.com/Kevin-Mok/kogito-cloud-operator/blob/KOGITO-1925-old/cmd/kogito/command/deploy/deploy_service_test.go); they seem to be deleted now, and I can't find them anywhere in the repo. Do I still need a unit test for this task then?  I added the one I wrote for the old file previously anyway, but I'm not sure if it's needed?

## Requirements
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
