### PR TITLE
[KOGITO-3045] Set image's deployment properties

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -209,18 +209,13 @@ pipeline {
                     }
                     tagImage()
                     pushImage()
-                }
-            }
-            post {
-                success {
-                    script {
-                        // Store image deployment information
-                        String imgPrefix = 'kogito-cloud-operator.image'
-                        setDeployPropertyIfNeeded("${imgPrefix}.registry", getDeployImageRegistry())
-                        setDeployPropertyIfNeeded("${imgPrefix}.namespace", getDeployImageNamespace())
-                        setDeployPropertyIfNeeded("${imgPrefix}.name-suffix", getDeployImageNameSuffix())
-                        setDeployPropertyIfNeeded("${imgPrefix}.tag", getDeployImageTag())
-                    }
+
+                    // Store image deployment information
+                    String imgPrefix = 'kogito-cloud-operator.image'
+                    setDeployPropertyIfNeeded("${imgPrefix}.registry", getDeployImageRegistry())
+                    setDeployPropertyIfNeeded("${imgPrefix}.namespace", getDeployImageNamespace())
+                    setDeployPropertyIfNeeded("${imgPrefix}.name-suffix", getDeployImageNameSuffix())
+                    setDeployPropertyIfNeeded("${imgPrefix}.tag", getDeployImageTag())
                 }
             }
         }
@@ -236,16 +231,11 @@ pipeline {
                     githubscm.commitChanges(commitMsg, '.')
                     githubscm.pushObject('origin', getBotBranch(), env.BOT_CREDENTIALS_ID)
                     deployProperties['kogito-cloud-operator.pr.link'] = githubscm.createPR(commitMsg, prBody, getBuildBranch(), env.BOT_CREDENTIALS_ID)
-                }
-            }
-            post {
-                success {
-                    script {
-                        setDeployPropertyIfNeeded('kogito-cloud-operator.pr.source.uri', "https://github.com/${getBotAuthor()}/kogito-cloud-operator")
-                        setDeployPropertyIfNeeded('kogito-cloud-operator.pr.source.ref', getBotBranch())
-                        setDeployPropertyIfNeeded('kogito-cloud-operator.pr.target.uri', "https://github.com/${getGitAuthor()}/kogito-cloud-operator")
-                        setDeployPropertyIfNeeded('kogito-cloud-operator.pr.target.ref', getBuildBranch())
-                    }
+                    
+                    setDeployPropertyIfNeeded('kogito-cloud-operator.pr.source.uri', "https://github.com/${getBotAuthor()}/kogito-cloud-operator")
+                    setDeployPropertyIfNeeded('kogito-cloud-operator.pr.source.ref', getBotBranch())
+                    setDeployPropertyIfNeeded('kogito-cloud-operator.pr.target.uri', "https://github.com/${getGitAuthor()}/kogito-cloud-operator")
+                    setDeployPropertyIfNeeded('kogito-cloud-operator.pr.target.ref', getBuildBranch())
                 }
             }
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3045

If pipeline is unstable due to tests failing, then we still push to registry but properties were not set because of `success` post whereas the pipeline is no more success ...
Properties will be set normally after the push and PR created

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
