### PR TITLE
[KOGITO-3032] - Ignoring any injected variables on PodSpecTemplate

### DIFF
--- a/pkg/framework/comparator_test.go
+++ b/pkg/framework/comparator_test.go
@@ -616,7 +616,7 @@ func Test_CreateDeploymentComparator(t *testing.T) {
 									{
 										Name: "service",
 										Env: []v1.EnvVar{
-											CreateEnvVar(knativeKSINKEnvVar, "http://endpoint/"),
+											CreateEnvVar("K_SINK", "http://endpoint/"),
 										},
 									},
 								},
@@ -665,7 +665,7 @@ func Test_CreateDeploymentComparator(t *testing.T) {
 									{
 										Name: "service",
 										Env: []v1.EnvVar{
-											CreateEnvVar(knativeKSINKEnvVar, "http://endpoint/"),
+											CreateEnvVar("K_SINK", "http://endpoint/"),
 										},
 									},
 								},
@@ -688,7 +688,7 @@ func Test_CreateDeploymentComparator(t *testing.T) {
 									{
 										Name: "service",
 										Env: []v1.EnvVar{
-											CreateEnvVar(knativeKSINKEnvVar, "http://endpoint/"),
+											CreateEnvVar("K_SINK", "http://endpoint/"),
 										},
 									},
 									{


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3032

Knative 0.16 introduces a new variable being injected in the SinkBinding sources. Instead of keeping ignoring known env vars that could be injected, we are now ignoring any variables injected by other managers. This would also allow users to add a new env var to their deployment to make quick tests or something they need (through the web ui). For long term envs, they would still use the `KogitoService` interface as the recommended approach.

Keeping up to the Knative/Istio changes and injection in our PodSpecTemplate resources would be a pain to maintain.

I also removed unused functions from the `framework` package.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
