### PR TITLE
KOGITO-3332: Check whether jobs service is ready before deploying ser…

### DIFF
--- a/test/features/operator/deploy_kogito_runtime.feature
+++ b/test/features/operator/deploy_kogito_runtime.feature
@@ -84,6 +84,7 @@ Feature: Deploy Kogito Runtime
   Scenario Outline: Deploy <example-service> service with Jobs service and Maven profile <profile>
     Given Kogito Operator is deployed
     And Install Kogito Jobs Service with 1 replicas
+    And Kogito Jobs Service has 1 pods running within 10 minutes
     And Clone Kogito examples into local directory
     And Local example service "<example-service>" is built by Maven using profile "<profile>" and deployed to runtime registry
     And Deploy <runtime> example service "<example-service>" from runtime registry with configuration:


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3332
Description: There are some scenarios that require Jobs Service to work.
The problem is when we deploy kogito services that make use of jobs service and jobs service is not ready yet.
We need to ensure jobs service is ready before deploying the kogito services.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
