### PR TITLE
[KOGITO-3270] - Accepting external ConfigMaps to be mounted in a give…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,8 @@
+## Enhancements
+
+- [KOGITO-3270](https://issues.redhat.com/browse/KOGITO-3270) - Operator should support ConfigMap injecting in KogitoServices
+
+## Bug Fixes
+
+- 
+

--- a/cmd/kogito/command/flag/runtime_flag.go
+++ b/cmd/kogito/command/flag/runtime_flag.go
@@ -32,6 +32,7 @@ type RuntimeFlags struct {
 	EnablePersistence bool
 	EnableEvents      bool
 	ServiceLabels     []string
+	ConfigFile        string
 }
 
 // AddRuntimeFlags adds the RuntimeFlags to the given command
@@ -44,6 +45,7 @@ func AddRuntimeFlags(command *cobra.Command, flags *RuntimeFlags) {
 	command.Flags().BoolVar(&flags.EnablePersistence, "enable-persistence", false, "If set to true, deployed Kogito service will support integration with Infinispan server for persistence. Default to false")
 	command.Flags().BoolVar(&flags.EnableEvents, "enable-events", false, "If set to true, deployed Kogito service will support integration with Kafka cluster for events. Default to false")
 	command.Flags().StringSliceVar(&flags.ServiceLabels, "svc-labels", nil, "Labels that should be applied to the internal endpoint of the Kogito Service. Used by the service discovery engine. Example: 'label=value'. Can be set more than once.")
+	command.Flags().StringVar(&flags.ConfigFile, "config", "", "Path for custom application properties to be deployed with the service. This file will be mounted as an external ConfigMap to the service Deployment.")
 }
 
 // CheckRuntimeArgs validates the RuntimeFlags flags
@@ -62,6 +64,20 @@ func CheckRuntimeArgs(flags *RuntimeFlags) error {
 	}
 	if err := util.CheckKeyPair(flags.ServiceLabels); err != nil {
 		return fmt.Errorf("service labels are in the wrong format. Valid are key pairs like 'service=myservice', received %s", flags.ServiceLabels)
+	}
+	if err := checkConfigFile(flags.ConfigFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkConfigFile(configFilePath string) error {
+	if len(configFilePath) > 0 {
+		if exists, err := util.CheckFileExists(configFilePath); err != nil {
+			return err
+		} else if !exists {
+			return fmt.Errorf("configuration file does not exist in the given path: %s", configFilePath)
+		}
 	}
 	return nil
 }

--- a/cmd/kogito/command/service/config.go
+++ b/cmd/kogito/command/service/config.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	configMapPrefix     = "custom-properties"
+	configMapSuffix     = "custom-properties"
 	createdByAnnonKey   = "createdBy"
 	createdByAnnonValue = "Kogito CLI"
 )
@@ -38,7 +38,7 @@ func createConfigMapFromFile(cli *client.Client, flags *flag.RuntimeFlags) (cmNa
 		return "", nil
 	}
 	cm := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", flags.Name, configMapPrefix), Namespace: flags.Project},
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", flags.Name, configMapSuffix), Namespace: flags.Project},
 	}
 	fileContent, err := ioutil.ReadFile(flags.ConfigFile)
 	if err != nil {

--- a/cmd/kogito/command/service/config.go
+++ b/cmd/kogito/command/service/config.go
@@ -1,0 +1,69 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"fmt"
+	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/flag"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure/services"
+	"io/ioutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	configMapPrefix     = "-custom-properties"
+	createdByAnnonKey   = "createdBy"
+	createdByAnnonValue = "Kogito CLI"
+)
+
+// createConfigMapFromFile creates the custom ConfigMap based in the configuration file given in the flags parameter.
+// Does nothing if the config file path is empty
+func createConfigMapFromFile(cli *client.Client, flags *flag.RuntimeFlags) (cmName string, err error) {
+	if len(flags.ConfigFile) == 0 {
+		return "", nil
+	}
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", flags.Name, configMapPrefix), Namespace: flags.Project},
+	}
+	fileContent, err := ioutil.ReadFile(flags.ConfigFile)
+	if err != nil {
+		return "", err
+	}
+	exists, err := kubernetes.ResourceC(cli).Fetch(cm)
+	if err != nil {
+		return "", err
+	}
+	cm.Data = map[string]string{
+		services.ConfigMapApplicationPropertyKey: string(fileContent),
+	}
+	if cm.Annotations == nil {
+		cm.Annotations = map[string]string{}
+	}
+	cm.Annotations[createdByAnnonKey] = createdByAnnonValue
+	if exists {
+		if err := kubernetes.ResourceC(cli).Update(cm); err != nil {
+			return "", err
+		}
+	} else {
+		if err := kubernetes.ResourceC(cli).Create(cm); err != nil {
+			return "", err
+		}
+	}
+
+	return cm.Name, nil
+}

--- a/cmd/kogito/command/service/config.go
+++ b/cmd/kogito/command/service/config.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	configMapPrefix     = "-custom-properties"
+	configMapPrefix     = "custom-properties"
 	createdByAnnonKey   = "createdBy"
 	createdByAnnonValue = "Kogito CLI"
 )

