### PR TITLE
[KOGITO-3104] - Missing Resources for Operator CRs

### DIFF
--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
@@ -122,11 +122,11 @@ spec:
       kind: KogitoBuild
       name: kogitobuilds.app.kiegroup.org
       resources:
-      - kind: BuildConfigs
-        name: ""
+      - kind: BuildConfig
+        name: A Openshift Build Config
         version: build.openshift.io/v1
-      - kind: ImageStreams
-        name: ""
+      - kind: ImageStream
+        name: A Openshift Image Stream
         version: image.openshift.io/v1
       specDescriptors:
       - description: Artifact contains override information for building the Maven
@@ -241,20 +241,20 @@ spec:
       kind: KogitoDataIndex
       name: kogitodataindices.app.kiegroup.org
       resources:
-      - kind: ConfigMaps
-        name: ""
+      - kind: ConfigMap
+        name: A Kubernetes ConfigMap
         version: v1
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: KafkaTopics
-        name: ""
+      - kind: KafkaTopic
+        name: A Kafka Topic
         version: kafka.strimzi.io/v1beta1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: Additional labels to be added to the Deployment and Pods managed
@@ -318,17 +318,17 @@ spec:
       kind: KogitoInfra
       name: kogitoinfras.app.kiegroup.org
       resources:
-      - kind: Infinispans
-        name: ""
+      - kind: Infinispan
+        name: A Infinispan instance
         version: infinispan.org/v1
       - kind: Kafka
-        name: ""
+        name: A Kafka instance
         version: ksafka.strimzi.io/v1beta1
-      - kind: Keycloaks
-        name: ""
+      - kind: Keycloak
+        name: A Keycloak Instance
         version: keycloak.org/v1alpha1
-      - kind: Secrets
-        name: ""
+      - kind: Secret
+        name: A Kubernetes Secret
         version: v1
       specDescriptors:
       - description: Indicates if Infinispan should be installed or not using Infinispan
@@ -359,17 +359,17 @@ spec:
       kind: KogitoJobsService
       name: kogitojobsservices.app.kiegroup.org
       resources:
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: ImageStreams
-        name: ""
+      - kind: ImageStream
+        name: A Openshift ImageStream
         version: image.openshift.io/v1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: 'Retry backOff time in milliseconds between the job execution
@@ -439,17 +439,17 @@ spec:
       kind: KogitoMgmtConsole
       name: kogitomgmtconsoles.app.kiegroup.org
       resources:
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: ImageStreams
-        name: ""
+      - kind: ImageStream
+        name: A Openshift ImageStream
         version: image.openshift.io/v1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: Additional labels to be added to the Deployment and Pods managed
@@ -509,17 +509,17 @@ spec:
       kind: KogitoRuntime
       name: kogitoruntimes.app.kiegroup.org
       resources:
-      - kind: ConfigMaps
-        name: ""
+      - kind: ConfigMap
+        name: A Kubernetes ConfigMap
         version: v1
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: Additional labels to be added to the Deployment and Pods managed
@@ -597,17 +597,17 @@ spec:
       kind: KogitoTrusty
       name: kogitotrusties.app.kiegroup.org
       resources:
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: KafkaTopics
-        name: ""
+      - kind: KafkaTopic
+        name: A Kafka topic
         version: kafka.strimzi.io/v1beta1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: Additional labels to be added to the Deployment and Pods managed

--- a/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
@@ -122,11 +122,11 @@ spec:
       kind: KogitoBuild
       name: kogitobuilds.app.kiegroup.org
       resources:
-      - kind: BuildConfigs
-        name: ""
+      - kind: BuildConfig
+        name: A Openshift Build Config
         version: build.openshift.io/v1
-      - kind: ImageStreams
-        name: ""
+      - kind: ImageStream
+        name: A Openshift Image Stream
         version: image.openshift.io/v1
       specDescriptors:
       - description: Artifact contains override information for building the Maven
@@ -241,20 +241,20 @@ spec:
       kind: KogitoDataIndex
       name: kogitodataindices.app.kiegroup.org
       resources:
-      - kind: ConfigMaps
-        name: ""
+      - kind: ConfigMap
+        name: A Kubernetes ConfigMap
         version: v1
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: KafkaTopics
-        name: ""
+      - kind: KafkaTopic
+        name: A Kafka Topic
         version: kafka.strimzi.io/v1beta1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: Additional labels to be added to the Deployment and Pods managed
@@ -318,17 +318,17 @@ spec:
       kind: KogitoInfra
       name: kogitoinfras.app.kiegroup.org
       resources:
-      - kind: Infinispans
-        name: ""
+      - kind: Infinispan
+        name: A Infinispan instance
         version: infinispan.org/v1
       - kind: Kafka
