### PR TITLE
[KOGITO-2957] Considering K_SINK env var when comparing Deployments

### DIFF
--- a/pkg/framework/comparator_test.go
+++ b/pkg/framework/comparator_test.go
@@ -605,6 +605,117 @@ func Test_CreateDeploymentComparator(t *testing.T) {
 			reflect.TypeOf(apps.Deployment{}),
 			true,
 		},
+		{
+			"Knative injected an env var",
+			args{
+				deployed: &apps.Deployment{
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "service",
+										Env: []v1.EnvVar{
+											CreateEnvVar(knativeKSINKEnvVar, "http://endpoint/"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				requested: &apps.Deployment{
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "service",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reflect.TypeOf(apps.Deployment{}),
+			true,
+		},
+		{
+			"Knative injected only on request?",
+			args{
+				deployed: &apps.Deployment{
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "service",
+									},
+								},
+							},
+						},
+					},
+				},
+				requested: &apps.Deployment{
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "service",
+										Env: []v1.EnvVar{
+											CreateEnvVar(knativeKSINKEnvVar, "http://endpoint/"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reflect.TypeOf(apps.Deployment{}),
+			false,
+		},
+		{
+			"Knative with multiple containers",
+			args{
+				deployed: &apps.Deployment{
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "service",
+										Env: []v1.EnvVar{
+											CreateEnvVar(knativeKSINKEnvVar, "http://endpoint/"),
+										},
+									},
+									{
+										Name: "service2",
+									},
+								},
+							},
+						},
+					},
+				},
+				requested: &apps.Deployment{
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "service",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reflect.TypeOf(apps.Deployment{}),
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-2957

In this PR we ignore the injected `K_SINK` environment variable by Knative Eventing when comparing `PodTemplate`s to be full compatible of their way of service discovery mechanism. More info: https://knative.dev/docs/eventing/migration/sinkbinding/

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
