### PR TITLE
KOGITO-2771: Cucumber Tests: Cover Webhooks in KogitoBuild

### DIFF
--- a/test/features/deploy_kogito_build.feature
+++ b/test/features/deploy_kogito_build.feature
@@ -60,3 +60,14 @@ Feature: Deploy Kogito Build
     Examples:
       | runtime    | example-service         | native  | profile |
       | quarkus    | process-quarkus-example | enabled | native  |
+
+  Scenario Outline: Configure <type> webhook trigger in remote S2I using KogitoBuild
+    When Build quarkus example service "process-quarkus-example" with configuration:
+      | webhook | type   | <type>    |
+      | webhook | secret | <secret>  |
+    Then BuildConfig "process-quarkus-example" is created with webhooks within 2 minutes
+
+    Examples:
+      | type    | secret         | 
+      | GitHub  | github_secret  | 
+      | Generic | generic_secret | 

--- a/test/framework/kogitobuild.go
+++ b/test/framework/kogitobuild.go
@@ -25,7 +25,9 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/test/framework/mappers"
 	bddtypes "github.com/kiegroup/kogito-cloud-operator/test/types"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // DeployKogitoBuild deploy a KogitoBuild
@@ -88,6 +90,17 @@ func GetKogitoBuildStub(namespace, runtimeType, name string) *v1alpha1.KogitoBui
 	}
 
 	return kogitoBuild
+}
+
+// GetKogitoBuild returns the KogitoBuild type
+func GetKogitoBuild(namespace, buildName string) (*v1alpha1.KogitoBuild, error) {
+	build := &v1alpha1.KogitoBuild{}
+	if exists, err := kubernetes.ResourceC(kubeClient).FetchWithKey(types.NamespacedName{Name: buildName, Namespace: namespace}, build); err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("Error while trying to look for KogitoBuild %s: %v ", buildName, err)
+	} else if errors.IsNotFound(err) || !exists {
+		return nil, nil
+	}
+	return build, nil
 }
 
 // SetupKogitoBuildImageStreams sets the correct images for the KogitoBuild

--- a/test/framework/mappers/cr_to_cli.go
+++ b/test/framework/mappers/cr_to_cli.go
@@ -128,5 +128,12 @@ func GetBuildCLIFlags(kogitoBuild *v1alpha1.KogitoBuild) []string {
 		cmd = append(cmd, "--image-runtime", image)
 	}
 
+	// webhooks
+	if len(kogitoBuild.Spec.WebHooks) > 0 {
+		for _, webhook := range kogitoBuild.Spec.WebHooks {
+			cmd = append(cmd, "--web-hook", fmt.Sprintf("%s=%s", webhook.Type, webhook.Secret))
+		}
+	}
+
 	return cmd
 }

--- a/test/steps/mappers/create_kogito_build.go
+++ b/test/steps/mappers/create_kogito_build.go
@@ -26,10 +26,13 @@ import (
 
 const (
 	// DataTable first column
-	kogitoBuildConfigKey = "config"
+	kogitoBuildConfigKey  = "config"
+	kogitoBuildWebhookKey = "webhook"
 
 	// DataTable second column
 	kogitoBuildNativeKey = "native"
+	kogitoBuildTypeKey   = "type"
+	kogitoBuildSecretKey = "secret"
 )
 
 // MapKogitoBuildTable maps Cucumber table to KogitoBuildHolder
@@ -61,6 +64,9 @@ func mapKogitoBuildTableRow(row *messages.PickleStepArgument_PickleTable_PickleT
 	case kogitoBuildConfigKey:
 		return mapKogitoBuildConfigTableRow(row, kogitoBuild)
 
+	case kogitoBuildWebhookKey:
+		return mapKogitoBuildWebhookTableRow(row, kogitoBuild)
+
 	default:
 		return false, fmt.Errorf("Unrecognized configuration option: %s", firstColumn)
 	}
@@ -75,6 +81,26 @@ func mapKogitoBuildConfigTableRow(row *messages.PickleStepArgument_PickleTable_P
 
 	default:
 		return false, fmt.Errorf("Unrecognized config configuration option: %s", secondColumn)
+	}
+
+	return true, nil
+}
+
+func mapKogitoBuildWebhookTableRow(row *messages.PickleStepArgument_PickleTable_PickleTableRow, kogitoBuild *v1alpha1.KogitoBuild) (mappingFound bool, err error) {
+	secondColumn := getSecondColumn(row)
+
+	if len(kogitoBuild.Spec.WebHooks) == 0 {
+		kogitoBuild.Spec.WebHooks = []v1alpha1.WebhookSecret{{}}
+	}
+
+	switch secondColumn {
+	case kogitoBuildTypeKey:
+		kogitoBuild.Spec.WebHooks[0].Type = v1alpha1.WebhookType(getThirdColumn(row))
+	case kogitoBuildSecretKey:
+		kogitoBuild.Spec.WebHooks[0].Secret = getThirdColumn(row)
+
+	default:
+		return false, fmt.Errorf("Unrecognized webhook configuration option: %s", secondColumn)
 	}
 
 	return true, nil

--- a/test/steps/openshift.go
+++ b/test/steps/openshift.go
@@ -28,6 +28,7 @@ func registerOpenShiftSteps(ctx *godog.ScenarioContext, data *Data) {
 	// BuildConfig steps
 	ctx.Step(`^BuildConfig "([^"]*)" is created after (\d+) minutes$`, data.buildConfigIsCreatedAfterMinutes)
 	ctx.Step(`^BuildConfig "([^"]*)" is created with build resources within (\d+) minutes:$`, data.buildConfigHasResourcesWithinMinutes)
+	ctx.Step(`^BuildConfig "([^"]*)" is created with webhooks within (\d+) minutes$`, data.buildConfigHasWebhooksWithinMinutes)
 }
 
 // Build steps
@@ -59,4 +60,14 @@ func (data *Data) buildConfigHasResourcesWithinMinutes(buildConfigName string, t
 	}
 
 	return framework.WaitForBuildConfigToHaveResources(data.Namespace, buildConfigName, *requirements, timeoutInMin)
+}
+
+func (data *Data) buildConfigHasWebhooksWithinMinutes(buildConfigName string, timeoutInMin int) error {
+	kogitoBuild, err := framework.GetKogitoBuild(data.Namespace, buildConfigName)
+
+	if err != nil {
+		return err
+	}
+
+	return framework.WaitForBuildConfigCreatedWithWebhooks(data.Namespace, buildConfigName, kogitoBuild.Spec.WebHooks, timeoutInMin)
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-2771
Description: Cover that the kogito cloud operator initialises correctly the build config in Openshift.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
