### PR TITLE
[KOGITO-3516] Services now listen to default HTTP port

### DIFF
--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -22,7 +22,7 @@ export GOPATH=$(go env GOPATH)
 operator-sdk generate k8s
 operator-sdk generate crds --crd-version=v1beta1
 # get the openapi binary
-which openapi-gen > /dev/null || go build -o $GOPATH/bin/openapi-gen k8s.io/kube-openapi/cmd/openapi-gen
+which openapi-gen > /dev/null || go build -o "${GOPATH}"/bin/openapi-gen k8s.io/kube-openapi/cmd/openapi-gen
 # generate the openapi files
 echo "Generating openapi files"
 openapi-gen --logtostderr=true -o "" -i github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1 -O zz_generated.openapi -p ./pkg/apis/app/v1alpha1 -h ./hack/boilerplate.go.txt -r "-"
@@ -35,6 +35,6 @@ go vet ./...
 # Copy crds and csv to version folder
 OLM_FOLDER="deploy/olm-catalog/kogito-operator"
 olm_versioned_folder="${OLM_FOLDER}/${OP_VERSION}"
-mkdir -p ${olm_versioned_folder}
-cp ${OLM_FOLDER}/manifests/* ${olm_versioned_folder}/
-mv ${olm_versioned_folder}/kogito-operator.clusterserviceversion.yaml ${olm_versioned_folder}/kogito-operator.v${OP_VERSION}.clusterserviceversion.yaml 
+mkdir -p "${olm_versioned_folder}"
+cp ${OLM_FOLDER}/manifests/* "${olm_versioned_folder}"/
+mv "${olm_versioned_folder}/kogito-operator.clusterserviceversion.yaml" "${olm_versioned_folder}/kogito-operator.v${OP_VERSION}.clusterserviceversion.yaml"

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -893,11 +893,6 @@ func schema_pkg_apis_app_v1alpha1_KogitoInfraStatus(ref common.ReferenceCallback
 						},
 					},
 					"appProps": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-map-type": "atomic",
-							},
-						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Application properties extracted from the linked resource that will be added to the deployed Kogito service.",
 							Type:        []string{"object"},

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -893,6 +893,11 @@ func schema_pkg_apis_app_v1alpha1_KogitoInfraStatus(ref common.ReferenceCallback
 						},
 					},
 					"appProps": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-map-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Application properties extracted from the linked resource that will be added to the deployed Kogito service.",
 							Type:        []string{"object"},

--- a/pkg/controller/kogitodataindex/kogitodataindex_controller_test.go
+++ b/pkg/controller/kogitodataindex/kogitodataindex_controller_test.go
@@ -154,7 +154,7 @@ func TestReconcileKogitoDataIndex_UpdateHTTPPort(t *testing.T) {
 	assert.True(t, routeAfterReconcileFound)
 	assert.NoError(t, err)
 	assert.True(t, routeAfterReconcileFound)
-	assert.Equal(t, intstr.IntOrString{Type: 0, IntVal: 9090, StrVal: ""}, routeAfterReconcile.Spec.Port.TargetPort)
+	assert.Equal(t, "http", routeAfterReconcile.Spec.Port.TargetPort.StrVal)
 
 	// update the service
 	// reconcile and test
@@ -177,7 +177,7 @@ func TestReconcileKogitoDataIndex_UpdateHTTPPort(t *testing.T) {
 	assert.True(t, serviceAfterReconcileFound)
 	assert.NoError(t, err)
 	// compare again if the port was updated after reconcile
-	assert.Equal(t, int32(9090), serviceAfterReconcile.Spec.Ports[0].Port)
+	assert.Equal(t, int32(80), serviceAfterReconcile.Spec.Ports[0].Port)
 	assert.Equal(t, intstr.FromInt(9090), serviceAfterReconcile.Spec.Ports[0].TargetPort)
 }
 

--- a/pkg/controller/kogitoexplainability/kogitoexplainability_controller_test.go
+++ b/pkg/controller/kogitoexplainability/kogitoexplainability_controller_test.go
@@ -122,7 +122,7 @@ func TestReconcileKogitoExplainability_UpdateHTTPPort(t *testing.T) {
 	// get the route after reconcile
 	routeAfterReconcile := &routev1.Route{}
 	test.AssertFetchWithKeyMustExist(t, cli, routeAfterReconcile, instance)
-	assert.Equal(t, intstr.IntOrString{Type: 0, IntVal: 9090, StrVal: ""}, routeAfterReconcile.Spec.Port.TargetPort)
+	assert.Equal(t, "http", routeAfterReconcile.Spec.Port.TargetPort.StrVal)
 
 	// update the service
 	// reconcile and test
@@ -144,6 +144,6 @@ func TestReconcileKogitoExplainability_UpdateHTTPPort(t *testing.T) {
 	test.AssertFetchWithKeyMustExist(t, cli, serviceAfterReconcile, instance)
 
 	// compare again if the port was updated after reconcile
-	assert.Equal(t, int32(9090), serviceAfterReconcile.Spec.Ports[0].Port)
+	assert.Equal(t, int32(80), serviceAfterReconcile.Spec.Ports[0].Port)
 	assert.Equal(t, intstr.FromInt(9090), serviceAfterReconcile.Spec.Ports[0].TargetPort)
 }

--- a/pkg/controller/kogitoinfra/kogitoinfra_controller_test.go
+++ b/pkg/controller/kogitoinfra/kogitoinfra_controller_test.go
@@ -105,7 +105,7 @@ func Test_Reconcile_Infinispan(t *testing.T) {
 		Spec: v13.ServiceSpec{
 			Ports: []v13.ServicePort{
 				{
-					TargetPort: intstr.IntOrString{IntVal: 11222},
+					TargetPort: intstr.FromInt(11222),
 				},
 			},
 		},

--- a/pkg/controller/kogitotrusty/kogitotrusty_controller_test.go
+++ b/pkg/controller/kogitotrusty/kogitotrusty_controller_test.go
@@ -123,7 +123,7 @@ func TestReconcileKogitoTrusty_UpdateHTTPPort(t *testing.T) {
 	// get the route after reconcile
 	routeAfterReconcile := &routev1.Route{}
 	test.AssertFetchWithKeyMustExist(t, cli, routeAfterReconcile, instance)
-	assert.Equal(t, intstr.IntOrString{Type: 0, IntVal: 9090, StrVal: ""}, routeAfterReconcile.Spec.Port.TargetPort)
+	assert.Equal(t, "http", routeAfterReconcile.Spec.Port.TargetPort.StrVal)
 
 	// update the service
 	// reconcile and test
@@ -145,6 +145,6 @@ func TestReconcileKogitoTrusty_UpdateHTTPPort(t *testing.T) {
 	test.AssertFetchWithKeyMustExist(t, cli, serviceAfterReconcile, instance)
 
 	// compare again if the port was updated after reconcile
-	assert.Equal(t, int32(9090), serviceAfterReconcile.Spec.Ports[0].Port)
-	assert.Equal(t, intstr.FromInt(9090), serviceAfterReconcile.Spec.Ports[0].TargetPort)
+	assert.Equal(t, int32(80), serviceAfterReconcile.Spec.Ports[0].Port)
+	assert.Equal(t, intstr.FromInt(9090).IntVal, serviceAfterReconcile.Spec.Ports[0].TargetPort.IntVal)
 }

--- a/pkg/framework/containers.go
+++ b/pkg/framework/containers.go
@@ -19,6 +19,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	defaultHTTPPort = 80
+)
+
 // ExtractPortsFromContainer converts ports defined in the given container to ServicePorts
 func ExtractPortsFromContainer(container *corev1.Container) []corev1.ServicePort {
 	if container == nil {
@@ -29,7 +33,7 @@ func ExtractPortsFromContainer(container *corev1.Container) []corev1.ServicePort
 		svcPorts[i] = corev1.ServicePort{
 			Name:       port.Name,
 			Protocol:   port.Protocol,
-			Port:       port.ContainerPort,
+			Port:       defaultHTTPPort,
 			TargetPort: intstr.FromInt(int(port.ContainerPort)),
 		}
 	}

--- a/pkg/infrastructure/services/route.go
+++ b/pkg/infrastructure/services/route.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // createRequiredRoute creates a new Route resource based on the given Service
@@ -32,7 +33,7 @@ func createRequiredRoute(instance v1alpha1.KogitoService, service *corev1.Servic
 		ObjectMeta: service.ObjectMeta,
 		Spec: routev1.RouteSpec{
 			Port: &routev1.RoutePort{
-				TargetPort: service.Spec.Ports[0].TargetPort,
+				TargetPort: intstr.FromString(service.Spec.Ports[0].Name),
 			},
 			To: routev1.RouteTargetReference{
 				Kind: meta.KindService.Name,


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3516

Now any service can be called via `http://name.namespace` from the cluster.

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