-        name: ""
+        name: A Kafka instance
         version: ksafka.strimzi.io/v1beta1
-      - kind: Keycloaks
-        name: ""
+      - kind: Keycloak
+        name: A Keycloak Instance
         version: keycloak.org/v1alpha1
-      - kind: Secrets
-        name: ""
+      - kind: Secret
+        name: A Kubernetes Secret
         version: v1
       specDescriptors:
       - description: Indicates if Infinispan should be installed or not using Infinispan
@@ -359,17 +359,17 @@ spec:
       kind: KogitoJobsService
       name: kogitojobsservices.app.kiegroup.org
       resources:
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: ImageStreams
-        name: ""
+      - kind: ImageStream
+        name: A Openshift ImageStream
         version: image.openshift.io/v1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: 'Retry backOff time in milliseconds between the job execution
@@ -439,17 +439,17 @@ spec:
       kind: KogitoMgmtConsole
       name: kogitomgmtconsoles.app.kiegroup.org
       resources:
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: ImageStreams
-        name: ""
+      - kind: ImageStream
+        name: A Openshift ImageStream
         version: image.openshift.io/v1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: Additional labels to be added to the Deployment and Pods managed
@@ -509,17 +509,17 @@ spec:
       kind: KogitoRuntime
       name: kogitoruntimes.app.kiegroup.org
       resources:
-      - kind: ConfigMaps
-        name: ""
+      - kind: ConfigMap
+        name: A Kubernetes ConfigMap
         version: v1
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: Additional labels to be added to the Deployment and Pods managed
@@ -597,17 +597,17 @@ spec:
       kind: KogitoTrusty
       name: kogitotrusties.app.kiegroup.org
       resources:
-      - kind: Deployments
-        name: ""
+      - kind: Deployment
+        name: A Kubernetes Deployment
         version: apps/v1
-      - kind: KafkaTopics
-        name: ""
+      - kind: KafkaTopic
+        name: A Kafka topic
         version: kafka.strimzi.io/v1beta1
-      - kind: Routes
-        name: ""
+      - kind: Route
+        name: A Openshift Route
         version: route.openshift.io/v1
-      - kind: Services
-        name: ""
+      - kind: Service
+        name: A Kubernetes Service
         version: v1
       specDescriptors:
       - description: Additional labels to be added to the Deployment and Pods managed

