### PR TITLE
[KOGITO-3148] - Remove third party required dependencies from CSV

### DIFF
--- a/cmd/kogito/command/install/infinispan.go
+++ b/cmd/kogito/command/install/infinispan.go
@@ -54,7 +54,9 @@ func (i *installInfinispanCommand) RegisterHook() {
 		Use:     "infinispan [flags]",
 		Short:   "Installs an infinispan instance into the OpenShift/Kubernetes cluster",
 		Example: "install infinispan -p my-project",
-		Long:    `Installs an infinispan instance via custom Kubernetes resources. This feature won't create custom subscriptions with the OLM.`,
+		Long:    `Installs an infinispan instance via custom Kubernetes resources. 
+Requires Infinispan Operator to be installed, please make sure that you've installed it before proceeding. 
+This feature won't create custom subscriptions with the OLM.`,
 		RunE:    i.Exec,
 		PreRun:  i.CommonPreRun,
 		PostRun: i.CommonPostRun,
@@ -72,7 +74,7 @@ func (i *installInfinispanCommand) InitHook() {
 	i.Parent.AddCommand(i.command)
 	flag.AddOperatorFlags(i.command, &i.flags.OperatorFlags)
 
-	i.command.Flags().StringVarP(&i.flags.project, "project", "p", "", "The project name where the operator will be deployed")
+	i.command.Flags().StringVarP(&i.flags.project, "project", "p", "", "The project name where the Infinispan server will be deployed")
 }
 
 func (i *installInfinispanCommand) Exec(cmd *cobra.Command, args []string) error {

--- a/cmd/kogito/command/install/infinispan.go
+++ b/cmd/kogito/command/install/infinispan.go
@@ -54,7 +54,7 @@ func (i *installInfinispanCommand) RegisterHook() {
 		Use:     "infinispan [flags]",
 		Short:   "Installs an infinispan instance into the OpenShift/Kubernetes cluster",
 		Example: "install infinispan -p my-project",
-		Long:    `Installs an infinispan instance via custom Kubernetes resources. 
+		Long: `Installs an infinispan instance via custom Kubernetes resources. 
 Requires Infinispan Operator to be installed, please make sure that you've installed it before proceeding. 
 This feature won't create custom subscriptions with the OLM.`,
 		RunE:    i.Exec,

--- a/cmd/kogito/command/install/kafka.go
+++ b/cmd/kogito/command/install/kafka.go
@@ -54,7 +54,7 @@ func (i *installKafkaCommand) RegisterHook() {
 		Use:     "kafka [flags]",
 		Short:   "Installs a kafka instance into the OpenShift/Kubernetes cluster",
 		Example: "install kafka -p my-project",
-		Long:    `Installs a kafka instance via custom Kubernetes resources. 
+		Long: `Installs a kafka instance via custom Kubernetes resources. 
 Requires Strimzi to be installed, please make sure that you've installed it before proceeding.
 This feature won't create custom subscriptions with the OLM.`,
 		RunE:    i.Exec,

--- a/cmd/kogito/command/install/kafka.go
+++ b/cmd/kogito/command/install/kafka.go
@@ -54,7 +54,9 @@ func (i *installKafkaCommand) RegisterHook() {
 		Use:     "kafka [flags]",
 		Short:   "Installs a kafka instance into the OpenShift/Kubernetes cluster",
 		Example: "install kafka -p my-project",
-		Long:    `Installs a kafka instance via custom Kubernetes resources. This feature won't create custom subscriptions with the OLM.`,
+		Long:    `Installs a kafka instance via custom Kubernetes resources. 
+Requires Strimzi to be installed, please make sure that you've installed it before proceeding.
+This feature won't create custom subscriptions with the OLM.`,
 		RunE:    i.Exec,
 		PreRun:  i.CommonPreRun,
 		PostRun: i.CommonPostRun,
@@ -72,7 +74,7 @@ func (i *installKafkaCommand) InitHook() {
 	i.Parent.AddCommand(i.command)
 	flag.AddOperatorFlags(i.command, &i.flags.OperatorFlags)
 
-	i.command.Flags().StringVarP(&i.flags.project, "project", "p", "", "The project name where the operator will be deployed")
+	i.command.Flags().StringVarP(&i.flags.project, "project", "p", "", "The project name where the Kafka server will be deployed")
 }
 
 func (i *installKafkaCommand) Exec(cmd *cobra.Command, args []string) error {

--- a/cmd/kogito/command/install/keycloak.go
+++ b/cmd/kogito/command/install/keycloak.go
@@ -54,7 +54,7 @@ func (i *installKeycloakCommand) RegisterHook() {
 		Use:     "keycloak [flags]",
 		Short:   "Installs a keycloak instance into the OpenShift/Kubernetes cluster",
 		Example: "install keycloak -p my-project",
-		Long:    `Installs a keycloak instance via custom Kubernetes resources.
+		Long: `Installs a keycloak instance via custom Kubernetes resources.
 Requires Keycloak Operator to be installed, please make sure that you've installed it before proceeding.
 This feature won't create custom subscriptions with the OLM.`,
 		RunE:    i.Exec,

--- a/cmd/kogito/command/install/keycloak.go
+++ b/cmd/kogito/command/install/keycloak.go
@@ -54,7 +54,9 @@ func (i *installKeycloakCommand) RegisterHook() {
 		Use:     "keycloak [flags]",
 		Short:   "Installs a keycloak instance into the OpenShift/Kubernetes cluster",
 		Example: "install keycloak -p my-project",
-		Long:    `Installs a keycloak instance via custom Kubernetes resources. This feature won't create custom subscriptions with the OLM.`,
+		Long:    `Installs a keycloak instance via custom Kubernetes resources.
+Requires Keycloak Operator to be installed, please make sure that you've installed it before proceeding.
+This feature won't create custom subscriptions with the OLM.`,
 		RunE:    i.Exec,
 		PreRun:  i.CommonPreRun,
 		PostRun: i.CommonPostRun,
@@ -72,7 +74,7 @@ func (i *installKeycloakCommand) InitHook() {
 	i.Parent.AddCommand(i.command)
 	flag.AddOperatorFlags(i.command, &i.flags.OperatorFlags)
 
-	i.command.Flags().StringVarP(&i.flags.project, "project", "p", "", "The project name where the operator will be deployed")
+	i.command.Flags().StringVarP(&i.flags.project, "project", "p", "", "The project name where the Keycloak server will be deployed")
 }
 
 func (i *installKeycloakCommand) Exec(cmd *cobra.Command, args []string) error {

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
@@ -657,28 +657,6 @@ spec:
         displayName: Image
         path: image
       version: v1alpha1
-    required:
-    - description: Represents a Infinispan cluster used internally by Kogito Data
-        Index Service
-      displayName: Infinispan Cluster
-      kind: Infinispan
-      name: infinispans.infinispan.org
-      version: v1
-    - description: Represents a Kafka cluster
-      displayName: Kafka
-      kind: Kafka
-      name: kafkas.kafka.strimzi.io
-      version: v1beta1
-    - description: Represents a topic inside a Kafka cluster
-      displayName: Kafka Topic
-      kind: KafkaTopic
-      name: kafkatopics.kafka.strimzi.io
-      version: v1beta1
-    - description: Represents a Keycloak server to provide SSO for Kogito Services
-      displayName: Keycloak
-      kind: Keycloak
-      name: keycloaks.keycloak.org
-      version: v1alpha1
   description: |-
     Kogito Operator is designed to deploy Kogito services from source (only on OpenShift) and every piece of infrastructure that the services might need:
 

--- a/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
@@ -657,28 +657,6 @@ spec:
         displayName: Image
         path: image
       version: v1alpha1
-    required:
-    - description: Represents a Infinispan cluster used internally by Kogito Data
-        Index Service
-      displayName: Infinispan Cluster
-      kind: Infinispan
-      name: infinispans.infinispan.org
-      version: v1
-    - description: Represents a Kafka cluster
-      displayName: Kafka
-      kind: Kafka
-      name: kafkas.kafka.strimzi.io
-      version: v1beta1
-    - description: Represents a topic inside a Kafka cluster
-      displayName: Kafka Topic
-      kind: KafkaTopic
-      name: kafkatopics.kafka.strimzi.io
-      version: v1beta1
-    - description: Represents a Keycloak server to provide SSO for Kogito Services
-      displayName: Keycloak
-      kind: Keycloak
-      name: keycloaks.keycloak.org
-      version: v1alpha1
   description: |-
     Kogito Operator is designed to deploy Kogito services from source (only on OpenShift) and every piece of infrastructure that the services might need:
 


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3148

In this PR we removed the CSV required field, so OLM won't install third party operators any more when installing Kogito Operator.

We're missing the docs PR to add links to the installation pages of Strimzi and Infinispan.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