--- a/cmd/kogito/command/service/runtime_service.go
+++ b/cmd/kogito/command/service/runtime_service.go
@@ -56,7 +56,10 @@ func (i runtimeService) InstallRuntimeService(cli *client.Client, flags *flag.Ru
 	if err != nil {
 		return err
 	}
-
+	configMap, err := createConfigMapFromFile(cli, flags)
+	if err != nil {
+		return err
+	}
 	kogitoRuntime := v1alpha1.KogitoRuntime{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      flags.Name,
@@ -74,6 +77,7 @@ func (i runtimeService) InstallRuntimeService(cli *client.Client, flags *flag.Ru
 				ServiceLabels:         util.FromStringsKeyPairToMap(flags.ServiceLabels),
 				HTTPPort:              flags.HTTPPort,
 				InsecureImageRegistry: flags.ImageFlags.InsecureImageRegistry,
+				PropertiesConfigMap:   configMap,
 			},
 			InfinispanMeta: infinispanMeta,
 			KafkaMeta:      converter.FromKafkaFlagsToKafkaMeta(&flags.KafkaFlags, flags.EnableEvents),

--- a/cmd/kogito/command/util/common_util.go
+++ b/cmd/kogito/command/util/common_util.go
@@ -17,6 +17,7 @@ package util
 import (
 	"fmt"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/framework"
+	"os"
 	"strings"
 )
 
@@ -88,4 +89,19 @@ func FromStringsKeyPairToMap(array []string) map[string]string {
 		}
 	}
 	return keyPairMap
+}
+
+// CheckFileExists checks if the given path is valid
+func CheckFileExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if info.IsDir() {
+		return false, nil
+	}
+	return true, nil
 }

--- a/cmd/kogito/command/util/common_util_test.go
+++ b/cmd/kogito/command/util/common_util_test.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"testing"
 )
 
