### PR TITLE
[KOGITO-3304] - Relaxing regexp to match docker images with IPs and d…

### DIFF
--- a/cmd/kogito/command/converter/image_converter_test.go
+++ b/cmd/kogito/command/converter/image_converter_test.go
@@ -52,3 +52,33 @@ func Test_FromImageFlagToImage(t *testing.T) {
 	assert.Equal(t, "builder-image", image.Name)
 	assert.Equal(t, "1.0", image.Tag)
 }
+
+func Test_FromImageTagWithPortToImage(t *testing.T) {
+	buildImage := "mydomain.io:5050/mynamespace/builder-image:1.0"
+	image := FromImageTagToImage(buildImage, "2.0")
+	assert.NotNil(t, image)
+	assert.Equal(t, "mydomain.io:5050", image.Domain)
+	assert.Equal(t, "mynamespace", image.Namespace)
+	assert.Equal(t, "builder-image", image.Name)
+	assert.Equal(t, "1.0", image.Tag)
+}
+
+func Test_FromImageTagWithPortNoTagToImage(t *testing.T) {
+	buildImage := "mydomain.io:5050/mynamespace/builder-image"
+	image := FromImageTagToImage(buildImage, "2.0")
+	assert.NotNil(t, image)
+	assert.Equal(t, "mydomain.io:5050", image.Domain)
+	assert.Equal(t, "mynamespace", image.Namespace)
+	assert.Equal(t, "builder-image", image.Name)
+	assert.Equal(t, "latest", image.Tag)
+}
+
+func Test_FromImageTagWithPortNoLocalhostTagToImage(t *testing.T) {
+	buildImage := "localhost:5050/mynamespace/builder-image"
+	image := FromImageTagToImage(buildImage, "2.0")
+	assert.NotNil(t, image)
+	assert.Equal(t, "localhost:5050", image.Domain)
+	assert.Equal(t, "mynamespace", image.Namespace)
+	assert.Equal(t, "builder-image", image.Name)
+	assert.Equal(t, "latest", image.Tag)
+}

--- a/pkg/framework/image_test.go
+++ b/pkg/framework/image_test.go
@@ -38,6 +38,9 @@ func TestFromStringToImage(t *testing.T) {
 		{"tag empty", args{"myimage"}, v1alpha1.Image{Name: "myimage", Tag: "latest", Namespace: "", Domain: ""}},
 		{"tag empty with a trick", args{"myimage:"}, v1alpha1.Image{Name: "myimage", Tag: "latest", Namespace: "", Domain: ""}},
 		{"just tag", args{":1.0"}, v1alpha1.Image{Name: "", Tag: "1.0", Namespace: "", Domain: ""}},
+		{"localhost domain", args{"localhost:6000/namespace/image"}, v1alpha1.Image{Name: "image", Tag: "latest", Namespace: "namespace", Domain: "localhost:6000"}},
+		{"IP only", args{"10.10.2.1/namespace/image"}, v1alpha1.Image{Name: "image", Tag: "latest", Namespace: "namespace", Domain: "10.10.2.1"}},
+		{"IP and port", args{"10.10.2.1:5000/namespace/image"}, v1alpha1.Image{Name: "image", Tag: "latest", Namespace: "namespace", Domain: "10.10.2.1:5000"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
…omain without period

See: https://issues.redhat.com/browse/KOGITO-3304

In this PR we relaxed the regexp to match domain names that are just plain names like `localhost` or `my-cool-dns-at-home`. Also, there was a bug when parsing IPs. Now images like `192.168.0.2:3000/namespace/name:tag` will work as well.

@Kaitou786 @sutaakar I believe that you might need to rebase with this PR to unblock the KIND migration.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
