### PR TITLE
[KOGITO-3708] - Decreasing the amount of reconciliation loops for Kog…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,14 @@
 ## Enhancements
 - [KOGITO-2562](https://issues.redhat.com/browse/KOGITO-2562) - Knative Eventing resources created for Kogito Applications that uses [Knative Addon](https://github.com/kiegroup/kogito-examples/tree/stable/process-knative-quickstart-quarkus).
-- [KOGITO-3094](Provide data-index-infinispan/mongodb as independent images) - Provide data-index-infinispan/mongodb as independent images
+- [KOGITO-3094](https://issues.redhat.com/browse/KOGITO-3094) - Provide data-index-infinispan/mongodb as independent images
      - To switch to Mongodb persistence provider just provide the `quay.io/kiegroup/kogito-data-index-mongodb:1.0.0-snapshot` on the Kogito CR  
 - [KOGITO-3624](https://issues.redhat.com/browse/KOGITO-3624) - Grafana dashboard resources created for Kogito Applications that uses [Monitoring Addon](https://blog.kie.org/2020/07/trustyai-meets-kogito-decision-monitoring.html)
 - [KOGITO-3273](https://issues.redhat.com/browse/KOGITO-3273) - Research to remove supporting Kogito Services CRD
 - [KOGITO-3568](https://issues.redhat.com/browse/KOGITO-3273) - Remove spec.httpPort attribute from Operator and HTTP_PORT env var from Kogito images
 - [KOGITO-3376](https://issues.redhat.com/browse/KOGITO-3376) - Update protobuf ConfigMap using fetched files
-
+- [KOGITO-3708](https://issues.redhat.com/browse/KOGITO-3708) - Decreasing the amount of reconciliation loops for `KogitoInfra` resources when
+third party infrastructure resources are not yet available
+ 
 ## Bug Fixes
 
 ## Known Issues

--- a/examples/kogitoinfra-infinispan.yaml
+++ b/examples/kogitoinfra-infinispan.yaml
@@ -1,0 +1,9 @@
+#Infinispan operator should be pre-installed in namespace
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoInfra
+metadata:
+  name: kogito-infinispan-infra
+spec:
+  resource:
+    apiVersion: infinispan.org/v1
+    kind: Infinispan

--- a/examples/kogitoinfra-kafka.yaml
+++ b/examples/kogitoinfra-kafka.yaml
@@ -1,0 +1,9 @@
+#Strimzi operator should be pre-installed in namespace
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoInfra
+metadata:
+  name: kogito-kafka-infra
+spec:
+  resource:
+    apiVersion: kafka.strimzi.io/v1beta1
+    kind: Kafka

--- a/examples/kogitoinfra-keycloak.yaml
+++ b/examples/kogitoinfra-keycloak.yaml
@@ -1,0 +1,9 @@
+#Keycloak operator should be pre-installed in namespace
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoInfra
+metadata:
+  name: kogito-keycloak
+spec:
+  resource:
+    apiVersion: keycloak.org/v1alpha1
+    kind: Keycloak

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -40,6 +40,6 @@ cp ${OLM_FOLDER}/manifests/* "${olm_versioned_folder}"/
 mv "${olm_versioned_folder}/kogito-operator.clusterserviceversion.yaml" "${olm_versioned_folder}/kogito-operator.v${OP_VERSION}.clusterserviceversion.yaml"
 
 # Generate kogito-operator.yaml
-rm ./kogito-operator.yaml
-for yaml in deploy/crds/*_crd.yaml; do cat "${yaml}" >> ./kogito-operator.yaml; printf "\n---\n" >> ./kogito-operator.yaml; done
-for yaml in deploy/*.yaml; do cat "${yaml}" >> ./kogito-operator.yaml; printf "\n---\n" >> ./kogito-operator.yaml; done
+rm kogito-operator.yaml
+for yaml in deploy/crds/*_crd.yaml; do cat "${yaml}" >> kogito-operator.yaml; printf "\n---\n" >> kogito-operator.yaml; done
+for yaml in deploy/*.yaml; do cat "${yaml}" >> kogito-operator.yaml; printf "\n---\n" >> kogito-operator.yaml; done

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -800,11 +800,6 @@ spec:
                 type: object
               type: array
               x-kubernetes-list-type: atomic
-            httpPort:
-              description: HTTPPort will set the environment env HTTP_PORT to define
-                which port service will listen internally.
-              format: int32
-              type: integer
             image:
               description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest".
                 On OpenShift an ImageStream will be created in the current namespace
@@ -1130,11 +1125,6 @@ spec:
                 type: object
               type: array
               x-kubernetes-list-type: atomic
-            httpPort:
-              description: HTTPPort will set the environment env HTTP_PORT to define
-                which port service will listen internally.
-              format: int32
-              type: integer
             image:
               description: 'Image definition for the service. Example: "quay.io/kiegroup/kogito-service:latest".
                 On OpenShift an ImageStream will be created in the current namespace
@@ -1483,6 +1473,17 @@ rules:
       - watch
       - create
       - delete
+      - update
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanadashboards
+    verbs:
+      - get
+      - create
+      - list
+      - delete
+      - watch
       - update
 ---
 

--- a/pkg/controller/kogitoinfra/errors.go
+++ b/pkg/controller/kogitoinfra/errors.go
@@ -80,6 +80,9 @@ func getSupportedResources() []string {
 }
 
 func reasonForError(err error) v1alpha1.KogitoInfraConditionReason {
+	if err == nil {
+		return ""
+	}
 	switch t := err.(type) {
 	case reconciliationError:
 		return t.Reason

--- a/pkg/controller/kogitoinfra/manage_status.go
+++ b/pkg/controller/kogitoinfra/manage_status.go
@@ -27,7 +27,9 @@ import (
 func updateBaseStatus(client *client.Client, instance *v1alpha1.KogitoInfra, err *error) {
 	log.Info("Updating Kogito Infra status")
 	if *err != nil {
-		log.Warn("Seems that an error occurred, setting failure state: ", *err)
+		if reasonForError(*err) == v1alpha1.ReconciliationFailure {
+			log.Warn("Seems that an error occurred, setting failure state: ", *err)
+		}
 		setResourceFailed(instance, *err)
 	} else {
 		setResourceSuccess(instance)


### PR DESCRIPTION
…itoInfra

See: https://issues.redhat.com/browse/KOGITO-3708

This is what looks like a non-OK infra resource:

```
oc get kogitoinfra
NAME                      RESOURCE NAME   KIND         API VERSION         STATUS   REASON
kogito-infinispan-infra                   Infinispan   infinispan.org/v1   False    ResourceAPINotFound
```

Here's the interval between reconciliations:

```
2020-10-28T17:05:36.365-0300	INFO	kogitoinfra_controller	Successfully Update Kogito Infra status
...
2020-10-28T17:06:06.338-0300	INFO	kogitoinfra_controller	Reconciling KogitoInfra for kogito-infinispan-infra in kogito-3708
```

30 seconds :)

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