@@ -63,4 +64,42 @@ func Test_ValidateImageTag_CorrectInput(t *testing.T) {
 	image := "quay.io/kiegroup/data_index:1.0"
 	err := CheckImageTag(image)
 	assert.NoError(t, err)
+}
+
+func TestCheckFileExists(t *testing.T) {
+	tempFile, err := ioutil.TempFile("", "application.properties")
+	assert.NoError(t, err)
+	tempDir, err := ioutil.TempDir("", "checkdir")
+	assert.NoError(t, err)
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			"File exists", args{path: tempFile.Name()}, true, false,
+		},
+		{
+			"It's a directory", args{path: tempDir}, false, false,
+		},
+		{
+			"File does not exists", args{"/an/imaginary/path"}, false, false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CheckFileExists(tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckFileExists() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("CheckFileExists() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/deploy/crds/app.kiegroup.org_kogitodataindices_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitodataindices_crd.yaml
@@ -155,7 +155,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -253,6 +253,14 @@ spec:
                     infrastructure.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/crds/app.kiegroup.org_kogitoexplainabilities_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitoexplainabilities_crd.yaml
@@ -156,7 +156,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -203,6 +203,14 @@ spec:
                     infrastructure.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/crds/app.kiegroup.org_kogitojobsservices_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitojobsservices_crd.yaml
@@ -162,7 +162,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -265,6 +265,14 @@ spec:
                 jobs, in case of failures. Default to service default, see: https://github.com/kiegroup/kogito-runtimes/wiki/Jobs-Service#configuration-properties'
               format: int64
               type: integer
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/crds/app.kiegroup.org_kogitomgmtconsoles_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitomgmtconsoles_crd.yaml
@@ -156,7 +156,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -180,6 +180,14 @@ spec:
                 Operator should be configured to allow pulling from insecure registries.
                 Usable just on OpenShift. Defaults to 'false'.
               type: boolean
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/crds/app.kiegroup.org_kogitoruntimes_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitoruntimes_crd.yaml
@@ -160,7 +160,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -272,6 +272,14 @@ spec:
                   description: Flag to allow Monitoring to scraping Kogito service.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/crds/app.kiegroup.org_kogitotrusties_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitotrusties_crd.yaml
@@ -155,7 +155,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -253,6 +253,14 @@ spec:
                     infrastructure.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/crds/app.kiegroup.org_kogitotrustyuis_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitotrustyuis_crd.yaml
@@ -155,7 +155,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -179,6 +179,14 @@ spec:
                 Operator should be configured to allow pulling from insecure registries.
                 Usable just on OpenShift. Defaults to 'false'.
               type: boolean
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitodataindices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitodataindices_crd.yaml
@@ -155,7 +155,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -253,6 +253,14 @@ spec:
                     infrastructure.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitoexplainabilities_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitoexplainabilities_crd.yaml
@@ -156,7 +156,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -203,6 +203,14 @@ spec:
                     infrastructure.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitojobsservices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitojobsservices_crd.yaml
@@ -162,7 +162,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -265,6 +265,14 @@ spec:
                 jobs, in case of failures. Default to service default, see: https://github.com/kiegroup/kogito-runtimes/wiki/Jobs-Service#configuration-properties'
               format: int64
               type: integer
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitomgmtconsoles_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitomgmtconsoles_crd.yaml
@@ -156,7 +156,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -180,6 +180,14 @@ spec:
                 Operator should be configured to allow pulling from insecure registries.
                 Usable just on OpenShift. Defaults to 'false'.
               type: boolean
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitoruntimes_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitoruntimes_crd.yaml
@@ -160,7 +160,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -272,6 +272,14 @@ spec:
                   description: Flag to allow Monitoring to scraping Kogito service.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitotrusties_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitotrusties_crd.yaml
@@ -155,7 +155,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -253,6 +253,14 @@ spec:
                     infrastructure.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitotrustyuis_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitotrustyuis_crd.yaml
@@ -155,7 +155,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -179,6 +179,14 @@ spec:
                 Operator should be configured to allow pulling from insecure registries.
                 Usable just on OpenShift. Defaults to 'false'.
               type: boolean
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
@@ -296,6 +296,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -487,10 +503,26 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: 'Maximum interval in milliseconds when retrying to execute jobs,
           in case of failures. Default to service default, see: https://github.com/kiegroup/kogito-runtimes/wiki/Jobs-Service#configuration-properties'
         displayName: Max Interval Limit To Retry Millis
         path: maxIntervalLimitToRetryMillis
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -562,6 +594,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -639,11 +687,27 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Create Service monitor instance to connect with Monitoring service
         displayName: Monitoring
         path: monitoring
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -720,6 +784,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -790,6 +870,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
@@ -383,6 +383,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitodataindices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitodataindices_crd.yaml
@@ -155,7 +155,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -253,6 +253,14 @@ spec:
                     infrastructure.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoexplainabilities_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoexplainabilities_crd.yaml
@@ -156,7 +156,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -203,6 +203,14 @@ spec:
                     infrastructure.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitojobsservices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitojobsservices_crd.yaml
@@ -162,7 +162,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -265,6 +265,14 @@ spec:
                 jobs, in case of failures. Default to service default, see: https://github.com/kiegroup/kogito-runtimes/wiki/Jobs-Service#configuration-properties'
               format: int64
               type: integer
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitomgmtconsoles_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitomgmtconsoles_crd.yaml
@@ -156,7 +156,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -180,6 +180,14 @@ spec:
                 Operator should be configured to allow pulling from insecure registries.
                 Usable just on OpenShift. Defaults to 'false'.
               type: boolean
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoruntimes_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoruntimes_crd.yaml
@@ -160,7 +160,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -272,6 +272,14 @@ spec:
                   description: Flag to allow Monitoring to scraping Kogito service.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitotrusties_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitotrusties_crd.yaml
@@ -155,7 +155,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -253,6 +253,14 @@ spec:
                     infrastructure.
                   type: boolean
               type: object
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitotrustyuis_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitotrustyuis_crd.yaml
@@ -155,7 +155,7 @@ spec:
               type: array
               x-kubernetes-list-type: atomic
             httpPort:
-              description: HttpPort will set the environment env HTTP_PORT to define
+              description: HTTPPort will set the environment env HTTP_PORT to define
                 which port service will listen internally.
               format: int32
               type: integer
@@ -179,6 +179,14 @@ spec:
                 Operator should be configured to allow pulling from insecure registries.
                 Usable just on OpenShift. Defaults to 'false'.
               type: boolean
+            propertiesConfigMap:
+              description: Custom ConfigMap with application.properties file to be
+                mounted for the Kogito service. The ConfigMap must be created in the
+                same namespace. Use this property if you need custom properties to
+                be mounted before the application deployment. If left empty, one will
+                be created for you. Later it can be updated to add any custom properties
+                to apply to the service.
+              type: string
             replicas:
               description: 'Number of replicas that the service will have deployed
                 in the cluster. Default value: 1.'

--- a/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
@@ -296,6 +296,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -487,10 +503,26 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: 'Maximum interval in milliseconds when retrying to execute jobs,
           in case of failures. Default to service default, see: https://github.com/kiegroup/kogito-runtimes/wiki/Jobs-Service#configuration-properties'
         displayName: Max Interval Limit To Retry Millis
         path: maxIntervalLimitToRetryMillis
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -562,6 +594,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -639,11 +687,27 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Create Service monitor instance to connect with Monitoring service
         displayName: Monitoring
         path: monitoring
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -720,6 +784,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas
@@ -790,6 +870,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas

--- a/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
@@ -383,6 +383,22 @@ spec:
           image.'
         displayName: Image
         path: image
+      - description: A flag indicating that image streams created by Kogito Operator
+          should be configured to allow pulling from insecure registries. Usable just
+          on OpenShift. Defaults to 'false'.
+        displayName: Insecure Image Registry
+        path: insecureImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Custom ConfigMap with application.properties file to be mounted
+          for the Kogito service. The ConfigMap must be created in the same namespace.
+          Use this property if you need custom properties to be mounted before the
+          application deployment. If left empty, one will be created for you. Later
+          it can be updated to add any custom properties to apply to the service.
+        displayName: ConfigMap Properties
+        path: propertiesConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Number of replicas that the service will have deployed in the
           cluster. Default value: 1.'
         displayName: Replicas

--- a/pkg/apis/app/v1alpha1/kogitoservices_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoservices_types.go
@@ -116,6 +116,7 @@ type KogitoServiceSpecInterface interface {
 	GetHTTPPort() int32
 	SetHTTPPort(httpPort int32)
 	IsInsecureImageRegistry() bool
+	GetPropertiesConfigMap() string
 }
 
 // KogitoServiceSpec is the basic structure for the Kogito Service specification.
@@ -145,6 +146,9 @@ type KogitoServiceSpec struct {
 	// A flag indicating that image streams created by Kogito Operator should be configured to allow pulling from insecure registries.
 	// Usable just on OpenShift.
 	// Defaults to 'false'.
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Insecure Image Registry"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	InsecureImageRegistry bool `json:"insecureImageRegistry,omitempty"`
 
 	// Defined compute resource requirements for the deployed service.
@@ -165,9 +169,19 @@ type KogitoServiceSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	ServiceLabels map[string]string `json:"serviceLabels,omitempty"`
 
-	// HttpPort will set the environment env HTTP_PORT to define which port service will listen internally.
+	// HTTPPort will set the environment env HTTP_PORT to define which port service will listen internally.
 	// +optional
 	HTTPPort int32 `json:"httpPort,omitempty"`
+
+	// +optional
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="ConfigMap Properties"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	// Custom ConfigMap with application.properties file to be mounted for the Kogito service.
+	// The ConfigMap must be created in the same namespace.
+	// Use this property if you need custom properties to be mounted before the application deployment.
+	// If left empty, one will be created for you. Later it can be updated to add any custom properties to apply to the service.
+	PropertiesConfigMap string `json:"propertiesConfigMap,omitempty"`
 }
 
 // GetReplicas ...
@@ -279,3 +293,6 @@ func (k *KogitoServiceSpec) AddServiceLabel(name, value string) {
 
 // IsInsecureImageRegistry ...
 func (k *KogitoServiceSpec) IsInsecureImageRegistry() bool { return k.InsecureImageRegistry }
+
+// GetPropertiesConfigMap ...
+func (k *KogitoServiceSpec) GetPropertiesConfigMap() string { return k.PropertiesConfigMap }

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -564,9 +564,16 @@ func schema_pkg_apis_app_v1alpha1_KogitoDataIndexSpec(ref common.ReferenceCallba
 					},
 					"httpPort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "HttpPort will set the environment env HTTP_PORT to define which port service will listen internally.",
+							Description: "HTTPPort will set the environment env HTTP_PORT to define which port service will listen internally.",
 							Type:        []string{"integer"},
 							Format:      "int32",
+						},
+					},
+					"propertiesConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Custom ConfigMap with application.properties file to be mounted for the Kogito service. The ConfigMap must be created in the same namespace. Use this property if you need custom properties to be mounted before the application deployment. If left empty, one will be created for you. Later it can be updated to add any custom properties to apply to the service.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -1097,9 +1104,16 @@ func schema_pkg_apis_app_v1alpha1_KogitoJobsServiceSpec(ref common.ReferenceCall
 					},
 					"httpPort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "HttpPort will set the environment env HTTP_PORT to define which port service will listen internally.",
+							Description: "HTTPPort will set the environment env HTTP_PORT to define which port service will listen internally.",
 							Type:        []string{"integer"},
 							Format:      "int32",
+						},
+					},
+					"propertiesConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Custom ConfigMap with application.properties file to be mounted for the Kogito service. The ConfigMap must be created in the same namespace. Use this property if you need custom properties to be mounted before the application deployment. If left empty, one will be created for you. Later it can be updated to add any custom properties to apply to the service.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"backOffRetryMillis": {
@@ -1412,9 +1426,16 @@ func schema_pkg_apis_app_v1alpha1_KogitoTrustySpec(ref common.ReferenceCallback)
 					},
 					"httpPort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "HttpPort will set the environment env HTTP_PORT to define which port service will listen internally.",
