### PR TITLE
[KOGITO-3005] Add exe extension to Windows CLI

### DIFF
--- a/hack/go-build-cli.sh
+++ b/hack/go-build-cli.sh
@@ -59,7 +59,8 @@ if [ "$release" = "true" ]; then
     cleanTemplateFiles
 
     if [ "${i}" = "windows" ]; then
-      zip -j "build/_output/release/kogito-cli-${version}-${i}-${arch}.zip" build/_output/bin/kogito
+      mv build/_output/bin/kogito{,.exe}
+      zip -j "build/_output/release/kogito-cli-${version}-${i}-${arch}.zip" build/_output/bin/kogito.exe
       if [ $? -ne 0 ]; then
         exit 1
       fi


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-3005

### Test
I ran `./hack/go-build-cli.sh true 0.14.0` to produce `kogito-cli-0.14.0-windows-amd64.zip` (contains `kogito.exe`) which I uploaded [here](https://github.com/Kevin-Mok/kogito-cloud-operator/releases/download/7.31.0/kogito-cli-0.14.0-windows-amd64.zip). Extracting it and running it works without asking which program to use it with:
```
PS C:\Users\Kevin> C:\Users\Kevin\Downloads\kogito.exe
{"level":"warn","T":"2020-08-07T17:08:47.685-0400","logger":"client_api","msg":"Kubernetes local configuration 'C:\\Users\\Kevin/.kube/config' is empty."}
{"level":"warn","T":"2020-08-07T17:08:47.686-0400","logger":"client_api","msg":"Make sure to login to your cluster with oc/kubectl before using this tool"}
panic: Impossible to get Kubernetes local configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable

goroutine 1 [running]:
github.com/kiegroup/kogito-cloud-operator/pkg/client.NewForConsole(0xc000539ee8)
        /home/kevin/go/src/github.com/kiegroup/kogito-cloud-operator/pkg/client/client.go:71 +0x9a
github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command.DefaultBuildCommands(0xc000539f18)
        /home/kevin/go/src/github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/command.go:32 +0x29
main.Main(0xc000539f48, 0x4455ae)
        /home/kevin/go/src/github.com/kiegroup/kogito-cloud-operator/cmd/kogito/main.go:26 +0x29
main.Execute()
        /home/kevin/go/src/github.com/kiegroup/kogito-cloud-operator/cmd/kogito/main.go:32 +0x2d
main.main()
        /home/kevin/go/src/github.com/kiegroup/kogito-cloud-operator/cmd/kogito/main.go:39 +0x27
```

*Note*: The commit message has "Closes #500", so it'll close that issue automatically when this is merged.

### Requirements
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: 
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
