### PR TITLE
[KOGITO-3154] Update TrustyAI endpoint path in tests

### DIFF
--- a/test/features/install_trusty.feature
+++ b/test/features/install_trusty.feature
@@ -68,4 +68,4 @@ Feature: Kogito Trusty
       }
       """
 
-    Then HTTP GET request on service "trusty" with path "/v1/executions" should contain a string "DECISION" within 3 minutes
+    Then HTTP GET request on service "trusty" with path "/executions" should contain a string "DECISION" within 3 minutes

--- a/test/features/olm/cli_install_operator.feature
+++ b/test/features/olm/cli_install_operator.feature
@@ -53,4 +53,4 @@ Feature: CLI: Install Kogito Operator
     When CLI install Kogito operator with Kogito Trusty
 
     Then Kogito Trusty has 1 pods running within 5 minutes
-    And HTTP GET request on service "trusty" is successful within 2 minutes with path "v1/executions"
+    And HTTP GET request on service "trusty" is successful within 2 minutes with path "executions"

--- a/test/features/olm/cli_new_project.feature
+++ b/test/features/olm/cli_new_project.feature
@@ -50,4 +50,4 @@ Feature: CLI: Project
     When CLI create namespace with Kogito Trusty
 
     Then Kogito Trusty has 1 pods running within 5 minutes
-    And HTTP GET request on service "trusty" is successful within 2 minutes with path "v1/executions"
+    And HTTP GET request on service "trusty" is successful within 2 minutes with path "executions"

--- a/test/features/olm/cli_use_project.feature
+++ b/test/features/olm/cli_use_project.feature
@@ -53,4 +53,4 @@ Feature: CLI: Project
     When CLI use namespace with Kogito Trusty
 
     Then Kogito Trusty has 1 pods running within 5 minutes
-    And HTTP GET request on service "trusty" is successful within 2 minutes with path "v1/executions"
+    And HTTP GET request on service "trusty" is successful within 2 minutes with path "executions"


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3154

After KOGITO-2741 the path of the endpoint has been updated so here is the fix for BDD tests

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