+							Description: "HTTPPort will set the environment env HTTP_PORT to define which port service will listen internally.",
 							Type:        []string{"integer"},
 							Format:      "int32",
+						},
+					},
+					"propertiesConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Custom ConfigMap with application.properties file to be mounted for the Kogito service. The ConfigMap must be created in the same namespace. Use this property if you need custom properties to be mounted before the application deployment. If left empty, one will be created for you. Later it can be updated to add any custom properties to apply to the service.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -772,9 +772,16 @@ func schema_pkg_apis_app_v1alpha1_KogitoExplainabilitySpec(ref common.ReferenceC
 					},
 					"httpPort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "HttpPort will set the environment env HTTP_PORT to define which port service will listen internally.",
+							Description: "HTTPPort will set the environment env HTTP_PORT to define which port service will listen internally.",
 							Type:        []string{"integer"},
 							Format:      "int32",
+						},
+					},
+					"propertiesConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Custom ConfigMap with application.properties file to be mounted for the Kogito service. The ConfigMap must be created in the same namespace. Use this property if you need custom properties to be mounted before the application deployment. If left empty, one will be created for you. Later it can be updated to add any custom properties to apply to the service.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"kafka": {

--- a/pkg/client/kubernetes/resource_reader.go
+++ b/pkg/client/kubernetes/resource_reader.go
@@ -39,7 +39,7 @@ type ResourceReader interface {
 	// ListWithNamespaceAndLabel same as ListWithNamespace, but also limit the query scope by the given labels
 	ListWithNamespaceAndLabel(namespace string, list runtime.Object, labels map[string]string) error
 	// ListAll returns a map of Kubernetes resources organized by type, based on provided List objects
-	ListALL(objectTypes []runtime.Object, namespace string, ownerObject metav1.Object) (map[reflect.Type][]resource2.KubernetesResource, error)
+	ListAll(objectTypes []runtime.Object, namespace string, ownerObject metav1.Object) (map[reflect.Type][]resource2.KubernetesResource, error)
 }
 
 // ResourceReaderC provide ResourceReader reference
