### PR TITLE
[KOGITO-3127] Set the `replaces` correctly in csv

### DIFF
--- a/.github/workflows/Kogito-Operator-PR-Check.yaml
+++ b/.github/workflows/Kogito-Operator-PR-Check.yaml
@@ -77,13 +77,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod/cache
-          key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-cache-
       - name: Cache the binaries
         uses: actions/cache@v1
         with:

--- a/.github/workflows/Kogito-Operator-PR-Check.yaml
+++ b/.github/workflows/Kogito-Operator-PR-Check.yaml
@@ -72,6 +72,27 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+        id: go
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod/cache
+          key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-cache-
+      - name: Cache the binaries
+        uses: actions/cache@v1
+        with:
+          path: ~/go/bin/
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}
+      - name: Install Operator-sdk
+        run: ./hack/ci/install-operator-sdk.sh
       - name: Setup Bats
         run: |
           git clone https://github.com/bats-core/bats-core.git

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -64,6 +64,7 @@ if [ "${no_release_branch}" = "true" ]; then
     image_version="latest"
   fi
 fi
+echo "Set test config with image version ${image_version} and branch ${branch}"
 sed -i "s|tests.build-image-version=.*|tests.build-image-version=${image_version}|g" ${test_config_file}
 sed -i "s|tests.services-image-version=.*|tests.services-image-version=${image_version}|g" ${test_config_file}
 sed -i "s|tests.runtime-application-image-version=.*|tests.runtime-application-image-version=${image_version}|g" ${test_config_file}

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -15,6 +15,8 @@
 
 source ./hack/export-version.sh
 
+OLM_DIR="deploy/olm-catalog/kogito-operator"
+
 old_version=${OP_VERSION}
 new_version=$1
 release=$2
@@ -33,16 +35,23 @@ if [ -z "$no_release_branch" ]; then
   no_release_branch="true"
 fi
 
-sed -i "s/$old_version/$new_version/g" cmd/kogito/version/version.go README.md version/version.go deploy/operator.yaml deploy/olm-catalog/kogito-operator/kogito-operator.package.yaml deploy/olm-catalog/kogito-operator/custom-subscription-example.yaml hack/go-build.sh hack/go-vet.sh .osdk-scorecard.yaml
-sed -i "s|operated-by: kogito-operator.*|operated-by: kogito-operator.${new_version}|g" deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
+# Get latest released olm version from folders in deploy/olm-catalog/kogito-operator/
+latest_released_olm_version=$(cd ${OLM_DIR} && for i in $(ls -d */); do echo ${i%%/}; done | grep -v manifests | grep -v ${old_version} | sort -V | tail -1)
+echo "Latest released OLM version = $latest_released_olm_version"
 
-source ./hack/export-container-image.sh
-sed -i "s|containerImage: .*|containerImage: ${CONTAINER_IMAGE}|g" deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
+sed -i "s/$old_version/$new_version/g" cmd/kogito/version/version.go README.md version/version.go deploy/operator.yaml ${OLM_DIR}/kogito-operator.package.yaml ${OLM_DIR}/custom-subscription-example.yaml hack/go-build.sh hack/go-vet.sh .osdk-scorecard.yaml
 
 if [ "${old_version}" != "${new_version}" ]; then
   operator-sdk generate csv --apis-dir ./pkg/apis/app/v1alpha1 --verbose --csv-version "$new_version" --from-version "$old_version" --update-crds --operator-name kogito-operator
 fi
 make vet
+
+# replace in csv file
+source ./hack/export-container-image.sh
+csv_files="${OLM_DIR}/manifests/kogito-operator.clusterserviceversion.yaml ${OLM_DIR}/${new_version}/*.clusterserviceversion.yaml"
+sed -i "s|operated-by: kogito-operator.*|operated-by: kogito-operator.${new_version}|g" ${csv_files}
+sed -i "s|containerImage: .*|containerImage: ${CONTAINER_IMAGE}|g" ${csv_files}
+sed -i "s|replaces: kogito-operator.*|replaces: kogito-operator.v${latest_released_olm_version}|g" ${csv_files}
 
 # rewrite test default config, all other configuration into the file will be overridden
 test_config_file="test/.default_config"

