### PR TITLE
KOGITO-3359: Cucumber Tests: Add Trusty Custom Resources in logs

### DIFF
--- a/test/steps/data.go
+++ b/test/steps/data.go
@@ -109,7 +109,7 @@ func (data *Data) AfterScenario(scenario *godog.Scenario, err error) error {
 		if err := framework.BumpEvents(data.Namespace); err != nil {
 			framework.GetMainLogger().Errorf("Error bumping events for namespace %s: %v", namespace, err)
 		}
-		if err := framework.LogKubernetesObjects(data.Namespace, &imgv1.ImageStreamList{}, &appv1alpha1.KogitoRuntimeList{}, &appv1alpha1.KogitoBuildList{}, &appv1alpha1.KogitoDataIndexList{}, &appv1alpha1.KogitoInfraList{}, &appv1alpha1.KogitoJobsServiceList{}, &appv1alpha1.KogitoMgmtConsoleList{}); err != nil {
+		if err := framework.LogKubernetesObjects(data.Namespace, &imgv1.ImageStreamList{}, &appv1alpha1.KogitoRuntimeList{}, &appv1alpha1.KogitoBuildList{}, &appv1alpha1.KogitoDataIndexList{}, &appv1alpha1.KogitoInfraList{}, &appv1alpha1.KogitoJobsServiceList{}, &appv1alpha1.KogitoMgmtConsoleList{}, &appv1alpha1.KogitoTrustyList{}); err != nil {
 			framework.GetMainLogger().Errorf("Error logging Kubernetes objects for namespace %s: %v", namespace, err)
 		}
 		return nil


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3359
Description: Add the Trusty custom resource instances when running the cucumber tests.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