@@ -91,7 +91,7 @@ func (r *resourceReader) ListWithNamespaceAndLabel(namespace string, list runtim
 	return nil
 }
 
-func (r *resourceReader) ListALL(objectTypes []runtime.Object, namespace string, ownerObject metav1.Object) (map[reflect.Type][]resource2.KubernetesResource, error) {
+func (r *resourceReader) ListAll(objectTypes []runtime.Object, namespace string, ownerObject metav1.Object) (map[reflect.Type][]resource2.KubernetesResource, error) {
 	reader := read.New(r.client.ControlCli).WithNamespace(namespace).WithOwnerObject(ownerObject)
 	return reader.ListAll(objectTypes...)
 }

--- a/pkg/controller/kogitobuild/build/manager.go
+++ b/pkg/controller/kogitobuild/build/manager.go
@@ -51,7 +51,7 @@ type manager struct {
 func (m *manager) GetDeployedResources() (map[reflect.Type][]resource.KubernetesResource, error) {
 	objectTypes := []runtime.Object{&buildv1.BuildConfigList{}}
 	objectTypes = append(objectTypes, &imgv1.ImageStreamList{})
-	resources, err := kubernetes.ResourceC(m.client).ListALL(objectTypes, m.kogitoBuild.Namespace, m.kogitoBuild)
+	resources, err := kubernetes.ResourceC(m.client).ListAll(objectTypes, m.kogitoBuild.Namespace, m.kogitoBuild)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/infrastructure/services/configmap.go
+++ b/pkg/infrastructure/services/configmap.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	appPropConfigMapSuffix = "-properties"
-	appPropContentKey      = "application.properties"
 	defaultAppPropContent  = ""
 
 	// AppPropContentHashKey is the annotation key for the content hash of application.properties
@@ -38,8 +37,9 @@ const (
 	AppPropVolumeName = "app-prop-config"
 
 	appPropDefaultMode = int32(420)
-	appPropFileName    = "application.properties"
-	appPropFilePath    = "/home/kogito/config"
+	// ConfigMapApplicationPropertyKey is the file name used as a key for ConfigMaps mounted in Kogito services deployments
+	ConfigMapApplicationPropertyKey = "application.properties"
+	appPropFilePath                 = "/home/kogito/config"
 
 	appPropConcatPattern = "%s\n%s=%s"
 )
@@ -72,10 +72,10 @@ func getAppPropConfigMapContentHash(service v1alpha1.KogitoService, appProps map
 		}
 	}
 	configMap.Data = map[string]string{
-		appPropContentKey: appPropContent,
+		ConfigMapApplicationPropertyKey: appPropContent,
 	}
 
-	contentHash := fmt.Sprintf("%x", md5.Sum([]byte(configMap.Data[appPropContentKey])))
+	contentHash := fmt.Sprintf("%x", md5.Sum([]byte(configMap.Data[ConfigMapApplicationPropertyKey])))
 
 	return contentHash, configMap, nil
 }
@@ -110,8 +110,8 @@ func createAppPropVolume(service v1alpha1.KogitoService) corev1.Volume {
 				},
 				Items: []corev1.KeyToPath{
 					{
-						Key:  appPropContentKey,
-						Path: appPropFileName,
+						Key:  ConfigMapApplicationPropertyKey,
+						Path: ConfigMapApplicationPropertyKey,
 					},
 				},
 				DefaultMode: &defaultMode,
@@ -124,8 +124,8 @@ func createAppPropVolume(service v1alpha1.KogitoService) corev1.Volume {
 func getAppPropsFromConfigMap(configMap *corev1.ConfigMap, exist bool) map[string]string {
 	appProps := map[string]string{}
 	if exist {
-		if _, ok := configMap.Data[appPropContentKey]; ok {
-			props := strings.Split(configMap.Data[appPropContentKey], "\n")
+		if _, ok := configMap.Data[ConfigMapApplicationPropertyKey]; ok {
+			props := strings.Split(configMap.Data[ConfigMapApplicationPropertyKey], "\n")
 			for _, p := range props {
 				ps := strings.Split(p, "=")
 				if len(ps) > 1 {

--- a/pkg/infrastructure/services/configmap_test.go
+++ b/pkg/infrastructure/services/configmap_test.go
@@ -15,6 +15,7 @@
 package services
 
 import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
 	corev1 "k8s.io/api/core/v1"
@@ -25,16 +26,17 @@ import (
 )
 
 func TestGetAppPropConfigMapContentHash(t *testing.T) {
-	serviceName := "test"
-	serviceNamespace := "test"
+	service := &v1alpha1.KogitoRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+	}
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName + appPropConfigMapSuffix,
-			Namespace: serviceNamespace,
+			Name:      service.Name + appPropConfigMapSuffix,
+			Namespace: service.Namespace,
 		},
 		Data: map[string]string{
 			appPropFileName: defaultAppPropContent,
@@ -42,10 +44,9 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 	}
 
 	type args struct {
-		name      string
-		namespace string
-		appProps  map[string]string
-		cli       *client.Client
+		instance v1alpha1.KogitoService
+		appProps map[string]string
+		cli      *client.Client
 	}
 	tests := []struct {
 		name    string
@@ -57,16 +58,15 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 		{
 			"No ConfigMap, empty appProps",
 			args{
-				serviceName,
-				serviceNamespace,
+				service,
 				map[string]string{},
 				test.CreateFakeClientOnOpenShift([]runtime.Object{}, nil, nil),
 			},
 			"d41d8cd98f00b204e9800998ecf8427e",
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName + appPropConfigMapSuffix,
-					Namespace: serviceNamespace,
+					Name:      service.Name + appPropConfigMapSuffix,
+					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
 					appPropFileName: defaultAppPropContent,
@@ -77,16 +77,15 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 		{
 			"No ConfigMap, nil appProps",
 			args{
-				serviceName,
-				serviceNamespace,
+				service,
 				nil,
 				test.CreateFakeClientOnOpenShift([]runtime.Object{}, nil, nil),
 			},
 			"d41d8cd98f00b204e9800998ecf8427e",
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName + appPropConfigMapSuffix,
-					Namespace: serviceNamespace,
+					Name:      service.Name + appPropConfigMapSuffix,
+					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
 					appPropFileName: defaultAppPropContent,
@@ -97,8 +96,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 		{
 			"Default ConfigMap, empty appProps",
 			args{
-				serviceName,
-				serviceNamespace,
+				service,
 				map[string]string{},
 				test.CreateFakeClientOnOpenShift([]runtime.Object{cm}, nil, nil),
 			},
@@ -109,13 +107,12 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 		{
 			"Empty ConfigMap, empty appProps",
 			args{
-				serviceName,
-				serviceNamespace,
+				service,
 				map[string]string{},
 				test.CreateFakeClientOnOpenShift([]runtime.Object{&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      serviceName + appPropConfigMapSuffix,
-						Namespace: serviceNamespace,
+						Name:      service.Name + appPropConfigMapSuffix,
+						Namespace: service.Namespace,
 					},
 					Data: map[string]string{},
 				}}, nil, nil),
@@ -127,8 +124,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 		{
 			"No ConfigMap, appProps with data",
 			args{
-				serviceName,
-				serviceNamespace,
+				service,
 				map[string]string{
 					"test1": "abc",
 					"test2": "def",
@@ -139,8 +135,8 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 			"bb2bea2d5b08e3d93142da5b17ed2af0",
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName + appPropConfigMapSuffix,
-					Namespace: serviceNamespace,
+					Name:      service.Name + appPropConfigMapSuffix,
+					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
 					appPropFileName: "\ntest1=abc\ntest2=def\ntest3=ghi",
@@ -151,13 +147,12 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 		{
 			"ConfigMap with data, empty appProps",
 			args{
-				serviceName,
-				serviceNamespace,
+				service,
 				map[string]string{},
 				test.CreateFakeClientOnOpenShift([]runtime.Object{&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      serviceName + appPropConfigMapSuffix,
-						Namespace: serviceNamespace,
+						Name:      service.Name + appPropConfigMapSuffix,
+						Namespace: service.Namespace,
 					},
 					Data: map[string]string{
 						appPropFileName: "\ntest1=123\ntest2=456\ntest3=789\ntest4=012\ntest5=345",
@@ -171,8 +166,8 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName + appPropConfigMapSuffix,
-					Namespace: serviceNamespace,
+					Name:      service.Name + appPropConfigMapSuffix,
+					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
 					appPropFileName: "\ntest1=123\ntest2=456\ntest3=789\ntest4=012\ntest5=345",
@@ -183,8 +178,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 		{
 			"ConfigMap with data, appProps with data",
 			args{
-				serviceName,
-				serviceNamespace,
+				service,
 				map[string]string{
 					"test1": "abc",
 					"test2": "def",
@@ -193,8 +187,8 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 				},
 				test.CreateFakeClientOnOpenShift([]runtime.Object{&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      serviceName + appPropConfigMapSuffix,
-						Namespace: serviceNamespace,
+						Name:      service.Name + appPropConfigMapSuffix,
+						Namespace: service.Namespace,
 					},
 					Data: map[string]string{
 						appPropFileName: "\ntest1=123\ntest2=456\ntest3=789\ntest4=012\ntest5=345",
@@ -208,8 +202,8 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName + appPropConfigMapSuffix,
-					Namespace: serviceNamespace,
+					Name:      service.Name + appPropConfigMapSuffix,
+					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
 					appPropFileName: "\ntest1=abc\ntest2=def\ntest3=ghi\ntest4=012\ntest5=345\ntest7=jkl",
@@ -220,17 +214,17 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := GetAppPropConfigMapContentHash(tt.args.name, tt.args.namespace, tt.args.appProps, tt.args.cli)
+			got, got1, err := getAppPropConfigMapContentHash(tt.args.instance, tt.args.appProps, tt.args.cli)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetAppPropConfigMapContentHash() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("getAppPropConfigMapContentHash() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("GetAppPropConfigMapContentHash() got = %v, want %v", got, tt.want)
+				t.Errorf("getAppPropConfigMapContentHash() got = %v, want %v", got, tt.want)
 				return
 			}
 			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("GetAppPropConfigMapContentHash() got1 = %v, want %v", got1, tt.want1)
+				t.Errorf("getAppPropConfigMapContentHash() got1 = %v, want %v", got1, tt.want1)
 			}
 		})
 	}

--- a/pkg/infrastructure/services/configmap_test.go
+++ b/pkg/infrastructure/services/configmap_test.go
@@ -39,7 +39,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 			Namespace: service.Namespace,
 		},
 		Data: map[string]string{
-			appPropFileName: defaultAppPropContent,
+			ConfigMapApplicationPropertyKey: defaultAppPropContent,
 		},
 	}
 
@@ -69,7 +69,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
-					appPropFileName: defaultAppPropContent,
+					ConfigMapApplicationPropertyKey: defaultAppPropContent,
 				},
 			},
 			false,
@@ -88,7 +88,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
-					appPropFileName: defaultAppPropContent,
+					ConfigMapApplicationPropertyKey: defaultAppPropContent,
 				},
 			},
 			false,
@@ -139,7 +139,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
-					appPropFileName: "\ntest1=abc\ntest2=def\ntest3=ghi",
+					ConfigMapApplicationPropertyKey: "\ntest1=abc\ntest2=def\ntest3=ghi",
 				},
 			},
 			false,
@@ -155,7 +155,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 						Namespace: service.Namespace,
 					},
 					Data: map[string]string{
-						appPropFileName: "\ntest1=123\ntest2=456\ntest3=789\ntest4=012\ntest5=345",
+						ConfigMapApplicationPropertyKey: "\ntest1=123\ntest2=456\ntest3=789\ntest4=012\ntest5=345",
 					},
 				}}, nil, nil),
 			},
@@ -170,7 +170,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
-					appPropFileName: "\ntest1=123\ntest2=456\ntest3=789\ntest4=012\ntest5=345",
+					ConfigMapApplicationPropertyKey: "\ntest1=123\ntest2=456\ntest3=789\ntest4=012\ntest5=345",
 				},
 			},
 			false,
@@ -191,7 +191,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 						Namespace: service.Namespace,
 					},
 					Data: map[string]string{
-						appPropFileName: "\ntest1=123\ntest2=456\ntest3=789\ntest4=012\ntest5=345",
+						ConfigMapApplicationPropertyKey: "\ntest1=123\ntest2=456\ntest3=789\ntest4=012\ntest5=345",
 					},
 				}}, nil, nil),
 			},
