### PR TITLE
[KOGITO-3350] CLI fails to download GitHub file properly

### DIFF
--- a/cmd/kogito/command/service/buildresource_service.go
+++ b/cmd/kogito/command/service/buildresource_service.go
@@ -72,6 +72,14 @@ func GetResourceType(resource string) (ResourceType flag.ResourceType, err error
 	return "", fmt.Errorf("invalid resource %s", resource)
 }
 
+// getRawGitHubFileURL converts the GitHub URL of a file to
+// its raw URL for downloading purposes
+func getRawGitHubFileURL(resource string) string {
+	fileURL := strings.Replace(resource, "github.com", "raw.githubusercontent.com", 1)
+	fileURL = strings.Replace(fileURL, "blob/", "", 1)
+	return fileURL
+}
+
 // LoadGitFileIntoMemory reads file from remote Git location and load it in memory.
 func LoadGitFileIntoMemory(resource string) (io.Reader, string, error) {
 	log := context.GetDefaultLogger()
@@ -79,7 +87,12 @@ func LoadGitFileIntoMemory(resource string) (io.Reader, string, error) {
 	ff := strings.Split(parsedURL.Path, "/")
 	fileName := strings.Join(strings.Fields(ff[len(ff)-1]), "")
 
-	response, err := http.Get(resource)
+	fileURL := resource
+	if strings.Contains(resource, "github.com") {
+		fileURL = getRawGitHubFileURL(resource)
+	}
+
+	response, err := http.Get(fileURL)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to download %s, error message: %s", resource, err.Error())
 	}

--- a/cmd/kogito/command/service/buildresource_service_test.go
+++ b/cmd/kogito/command/service/buildresource_service_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import "testing"
+
+func Test_getRawGitHubFileURL(t *testing.T) {
+	type args struct {
+		resource string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"file in branch", args{"https://github.com/kiegroup/kogito-examples/blob/stable/licensesheader.txt"}, "https://raw.githubusercontent.com/kiegroup/kogito-examples/stable/licensesheader.txt"},
+		{"file in commit", args{"https://github.com/kiegroup/kogito-examples/blob/8bde586ed5e536abec46b16b08f2d0b108391107/licensesheader.txt"}, "https://raw.githubusercontent.com/kiegroup/kogito-examples/8bde586ed5e536abec46b16b08f2d0b108391107/licensesheader.txt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getRawGitHubFileURL(tt.args.resource); got != tt.want {
+				t.Errorf("getRawGitHubFileURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-3350

This PR adds a helper function to convert a GitHub link to a file in a repo to its raw URL so that it can be downloaded correctly.

## Testing
I wrote unit tests to check the conversion of a URL to a file in a specific branch and commit. I also ran an s2i build of a BPMN file which was able to deploy correctly.

## Requirements
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: 
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
