### PR TITLE
Fix EXAMPLES_DIR path

### DIFF
--- a/examples/kubernetes/travel-agency/deploy.sh
+++ b/examples/kubernetes/travel-agency/deploy.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-EXAMPLES_DIR=./deploy/examples
+EXAMPLES_DIR=./examples
 TARGET_DIR="${EXAMPLES_DIR}/kubernetes/travel-agency"
 STRIMZI_VERSION=0.17.0
 INFINISPAN_VERSION=1.1.1.Final


### PR DESCRIPTION
Getting below error while running deploy.sh(/examples/kubernetes/travel-agency/deploy.sh) script to deploy travel-agency example on Kuberentes 

> error: the path "./deploy/examples/kubernetes/travel-agency/data-index.yaml" does not exist
> error: the path "./deploy/examples/kubernetes/travel-agency/data-index-ingress.yaml" does not exist
> Deploying Management Console
> error: the path "./deploy/examples/kubernetes/travel-agency/management-console.yaml" does not exist
> error: the path "./deploy/examples/kubernetes/travel-agency/management-console-ingress.yaml" does not exist
> Deploying Kogito Travels Application
> error: the path "./deploy/examples/kubernetes/travel-agency/kogito-travels.yaml" does not exist
> error: the path "./deploy/examples/kubernetes/travel-agency/kogito-travels-ingress.yaml" does not exist
> error: the path "./deploy/examples/kubernetes/travel-agency/kogito-visas.yaml" does not exist
> error: the path "./deploy/examples/kubernetes/travel-agency/kogito-visas-ingress.yaml" does not exist

To fix the issue EXAMPLES_DIR variable path must be point to correct directory

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
