### PR TITLE
[0.15.x] KOGITO-3176 - disable standalone trusty test due to kafka change

### DIFF
--- a/test/features/install_trusty.feature
+++ b/test/features/install_trusty.feature
@@ -7,6 +7,7 @@ Feature: Kogito Trusty
     Given Namespace is created
     And Kogito Operator is deployed with Infinispan and Kafka operators
 
+  @disabled
   @smoke
   Scenario: Install Kogito Trusty
     When Install Kogito Trusty with 1 replicas

--- a/test/features/install_trusty.feature
+++ b/test/features/install_trusty.feature
@@ -14,6 +14,8 @@ Feature: Kogito Trusty
     
 #####
 
+  # Disabled as long as https://issues.redhat.com/browse/KOGITO-3176 is not solved
+  @disabled
   @externalcomponent
   @infinispan
   @kafka


### PR DESCRIPTION
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
