### PR TITLE
[KOGITO-3063] Redirecting kogito CLI default output to stdout

### DIFF
--- a/cmd/kogito/command/command.go
+++ b/cmd/kogito/command/command.go
@@ -15,8 +15,6 @@
 package command
 
 import (
-	"io"
-
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/completion"
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/deploy"
@@ -25,11 +23,13 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/remove"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 	"github.com/spf13/cobra"
+	"io"
+	"os"
 )
 
 // DefaultBuildCommands creates a new start command for the Kogito CLI
 func DefaultBuildCommands() *cobra.Command {
-	return BuildCommands(client.NewForConsole(), nil)
+	return BuildCommands(client.NewForConsole(), os.Stdout)
 }
 
 // BuildCommands creates a customized start command for the Kogito CLI

--- a/cmd/kogito/command/context/logger.go
+++ b/cmd/kogito/command/context/logger.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/logger"
 	"go.uber.org/zap"
 	"io"
+	"os"
 )
 
 var (
@@ -38,14 +39,17 @@ func getDefaultLoggerWithOut(verbose bool, outputFormat string, commandOutput io
 		badOutputFormatMsg = "'" + outputFormat + "' is not a supported output format"
 		outputFormat = ""
 	}
-	logger := logger.GetLoggerWithOptions("kogito-cli", &logger.Opts{
+	if commandOutput == nil {
+		commandOutput = os.Stdout
+	}
+	log := logger.GetLoggerWithOptions("kogito-cli", &logger.Opts{
 		Output:       commandOutput,
 		OutputFormat: outputFormat,
 		Verbose:      verbose,
 		Console:      true,
 	})
 	if len(badOutputFormatMsg) > 0 {
-		logger.Warn(badOutputFormatMsg)
+		log.Warn(badOutputFormatMsg)
 	}
-	return logger
+	return log
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	defaultOutput = os.Stderr
+	defaultOutput = os.Stdout
 )
 
 // Logger shared logger struct


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3063

This is incredible. We should take control of the CLI for testing purposes, but instead we were setting to `nil`. We should be fine now. Tested redirecting the output to `/dev/null` like `kogito install data-index >/dev/null`. It's working.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