--- a/pkg/apis/app/v1alpha1/kogitobuild_types.go
+++ b/pkg/apis/app/v1alpha1/kogitobuild_types.go
@@ -321,8 +321,8 @@ type WebHookSecret struct {
 // +kubebuilder:printcolumn:name="Maven URL",type="string",JSONPath=".spec.mavenMirrorURL",description="URL for the proxy Maven repository"
 // +kubebuilder:printcolumn:name="Kogito Runtime",type="string",JSONPath=".spec.targetKogitoRuntime",description="Target KogitoRuntime for this build"
 // +kubebuilder:printcolumn:name="Git Repository",type="string",JSONPath=".spec.gitSource.uri",description="Git repository URL (RemoteSource builds only)"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="ImageStreams,image.openshift.io/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="BuildConfigs,build.openshift.io/v1"
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="ImageStream,image.openshift.io/v1,\" A Openshift Image Stream\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="BuildConfig,build.openshift.io/v1,\" A Openshift Build Config\""
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="Kogito Build"
 type KogitoBuild struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/app/v1alpha1/kogitodataindex_types.go
+++ b/pkg/apis/app/v1alpha1/kogitodataindex_types.go
@@ -50,11 +50,11 @@ type KogitoDataIndexStatus struct {
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".status.image",description="Base image for this service"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.externalURI",description="External URI to access this service"
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="Kogito Data Index"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployments,apps/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Routes,route.openshift.io/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="ConfigMaps,v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Services,v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="KafkaTopics,kafka.strimzi.io/v1beta1"
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployment,apps/v1,\"A Kubernetes Deployment\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Route,route.openshift.io/v1,\"A Openshift Route\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="ConfigMap,v1,\"A Kubernetes ConfigMap\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Service,v1,\"A Kubernetes Service\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="KafkaTopic,kafka.strimzi.io/v1beta1,\"A Kafka Topic\""
 type KogitoDataIndex struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/app/v1alpha1/kogitoinfra_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoinfra_types.go
@@ -122,10 +122,10 @@ const (
 // +kubebuilder:printcolumn:name="Kafka",type="boolean",JSONPath=".spec.installKafka",description="Kafka should be installed"
 // +kubebuilder:printcolumn:name="Keycloak",type="boolean",JSONPath=".spec.installKeycloak",description="Keycloak should be installed"
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="Kogito Infra"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Kafka,ksafka.strimzi.io/v1beta1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Infinispans,infinispan.org/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Keycloaks,keycloak.org/v1alpha1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Secrets,v1"
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Kafka,ksafka.strimzi.io/v1beta1,\"A Kafka instance\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Infinispan,infinispan.org/v1,\"A Infinispan instance\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Keycloak,keycloak.org/v1alpha1,\"A Keycloak Instance\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Secret,v1,\"A Kubernetes Secret\""
 type KogitoInfra struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/app/v1alpha1/kogitojobsservice_types.go
+++ b/pkg/apis/app/v1alpha1/kogitojobsservice_types.go
@@ -59,10 +59,10 @@ type KogitoJobsServiceStatus struct {
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".status.image",description="Base image for this service"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.externalURI",description="External URI to access this service"
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="Kogito Jobs Services"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployments,apps/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Services,v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="ImageStreams,image.openshift.io/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Routes,route.openshift.io/v1"
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployment,apps/v1,\"A Kubernetes Deployment\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Service,v1,\"A Kubernetes Service\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="ImageStream,image.openshift.io/v1,\"A Openshift ImageStream\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Route,route.openshift.io/v1,\"A Openshift Route\""
 type KogitoJobsService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/app/v1alpha1/kogitomgmtconsole_types.go
+++ b/pkg/apis/app/v1alpha1/kogitomgmtconsole_types.go
@@ -42,10 +42,10 @@ type KogitoMgmtConsoleStatus struct {
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".status.image",description="Base image for this service"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.externalURI",description="External URI to access this service"
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="Kogito Management Console"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployments,apps/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Services,v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="ImageStreams,image.openshift.io/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Routes,route.openshift.io/v1"
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployment,apps/v1,\"A Kubernetes Deployment\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Service,v1,\"A Kubernetes Service\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="ImageStream,image.openshift.io/v1,\"A Openshift ImageStream\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Route,route.openshift.io/v1,\"A Openshift Route\""
 type KogitoMgmtConsole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/app/v1alpha1/kogitoruntime_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoruntime_types.go
@@ -59,10 +59,10 @@ type KogitoRuntimeStatus struct {
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".status.image",description="Image of this service"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.externalURI",description="External URI to access this service"
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="Kogito service"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployments,apps/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Routes,route.openshift.io/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="ConfigMaps,v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Services,v1"
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployment,apps/v1,\"A Kubernetes Deployment\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Route,route.openshift.io/v1,\"A Openshift Route\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="ConfigMap,v1,\"A Kubernetes ConfigMap\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Service,v1,\"A Kubernetes Service\""
 type KogitoRuntime struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/app/v1alpha1/kogitotrusty_types.go
+++ b/pkg/apis/app/v1alpha1/kogitotrusty_types.go
@@ -50,10 +50,10 @@ type KogitoTrustyStatus struct {
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".status.image",description="Base image for this service"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.externalURI",description="External URI to access this service"
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="Kogito Trusty"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployments,apps/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Routes,route.openshift.io/v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="Services,v1"
-// +operator-sdk:gen-csv:customresourcedefinitions.resources="KafkaTopics,kafka.strimzi.io/v1beta1"
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Deployment,apps/v1,\"A Kubernetes Deployment\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Route,route.openshift.io/v1,\"A Openshift Route\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="Service,v1,\"A Kubernetes Service\""
+// +operator-sdk:gen-csv:customresourcedefinitions.resources="KafkaTopic,kafka.strimzi.io/v1beta1,\"A Kafka topic\""
 type KogitoTrusty struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3104

For the resources showing I was able to test this for `KogitoRuntime` and `KogitoBuild` objects with these latest changes
For KogitoRuntime using the contents:
```
apiVersion: app.kiegroup.org/v1alpha1
kind: KogitoRuntime
metadata:
  name: process-business-rules-quarkus
spec:
  replicas: 1
  image:
    domain: quay.io
    name: process-business-rules-quarkus
    tag: latest
    namespace: kaitou786
```
Resources:

![Screenshot from 2020-09-03 14-06-38](https://user-images.githubusercontent.com/36669272/92091726-c3ba7e80-edee-11ea-945f-052ce7877015.png)

For KogitoBuild I tested with creating an object directly through openshift console, with a default value
Resources:
![Screenshot from 2020-09-03 14-08-42](https://user-images.githubusercontent.com/36669272/92091961-15630900-edef-11ea-9809-542551b78ef4.png)

If you want to test this you can use my registry image: `quay.io/kaitou786/temp-registry:latest` with these changes in CSV
And follow this [guide](https://www.openshift.com/blog/openshift-4-3-managing-catalog-sources-in-the-openshift-web-console) for creating the custom catalog source


Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