@@ -206,7 +206,7 @@ func TestGetAppPropConfigMapContentHash(t *testing.T) {
 					Namespace: service.Namespace,
 				},
 				Data: map[string]string{
-					appPropFileName: "\ntest1=abc\ntest2=def\ntest3=ghi\ntest4=012\ntest5=345\ntest7=jkl",
+					ConfigMapApplicationPropertyKey: "\ntest1=abc\ntest2=def\ntest3=ghi\ntest4=012\ntest5=345\ntest7=jkl",
 				},
 			},
 			false,
@@ -261,7 +261,7 @@ func Test_getAppPropsFromConfigMap(t *testing.T) {
 			args{
 				&corev1.ConfigMap{
 					Data: map[string]string{
-						appPropContentKey: "",
+						ConfigMapApplicationPropertyKey: "",
 					},
 				},
 				true,
@@ -273,7 +273,7 @@ func Test_getAppPropsFromConfigMap(t *testing.T) {
 			args{
 				&corev1.ConfigMap{
 					Data: map[string]string{
-						appPropContentKey: "\ntest1=test1\ntest2=test2\ntest3=test3",
+						ConfigMapApplicationPropertyKey: "\ntest1=test1\ntest2=test2\ntest3=test3",
 					},
 				},
 				true,

--- a/pkg/infrastructure/services/deployer.go
+++ b/pkg/infrastructure/services/deployer.go
@@ -16,6 +16,8 @@ package services
 
 import (
 	"fmt"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"time"
 
@@ -209,6 +211,16 @@ func (s *serviceDeployer) Deploy() (reconcileAfter time.Duration, err error) {
 		}
 	}
 
+	// we need to take ownership of the custom configmap provided
+	if len(s.instance.GetSpec().GetPropertiesConfigMap()) > 0 {
+		reconcileAfter, err = s.takeCustomConfigMapOwnership()
+		if err != nil {
+			return
+		} else if reconcileAfter > 0 {
+			return
+		}
+	}
+
 	// create our resources
 	requestedResources, reconcileAfter, err := s.createRequiredResources()
 	if err != nil {
@@ -367,6 +379,28 @@ func (s *serviceDeployer) deployKafka() (requeueAfter time.Duration, err error) 
 		}
 	}
 	return
+}
+
+func (s *serviceDeployer) takeCustomConfigMapOwnership() (time.Duration, error) {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: s.instance.GetSpec().GetPropertiesConfigMap(), Namespace: s.getNamespace()},
+	}
+	if exists, err := kubernetes.ResourceC(s.client).Fetch(cm); err != nil {
+		return 0, err
+	} else if !exists {
+		s.recorder.Eventf(s.client, s.instance, v1.EventTypeWarning, "NotExists", "ConfigMap %s does not exist a new one will be created", s.instance.GetSpec().GetPropertiesConfigMap())
+		return 0, nil
+	}
+	if framework.IsOwner(cm, s.instance) {
+		return 0, nil
+	}
+	if err := framework.AddOwnerReference(s.instance, s.scheme, cm); err != nil {
+		return 0, err
+	}
+	if err := kubernetes.ResourceC(s.client).Update(cm); err != nil {
+		return 0, err
+	}
+	return time.Second * 15, nil
 }
 
 func (s *serviceDeployer) update() error {

--- a/pkg/infrastructure/services/resources.go
+++ b/pkg/infrastructure/services/resources.go
@@ -40,8 +40,6 @@ const (
 	enableEventsEnvKey      = "ENABLE_EVENTS"
 )
 
-// TODO: review the way we create those resources on KOGITO-1998: reorganize all those functions on other files within the package
-
 // createRequiredResources creates the required resources given the KogitoService instance
 func (s *serviceDeployer) createRequiredResources() (resources map[reflect.Type][]resource.KubernetesResource, reconcileAfter time.Duration, err error) {
 	reconcileAfter = 0
@@ -85,8 +83,7 @@ func (s *serviceDeployer) createRequiredResources() (resources map[reflect.Type]
 			}
 		}
 
-		// TODO: refactor GetAppPropConfigMapContentHash to createConfigMap on KOGITO-1998
-		contentHash, configMap, err := GetAppPropConfigMapContentHash(s.instance.GetName(), s.instance.GetNamespace(), appProps, s.client)
+		contentHash, configMap, err := getAppPropConfigMapContentHash(s.instance, appProps, s.client)
 		if err != nil {
 			return resources, reconcileAfter, err
 		}
@@ -260,14 +257,14 @@ func (s *serviceDeployer) applyApplicationPropertiesConfigurations(contentHash s
 		deployment.Spec.Template.Annotations[AppPropContentHashKey] = contentHash
 	}
 	if deployment.Spec.Template.Spec.Volumes == nil {
-		deployment.Spec.Template.Spec.Volumes = []corev1.Volume{CreateAppPropVolume(instance.GetName())}
+		deployment.Spec.Template.Spec.Volumes = []corev1.Volume{createAppPropVolume(instance)}
 	} else {
-		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, CreateAppPropVolume(instance.GetName()))
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, createAppPropVolume(instance))
 	}
 	if deployment.Spec.Template.Spec.Containers[0].VolumeMounts == nil {
-		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{CreateAppPropVolumeMount()}
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{createAppPropVolumeMount()}
 	} else {
-		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, CreateAppPropVolumeMount())
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, createAppPropVolumeMount())
 	}
 }
 