--- a/hack/bump-version.sh.bats
+++ b/hack/bump-version.sh.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+OLD_VERSION=998.0.0
+NEW_VERSION=999.0.0
+NEW_VERSION_MAJOR_MINOR=$(echo "${NEW_VERSION}" | awk -F. '{print $1"."$2}')
+
+function make() { 
+    echo "make $@" 
+}
+
+function operator-sdk() { 
+    echo "operator-sdk $@" 
+}
+
+setup() {
+    # copy structure in a temp folder for the test
+    dir="${BATS_TMPDIR}/${BATS_TEST_NAME}"
+    rm -rf ${dir}
+    mkdir -p ${dir}
+    cp -r ${BATS_TEST_DIRNAME}/.. ${dir}/
+
+    mkdir -p ${dir}/deploy/olm-catalog/kogito-operator/${OLD_VERSION}
+
+    export CURRENT_VERSION=$(grep -m 1 'Version =' ${dir}/version/version.go) && CURRENT_VERSION=$(echo ${CURRENT_VERSION#*=} | tr -d '"')
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/$BATS_TEST_NAME"
+}
+
+@test "check bump-version error with no version" {
+    run ${BATS_TEST_DIRNAME}/bump-version.sh
+    [ "$status" -eq 1 ]
+    [[ "${output}" =~ "Please inform the new version. Use X.X.X" ]]
+}
+
+@test "check bump-version set default config with version only" {
+    export -f make
+    export -f operator-sdk
+
+    dir="${BATS_TMPDIR}/${BATS_TEST_NAME}"
+    cd ${dir}
+    run hack/bump-version.sh ${NEW_VERSION}
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "Latest released OLM version = ${OLD_VERSION}" ]]
+    [[ "${output}" =~ "operator-sdk generate csv --apis-dir ./pkg/apis/app/v1alpha1 --verbose --csv-version ${NEW_VERSION}" ]]
+    [[ "${output}" =~ "make vet" ]]
+
+    # No version should be set in test config
+    result=$(cat test/.default_config)
+    [[ "${result}" =~ "latest" ]]
+    [[ "${result}" =~ "master" ]]
+    [[ "${result}" != *${NEW_VERSION_MAJOR_MINOR}.x* ]]
+    [[ "${result}" != *${NEW_VERSION_MAJOR_MINOR}* ]]
+}
+
+
+@test "check bump-version set default config with version and release true" {
+    export -f make
+    export -f operator-sdk
+
+    dir="${BATS_TMPDIR}/${BATS_TEST_NAME}"
+    cd ${dir}
+    run hack/bump-version.sh ${NEW_VERSION} true
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "Latest released OLM version = ${OLD_VERSION}" ]]
+    [[ "${output}" =~ "operator-sdk generate csv --apis-dir ./pkg/apis/app/v1alpha1 --verbose --csv-version ${NEW_VERSION}" ]]
+    [[ "${output}" =~ "make vet" ]]
+
+    # Only image version should be set
+    result=$(cat test/.default_config)
+    [[ "${result}" =~ "${NEW_VERSION_MAJOR_MINOR}" ]]
+    [[ "${result}" =~ "master" ]]
+    [[ "${result}" != *${NEW_VERSION_MAJOR_MINOR}.x* ]]
+    [[ "${result}" != *latest* ]]
+}
+
+@test "check bump-version set default config with version, release true and on release branch" {
+    export -f make
+    export -f operator-sdk
+
+    dir="${BATS_TMPDIR}/${BATS_TEST_NAME}"
+    cd ${dir}
+    run hack/bump-version.sh ${NEW_VERSION} true false
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "Latest released OLM version = ${OLD_VERSION}" ]]
+    [[ "${output}" =~ "operator-sdk generate csv --apis-dir ./pkg/apis/app/v1alpha1 --verbose --csv-version ${NEW_VERSION}" ]]
+    [[ "${output}" =~ "make vet" ]]
+
+    # Release branch and image version should be set
+    result=$(cat test/.default_config)
+    [[ "${result}" =~ "${NEW_VERSION_MAJOR_MINOR}" ]]
+    [[ "${result}" =~ "${NEW_VERSION_MAJOR_MINOR}.x" ]]
+    [[ "${result}" != *master* ]]
+    [[ "${result}" != *latest* ]]
+}
+
+@test "check csv file is set correctly" {
+    dir="${BATS_TMPDIR}/${BATS_TEST_NAME}"
+    cd ${dir}
+    #current_version=$(cat )
+    run hack/bump-version.sh ${NEW_VERSION}
+    [ "$status" -eq 0 ]
+    [[ "${output}" =~ "Latest released OLM version = ${OLD_VERSION}" ]]
+
+    # Check csv file
+    result=$(cat deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml)
+    [[ "${result}" =~ "${OLD_VERSION}" ]]
+    [[ "${result}" =~ "${NEW_VERSION}" ]]
+    [[ "${result}" != *${CURRENT_VERSION}* ]]
+    # fine tune results
+    [[ "${result}" =~ "replaces: kogito-operator.v${OLD_VERSION}" ]]
+    [[ "${result}" =~ "version: ${NEW_VERSION}" ]]
+    [[ "${result}" =~ "operated-by: kogito-operator.${NEW_VERSION}" ]]
+    [[ "${result}" =~ "quay.io/kiegroup/kogito-cloud-operator:${NEW_VERSION}" ]]
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3127

Csv fields are now corrected after the `make vet`
This is done as we may be coming from `1.0.0-snapshot`. latest released version is now taken from `deploy/olm-catalog/kogito-operator` directories.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