@@ -292,7 +289,7 @@ func (s *serviceDeployer) getDeployedResources() (resources map[reflect.Type][]r
 		objectTypes = append(objectTypes, s.definition.extraManagedObjectLists...)
 	}
 
-	resources, err = kubernetes.ResourceC(s.client).ListALL(objectTypes, s.instance.GetNamespace(), s.instance)
+	resources, err = kubernetes.ResourceC(s.client).ListAll(objectTypes, s.instance.GetNamespace(), s.instance)
 	if err != nil {
 		return
 	}

--- a/pkg/infrastructure/services/resources_test.go
+++ b/pkg/infrastructure/services/resources_test.go
@@ -184,7 +184,7 @@ func Test_serviceDeployer_createRequiredResources_CreateNewAppPropConfigMap(t *t
 	assert.True(t, ok)
 	_, ok = deployment.Spec.Template.Annotations[AppPropContentHashKey]
 	assert.True(t, ok)
-	_, ok = resources[reflect.TypeOf(corev1.ConfigMap{})][0].(*corev1.ConfigMap).Data[appPropContentKey]
+	_, ok = resources[reflect.TypeOf(corev1.ConfigMap{})][0].(*corev1.ConfigMap).Data[ConfigMapApplicationPropertyKey]
 	assert.True(t, ok)
 }
 
@@ -210,7 +210,7 @@ func Test_serviceDeployer_createRequiredResources_CreateWithAppPropConfigMap(t *
 			Namespace: instance.Namespace,
 		},
 		Data: map[string]string{
-			appPropFileName: defaultAppPropContent,
+			ConfigMapApplicationPropertyKey: defaultAppPropContent,
 		},
 	}
 	cli := test.CreateFakeClientOnOpenShift([]runtime.Object{instance, is, cm}, []runtime.Object{tag}, nil)


### PR DESCRIPTION
…n KogitoService

See: https://issues.redhat.com/browse/KOGITO-3270

In this PR we introduce a new attribute in the Kogito services interface, which can be informed to tell the operator to not create a configMap, but to use the one given in advance. This way users can configure the application upfront using an external process (like a CI) before deploying a given Kogito service in the namespace.

For example, one can create a configMap with:

```shell
$ oc create configmap mycustom-configmap --from-file=application.properties 
```

And then deploy the KogitoRuntime with:

```yaml
apiVersion: app.kiegroup.org/v1alpha1
kind: KogitoRuntime
metadata:
  name: process-quarkus-example
spec:
  propertiesConfigMap: mycustom-configmap
  replicas: 1
  image:
    domain: quay.io
    namespace: kiegroup
    name: process-quarkus-example
```

The same applies for any other supporting service like Management Console or Data Index.

Every property from the given CM, manually inserted properties, or properties manipulated by the operator will be in this CM and managed by the operator.

Note: I'm adding a RELEASE_NOTES.md file to be used later by our CI to create the Release Notes in the GH page. Please update this file from now on when sending a PR that have a feature/bug fix that needs to be included in the release notes.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
