### PR TITLE
[KOGITO-3556] Kogito CRs to update Status only

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 - [KOGITO-3376](https://issues.redhat.com/browse/KOGITO-3376) - Update protobuf ConfigMap using fetched files
 - [KOGITO-3708](https://issues.redhat.com/browse/KOGITO-3708) - Decreasing the amount of reconciliation loops for `KogitoInfra` resources when
 third party infrastructure resources are not yet available
+- [KOGITO-3556](https://issues.redhat.com/browse/KOGITO-3556) - Review CRDs Status resource update
  
 ## Bug Fixes
 

--- a/cmd/kogito/command/install/supportingservices.go
+++ b/cmd/kogito/command/install/supportingservices.go
@@ -68,8 +68,8 @@ For more information on Kogito Data Index Service see: https://github.com/kiegro
 	{
 		cmdName:     "explainability",
 		serviceName: infrastructure.DefaultExplainabilityName,
-		displayName: "Explainablity",
-		serviceType: v1alpha1.Explainablity,
+		displayName: "Explainability",
+		serviceType: v1alpha1.Explainability,
 		description: `'install explainability' will deploy the Explainability service to provide analysis on the decisions that have been taken by a kogito runtime application.
 
 If kafka-url is provided, it will be used to connect to the external Kafka server that is deployed in other project or infrastructure.

--- a/cmd/kogito/command/install/supportingservices.go
+++ b/cmd/kogito/command/install/supportingservices.go
@@ -16,6 +16,7 @@ package install
 
 import (
 	"fmt"
+
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/converter"
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/flag"

--- a/cmd/kogito/command/remove/supportingservices.go
+++ b/cmd/kogito/command/remove/supportingservices.go
@@ -49,7 +49,7 @@ var removableSupportingServices = []removableSupportingService{
 	},
 	{
 		cmdName:     "explainability",
-		serviceType: v1alpha1.Explainablity,
+		serviceType: v1alpha1.Explainability,
 	},
 	{
 		cmdName:     "jobs-service",

--- a/cmd/kogito/command/remove/supportingservices.go
+++ b/cmd/kogito/command/remove/supportingservices.go
@@ -16,6 +16,7 @@ package remove
 
 import (
 	"fmt"
+
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/context"
 	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/shared"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"

--- a/cmd/kogito/command/shared/install_services.go
+++ b/cmd/kogito/command/shared/install_services.go
@@ -126,7 +126,7 @@ func getSupportingServiceInfoMessages(serviceType v1alpha1.ServiceType) *service
 			checkStatus:                  message.SupportingServiceCheckStatus,
 			notInstalledNoKogitoOperator: message.MgmtConsoleNotInstalledNoKogitoOperator,
 		}
-	case v1alpha1.Explainablity:
+	case v1alpha1.Explainability:
 		return &serviceInfoMessages{
 			errCreating:                  message.ExplainabilityErrCreating,
 			installed:                    message.ExplainabilitySuccessfulInstalled,

--- a/deploy/crds/app.kiegroup.org_kogitobuilds_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitobuilds_crd.yaml
@@ -35,7 +35,8 @@ spec:
     plural: kogitobuilds
     singular: kogitobuild
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoBuild handles how to build a custom Kogito service in a Kubernetes/OpenShift

--- a/deploy/crds/app.kiegroup.org_kogitoruntimes_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitoruntimes_crd.yaml
@@ -23,7 +23,8 @@ spec:
     plural: kogitoruntimes
     singular: kogitoruntime
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoRuntime is a custom Kogito service.
@@ -260,7 +261,7 @@ spec:
                   message:
                     type: string
                   reason:
-                    description: ReasonType is the type of reason
+                    description: KogitoServiceConditionReason is the type of reason
                     type: string
                   status:
                     type: string

--- a/deploy/crds/app.kiegroup.org_kogitosupportingservices_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitosupportingservices_crd.yaml
@@ -241,10 +241,11 @@ spec:
               type: object
             serviceType:
               description: 'Defines the type for the supporting service, eg: DataIndex,
-                JobsService Default value: JobsService'
+                JobsService Default value: JobsService Defines the type for the supporting
+                service, eg: DataIndex, JobsService'
               enum:
               - DataIndex
-              - Explainablity
+              - Explainability
               - JobsService
               - MgmtConsole
               - TaskConsole

--- a/deploy/crds/app.kiegroup.org_kogitosupportingservices_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitosupportingservices_crd.yaml
@@ -27,7 +27,8 @@ spec:
     plural: kogitosupportingservices
     singular: kogitosupportingservice
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoSupportingService deploys the Supporting service in the given
@@ -268,7 +269,7 @@ spec:
                   message:
                     type: string
                   reason:
-                    description: ReasonType is the type of reason
+                    description: KogitoServiceConditionReason is the type of reason
                     type: string
                   status:
                     type: string

--- a/deploy/crds/app.kiegroup.org_kogitosupportingservices_crd.yaml
+++ b/deploy/crds/app.kiegroup.org_kogitosupportingservices_crd.yaml
@@ -241,8 +241,7 @@ spec:
               type: object
             serviceType:
               description: 'Defines the type for the supporting service, eg: DataIndex,
-                JobsService Default value: JobsService Defines the type for the supporting
-                service, eg: DataIndex, JobsService'
+                JobsService Default value: JobsService'
               enum:
               - DataIndex
               - Explainability

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitobuilds_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitobuilds_crd.yaml
@@ -35,7 +35,8 @@ spec:
     plural: kogitobuilds
     singular: kogitobuild
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoBuild handles how to build a custom Kogito service in a Kubernetes/OpenShift

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitoruntimes_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitoruntimes_crd.yaml
@@ -23,7 +23,8 @@ spec:
     plural: kogitoruntimes
     singular: kogitoruntime
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoRuntime is a custom Kogito service.
@@ -260,7 +261,7 @@ spec:
                   message:
                     type: string
                   reason:
-                    description: ReasonType is the type of reason
+                    description: KogitoServiceConditionReason is the type of reason
                     type: string
                   status:
                     type: string

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitosupportingservices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitosupportingservices_crd.yaml
@@ -241,10 +241,11 @@ spec:
               type: object
             serviceType:
               description: 'Defines the type for the supporting service, eg: DataIndex,
-                JobsService Default value: JobsService'
+                JobsService Default value: JobsService Defines the type for the supporting
+                service, eg: DataIndex, JobsService'
               enum:
               - DataIndex
-              - Explainablity
+              - Explainability
               - JobsService
               - MgmtConsole
               - TaskConsole

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitosupportingservices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitosupportingservices_crd.yaml
@@ -27,7 +27,8 @@ spec:
     plural: kogitosupportingservices
     singular: kogitosupportingservice
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoSupportingService deploys the Supporting service in the given
@@ -268,7 +269,7 @@ spec:
                   message:
                     type: string
                   reason:
-                    description: ReasonType is the type of reason
+                    description: KogitoServiceConditionReason is the type of reason
                     type: string
                   status:
                     type: string

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitosupportingservices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/app.kiegroup.org_kogitosupportingservices_crd.yaml
@@ -241,8 +241,7 @@ spec:
               type: object
             serviceType:
               description: 'Defines the type for the supporting service, eg: DataIndex,
-                JobsService Default value: JobsService Defines the type for the supporting
-                service, eg: DataIndex, JobsService'
+                JobsService Default value: JobsService'
               enum:
               - DataIndex
               - Explainability

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
@@ -409,7 +409,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Defines the type for the supporting service, eg: DataIndex,
-          JobsService Default value: JobsService'
+          JobsService Default value: JobsService Defines the type for the supporting
+          service, eg: DataIndex, JobsService'
         displayName: Resource Type
         path: serviceType
         x-descriptors:

--- a/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/1.0.0-snapshot/kogito-operator.v1.0.0-snapshot.clusterserviceversion.yaml
@@ -409,8 +409,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Defines the type for the supporting service, eg: DataIndex,
-          JobsService Default value: JobsService Defines the type for the supporting
-          service, eg: DataIndex, JobsService'
+          JobsService Default value: JobsService'
         displayName: Resource Type
         path: serviceType
         x-descriptors:

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitobuilds_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitobuilds_crd.yaml
@@ -35,7 +35,8 @@ spec:
     plural: kogitobuilds
     singular: kogitobuild
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoBuild handles how to build a custom Kogito service in a Kubernetes/OpenShift

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoruntimes_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitoruntimes_crd.yaml
@@ -23,7 +23,8 @@ spec:
     plural: kogitoruntimes
     singular: kogitoruntime
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoRuntime is a custom Kogito service.
@@ -260,7 +261,7 @@ spec:
                   message:
                     type: string
                   reason:
-                    description: ReasonType is the type of reason
+                    description: KogitoServiceConditionReason is the type of reason
                     type: string
                   status:
                     type: string

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitosupportingservices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitosupportingservices_crd.yaml
@@ -241,10 +241,11 @@ spec:
               type: object
             serviceType:
               description: 'Defines the type for the supporting service, eg: DataIndex,
-                JobsService Default value: JobsService'
+                JobsService Default value: JobsService Defines the type for the supporting
+                service, eg: DataIndex, JobsService'
               enum:
               - DataIndex
-              - Explainablity
+              - Explainability
               - JobsService
               - MgmtConsole
               - TaskConsole

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitosupportingservices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitosupportingservices_crd.yaml
@@ -27,7 +27,8 @@ spec:
     plural: kogitosupportingservices
     singular: kogitosupportingservice
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoSupportingService deploys the Supporting service in the given
@@ -268,7 +269,7 @@ spec:
                   message:
                     type: string
                   reason:
-                    description: ReasonType is the type of reason
+                    description: KogitoServiceConditionReason is the type of reason
                     type: string
                   status:
                     type: string

--- a/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitosupportingservices_crd.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/app.kiegroup.org_kogitosupportingservices_crd.yaml
@@ -241,8 +241,7 @@ spec:
               type: object
             serviceType:
               description: 'Defines the type for the supporting service, eg: DataIndex,
-                JobsService Default value: JobsService Defines the type for the supporting
-                service, eg: DataIndex, JobsService'
+                JobsService Default value: JobsService'
               enum:
               - DataIndex
               - Explainability

--- a/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
@@ -409,7 +409,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Defines the type for the supporting service, eg: DataIndex,
-          JobsService Default value: JobsService'
+          JobsService Default value: JobsService Defines the type for the supporting
+          service, eg: DataIndex, JobsService'
         displayName: Resource Type
         path: serviceType
         x-descriptors:

--- a/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kogito-operator/manifests/kogito-operator.clusterserviceversion.yaml
@@ -409,8 +409,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Defines the type for the supporting service, eg: DataIndex,
-          JobsService Default value: JobsService Defines the type for the supporting
-          service, eg: DataIndex, JobsService'
+          JobsService Default value: JobsService'
         displayName: Resource Type
         path: serviceType
         x-descriptors:

--- a/examples/explainability.yaml
+++ b/examples/explainability.yaml
@@ -14,7 +14,7 @@ kind: KogitoSupportingService
 metadata:
   name: explainability
 spec:
-  serviceType: Explainablity
+  serviceType: Explainability
   # environment variables to set in the runtime container. Example: JAVA_OPTIONS: "-Dquarkus.log.level=DEBUG"
   #env:
     # - name: JAVA_OPTIONS

--- a/examples/process-quarkus-example-persistence-nobuild.yaml
+++ b/examples/process-quarkus-example-persistence-nobuild.yaml
@@ -1,0 +1,19 @@
+#Infinispan operator should be pre-installed in namespace
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoInfra
+metadata:
+  name: kogito-infinispan-infra
+spec:
+  resource:
+    apiVersion: infinispan.org/v1
+    kind: Infinispan
+---
+apiVersion: app.kiegroup.org/v1alpha1
+kind: KogitoRuntime
+metadata:
+  name: example-quarkus
+spec:
+  # see the quarkus-jvm.Dockerfile in this directory to know how to build your image locally
+  image: quay.io/<namespace>/process-quarkus-example:latest
+  infra:
+    - kogito-infinispan-infra

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -35,7 +35,8 @@ spec:
     plural: kogitobuilds
     singular: kogitobuild
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoBuild handles how to build a custom Kogito service in a Kubernetes/OpenShift
@@ -658,7 +659,8 @@ spec:
     plural: kogitoruntimes
     singular: kogitoruntime
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoRuntime is a custom Kogito service.
@@ -895,7 +897,7 @@ spec:
                   message:
                     type: string
                   reason:
-                    description: ReasonType is the type of reason
+                    description: KogitoServiceConditionReason is the type of reason
                     type: string
                   status:
                     type: string
@@ -987,7 +989,8 @@ spec:
     plural: kogitosupportingservices
     singular: kogitosupportingservice
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: KogitoSupportingService deploys the Supporting service in the given
@@ -1228,7 +1231,7 @@ spec:
                   message:
                     type: string
                   reason:
-                    description: ReasonType is the type of reason
+                    description: KogitoServiceConditionReason is the type of reason
                     type: string
                   status:
                     type: string

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -1203,8 +1203,7 @@ spec:
               type: object
             serviceType:
               description: 'Defines the type for the supporting service, eg: DataIndex,
-                JobsService Default value: JobsService Defines the type for the supporting
-                service, eg: DataIndex, JobsService'
+                JobsService Default value: JobsService'
               enum:
               - DataIndex
               - Explainability

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -1203,10 +1203,11 @@ spec:
               type: object
             serviceType:
               description: 'Defines the type for the supporting service, eg: DataIndex,
-                JobsService Default value: JobsService'
+                JobsService Default value: JobsService Defines the type for the supporting
+                service, eg: DataIndex, JobsService'
               enum:
               - DataIndex
-              - Explainablity
+              - Explainability
               - JobsService
               - MgmtConsole
               - TaskConsole

--- a/pkg/apis/app/v1alpha1/conditions.go
+++ b/pkg/apis/app/v1alpha1/conditions.go
@@ -31,44 +31,30 @@ const (
 	FailedConditionType ConditionType = "Failed"
 )
 
-// ReasonType is the type of reason
-type ReasonType string
+// KogitoServiceConditionReason is the type of reason
+type KogitoServiceConditionReason string
 
 const (
-	// ServicesIntegrationFailedReason - Unable to inject external services to KogitoService
-	ServicesIntegrationFailedReason ReasonType = "ServicesIntegrationFailed"
-	// ParseCRRequestFailedReason - Unable to resolve the CR request
-	ParseCRRequestFailedReason ReasonType = "ParseCRRequestFailed"
-	// RetrieveDeployedResourceFailedReason - Unable to retrieve the deployed resources
-	RetrieveDeployedResourceFailedReason ReasonType = "RetrieveDeployedResourceFailed"
 	// CreateResourceFailedReason - Unable to create the requested resources
-	CreateResourceFailedReason ReasonType = "CreateResourceFailed"
-	// RemoveResourceFailedReason - Unable to remove the requested resources
-	RemoveResourceFailedReason ReasonType = "RemoveResourceFailed"
-	// UpdateResourceFailedReason - Unable to update the requested resources
-	UpdateResourceFailedReason ReasonType = "UpdateResourceFailed"
-	// TriggerBuildFailedReason - Unable to trigger the builds
-	TriggerBuildFailedReason ReasonType = "TriggerBuildFailed"
-	// BuildS2IFailedReason - Unable to build with the S2I image
-	BuildS2IFailedReason ReasonType = "BuildS2IFailedReason"
-	// BuildRuntimeFailedReason - Unable to build the runtime image
-	BuildRuntimeFailedReason ReasonType = "BuildRuntimeFailedReason"
+	CreateResourceFailedReason KogitoServiceConditionReason = "CreateResourceFailed"
 	// KogitoInfraNotReadyReason - Unable to deploy Kogito Infra
-	KogitoInfraNotReadyReason ReasonType = "KogitoInfraNotReadyReason"
-	// UnknownReason - Unable to determine the error
-	UnknownReason ReasonType = "Unknown"
-	// RolloutDeploymentFailedReason - Unable to rollout deployment
-	RolloutDeploymentFailedReason ReasonType = "RolloutDeploymentFailedReason"
+	KogitoInfraNotReadyReason KogitoServiceConditionReason = "KogitoInfraNotReadyReason"
+	// ServiceReconciliationFailure - Unable to determine the error
+	ServiceReconciliationFailure KogitoServiceConditionReason = "ReconciliationFailure"
+	// MessagingIntegrationFailureReason ...
+	MessagingIntegrationFailureReason KogitoServiceConditionReason = "MessagingProvisionFailure"
+	// MonitoringIntegrationFailureReason ...
+	MonitoringIntegrationFailureReason KogitoServiceConditionReason = "MonitoringIntegrationFailure"
 )
 
 // Condition is the detailed condition for the resource
 // +k8s:openapi-gen=true
 type Condition struct {
-	Type               ConditionType          `json:"type"`
-	Status             corev1.ConditionStatus `json:"status"`
-	LastTransitionTime metav1.Time            `json:"lastTransitionTime,omitempty"`
-	Reason             ReasonType             `json:"reason,omitempty"`
-	Message            string                 `json:"message,omitempty"`
+	Type               ConditionType                `json:"type"`
+	Status             corev1.ConditionStatus       `json:"status"`
+	LastTransitionTime metav1.Time                  `json:"lastTransitionTime,omitempty"`
+	Reason             KogitoServiceConditionReason `json:"reason,omitempty"`
+	Message            string                       `json:"message,omitempty"`
 }
 
 const maxBufferCondition = 5
@@ -77,7 +63,7 @@ const maxBufferCondition = 5
 type ConditionMetaInterface interface {
 	SetDeployed() bool
 	SetProvisioning() bool
-	SetFailed(reason ReasonType, err error)
+	SetFailed(reason KogitoServiceConditionReason, err error)
 	GetConditions() []Condition
 	SetConditions(conditions []Condition)
 }
@@ -132,7 +118,7 @@ func (c *ConditionsMeta) SetProvisioning() bool {
 }
 
 // SetFailed Sets the failed condition with the error reason and message
-func (c *ConditionsMeta) SetFailed(reason ReasonType, err error) {
+func (c *ConditionsMeta) SetFailed(reason KogitoServiceConditionReason, err error) {
 	condition := Condition{
 		Type:               FailedConditionType,
 		Status:             corev1.ConditionFalse,

--- a/pkg/apis/app/v1alpha1/conditions_test.go
+++ b/pkg/apis/app/v1alpha1/conditions_test.go
@@ -94,7 +94,7 @@ func TestSetProvisioningAndThenDeployed(t *testing.T) {
 func TestBuffer(t *testing.T) {
 	conditionsMeta := ConditionsMeta{}
 	for i := 0; i < maxBufferCondition+2; i++ {
-		conditionsMeta.SetFailed(UnknownReason, fmt.Errorf("error %d", i))
+		conditionsMeta.SetFailed(ServiceReconciliationFailure, fmt.Errorf("error %d", i))
 	}
 	size := len(conditionsMeta.Conditions)
 	assert.Equal(t, maxBufferCondition, size)
@@ -105,13 +105,13 @@ func TestSetFailed(t *testing.T) {
 	conditionsMeta := ConditionsMeta{}
 	failureMessage := "Unknown error occurs"
 
-	conditionsMeta.SetFailed(UnknownReason, fmt.Errorf(failureMessage))
+	conditionsMeta.SetFailed(ServiceReconciliationFailure, fmt.Errorf(failureMessage))
 
 	assert.NotEmpty(t, conditionsMeta.Conditions)
 	assert.Equal(t, 1, len(conditionsMeta.Conditions))
 	condition := conditionsMeta.Conditions[0]
 	assert.Equal(t, FailedConditionType, condition.Type)
 	assert.Equal(t, corev1.ConditionFalse, condition.Status)
-	assert.Equal(t, UnknownReason, condition.Reason)
+	assert.Equal(t, ServiceReconciliationFailure, condition.Reason)
 	assert.Equal(t, failureMessage, condition.Message)
 }

--- a/pkg/apis/app/v1alpha1/kogitobuild_types.go
+++ b/pkg/apis/app/v1alpha1/kogitobuild_types.go
@@ -315,6 +315,7 @@ type WebHookSecret struct {
 // KogitoBuild handles how to build a custom Kogito service in a Kubernetes/OpenShift cluster.
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=kogitobuilds,scope=Namespaced
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",description="Type of this build instance"
 // +kubebuilder:printcolumn:name="Runtime",type="string",JSONPath=".spec.runtime",description="Runtime used to build the service"
 // +kubebuilder:printcolumn:name="Native",type="boolean",JSONPath=".spec.native",description="Indicates it's a native build"

--- a/pkg/apis/app/v1alpha1/kogitoruntime_types.go
+++ b/pkg/apis/app/v1alpha1/kogitoruntime_types.go
@@ -47,6 +47,7 @@ type KogitoRuntimeStatus struct {
 // KogitoRuntime is a custom Kogito service.
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=kogitoruntimes,scope=Namespaced
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="Number of replicas set for this service"
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".status.image",description="Image of this service"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.externalURI",description="External URI to access this service"

--- a/pkg/apis/app/v1alpha1/kogitosupportingservice_types.go
+++ b/pkg/apis/app/v1alpha1/kogitosupportingservice_types.go
@@ -50,6 +50,7 @@ type KogitoSupportingServiceSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:label"
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=DataIndex;Explainablity;JobsService;MgmtConsole;TaskConsole;TrustyAI;TrustyUI
+	// Defines the type for the supporting service, eg: DataIndex, JobsService
 	ServiceType ServiceType `json:"serviceType"`
 }
 
@@ -69,6 +70,7 @@ type KogitoSupportingServiceStatus struct {
 // KogitoSupportingService deploys the Supporting service in the given namespace.
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=kogitosupportingservices,scope=Namespaced
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="Number of replicas set for this service"
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".status.image",description="Base image for this service"
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".status.externalURI",description="External URI to access this service"

--- a/pkg/apis/app/v1alpha1/kogitosupportingservice_types.go
+++ b/pkg/apis/app/v1alpha1/kogitosupportingservice_types.go
@@ -50,7 +50,6 @@ type KogitoSupportingServiceSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:label"
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=DataIndex;Explainability;JobsService;MgmtConsole;TaskConsole;TrustyAI;TrustyUI
-	// Defines the type for the supporting service, eg: DataIndex, JobsService
 	ServiceType ServiceType `json:"serviceType"`
 }
 

--- a/pkg/apis/app/v1alpha1/kogitosupportingservice_types.go
+++ b/pkg/apis/app/v1alpha1/kogitosupportingservice_types.go
@@ -24,8 +24,8 @@ type ServiceType string
 const (
 	// DataIndex supporting service resource type
 	DataIndex ServiceType = "DataIndex"
-	// Explainablity supporting service resource type
-	Explainablity ServiceType = "Explainablity"
+	// Explainability supporting service resource type
+	Explainability ServiceType = "Explainability"
 	// JobsService supporting service resource type
 	JobsService ServiceType = "JobsService"
 	// MgmtConsole supporting service resource type
@@ -49,7 +49,7 @@ type KogitoSupportingServiceSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Resource Type"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:label"
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=DataIndex;Explainablity;JobsService;MgmtConsole;TaskConsole;TrustyAI;TrustyUI
+	// +kubebuilder:validation:Enum=DataIndex;Explainability;JobsService;MgmtConsole;TaskConsole;TrustyAI;TrustyUI
 	// Defines the type for the supporting service, eg: DataIndex, JobsService
 	ServiceType ServiceType `json:"serviceType"`
 }

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -690,7 +690,7 @@ func schema_pkg_apis_app_v1alpha1_KogitoSupportingServiceSpec(ref common.Referen
 					},
 					"serviceType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Defines the type for the supporting service, eg: DataIndex, JobsService Default value: JobsService Defines the type for the supporting service, eg: DataIndex, JobsService",
+							Description: "Defines the type for the supporting service, eg: DataIndex, JobsService Default value: JobsService",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -690,7 +690,7 @@ func schema_pkg_apis_app_v1alpha1_KogitoSupportingServiceSpec(ref common.Referen
 					},
 					"serviceType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Defines the type for the supporting service, eg: DataIndex, JobsService Default value: JobsService",
+							Description: "Defines the type for the supporting service, eg: DataIndex, JobsService Default value: JobsService Defines the type for the supporting service, eg: DataIndex, JobsService",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/client/kubernetes/resource.go
+++ b/pkg/client/kubernetes/resource.go
@@ -33,7 +33,6 @@ type ResourceInterface interface {
 	ResourceReader
 	ResourceWriter
 	// CreateIfNotExists will fetch for the object resource in the Kubernetes cluster, if not exists, will create it.
-	// returns true if the object exists before
 	CreateIfNotExists(resource meta.ResourceObject) (err error)
 	// CreateIfNotExistsForOwner sets the controller owner to the given resource and creates if it not exists.
 	// If the given resource exists, won't update the object with the given owner.

--- a/pkg/client/kubernetes/resource.go
+++ b/pkg/client/kubernetes/resource.go
@@ -33,10 +33,11 @@ type ResourceInterface interface {
 	ResourceReader
 	ResourceWriter
 	// CreateIfNotExists will fetch for the object resource in the Kubernetes cluster, if not exists, will create it.
-	CreateIfNotExists(resource meta.ResourceObject) (exists bool, err error)
+	// returns true if the object exists before
+	CreateIfNotExists(resource meta.ResourceObject) (err error)
 	// CreateIfNotExistsForOwner sets the controller owner to the given resource and creates if it not exists.
 	// If the given resource exists, won't update the object with the given owner.
-	CreateIfNotExistsForOwner(resource meta.ResourceObject, owner metav1.Object, scheme *runtime.Scheme) (bool, error)
+	CreateIfNotExistsForOwner(resource meta.ResourceObject, owner metav1.Object, scheme *runtime.Scheme) (err error)
 	// CreateForOwner sets the controller owner to the given resource and creates the resource.
 	CreateForOwner(resource meta.ResourceObject, owner metav1.Object, scheme *runtime.Scheme) error
 	// CreateFromYamlContent creates Kubernetes resources from a yaml string content
@@ -59,26 +60,26 @@ func newResource(c *client.Client) *resource {
 	}
 }
 
-func (r *resource) CreateIfNotExists(resource meta.ResourceObject) (bool, error) {
+func (r *resource) CreateIfNotExists(resource meta.ResourceObject) error {
 	log := log.With("kind", resource.GetObjectKind().GroupVersionKind().Kind, "name", resource.GetName(), "namespace", resource.GetNamespace())
 
 	if exists, err := r.ResourceReader.Fetch(resource); err == nil && !exists {
 		if err := r.ResourceWriter.Create(resource); err != nil {
-			return false, err
+			return err
 		}
-		return true, nil
+		return nil
 	} else if err != nil {
-		log.Debug("Failed to fecth object. ", err)
-		return false, err
+		log.Debug("Failed to fetch object. ", err)
+		return err
 	}
 	log.Debug("Skip creating - object already exists")
-	return false, nil
+	return nil
 }
 
-func (r *resource) CreateIfNotExistsForOwner(resource meta.ResourceObject, owner metav1.Object, scheme *runtime.Scheme) (bool, error) {
+func (r *resource) CreateIfNotExistsForOwner(resource meta.ResourceObject, owner metav1.Object, scheme *runtime.Scheme) error {
 	err := controllerutil.SetControllerReference(owner, resource, scheme)
 	if err != nil {
-		return false, err
+		return err
 	}
 	return r.CreateIfNotExists(resource)
 }
@@ -111,7 +112,7 @@ func (r *resource) CreateFromYamlContent(yamlFileContent, namespace string, reso
 		if beforeCreate != nil {
 			beforeCreate(resourceRef)
 		}
-		if _, err := r.CreateIfNotExists(resourceRef); err != nil {
+		if err := r.CreateIfNotExists(resourceRef); err != nil {
 			return fmt.Errorf("Error creating object %s: %v ", resourceRef.GetName(), err)
 		}
 	}

--- a/pkg/controller/kogitobuild/kogitobuild_controller.go
+++ b/pkg/controller/kogitobuild/kogitobuild_controller.go
@@ -207,10 +207,3 @@ func (r *ReconcileKogitoBuild) onBuildConfigChange(instance *appv1alpha1.KogitoB
 	}
 	return nil
 }
-
-func (r *ReconcileKogitoBuild) update(instance *appv1alpha1.KogitoBuild) error {
-	if err := kubernetes.ResourceC(r.client).Update(instance); err != nil {
-		return err
-	}
-	return nil
-}

--- a/pkg/controller/kogitobuild/status.go
+++ b/pkg/controller/kogitobuild/status.go
@@ -149,9 +149,16 @@ func (r *ReconcileKogitoBuild) handleStatusChange(instance *appv1alpha1.KogitoBu
 	}
 	trimConditions(instance)
 	if needUpdate {
-		if statusErr = r.update(instance); statusErr != nil {
+		if statusErr = r.updateStatus(instance); statusErr != nil {
 			err = &statusErr
 			log.Errorf("Failed to update KogitoBuild instance %s: %v", instance.Name, err)
 		}
 	}
+}
+
+func (r *ReconcileKogitoBuild) updateStatus(instance *appv1alpha1.KogitoBuild) error {
+	if err := kubernetes.ResourceC(r.client).UpdateStatus(instance); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/controller/kogitoinfra/errors.go
+++ b/pkg/controller/kogitoinfra/errors.go
@@ -20,7 +20,6 @@ import (
 )
 
 // reconciliationError type for KogitoInfra reconciliation cycle cases.
-// MUST be public because it's used by the sub packages of kogitoinfra.
 type reconciliationError struct {
 	Reason     v1alpha1.KogitoInfraConditionReason
 	innerError error
@@ -36,24 +35,21 @@ func (e reconciliationError) Error() string {
 	return e.innerError.Error()
 }
 
-// newResourceNotFoundError ...
-func newResourceNotFoundError(kind, instance, namespace string) reconciliationError {
+func errorForResourceNotFound(kind, instance, namespace string) reconciliationError {
 	return reconciliationError{
 		Reason:     v1alpha1.ResourceNotFound,
 		innerError: fmt.Errorf("%s instance(%s) not found in namespace %s", kind, instance, namespace),
 	}
 }
 
-// newResourceAPINotFoundError ...
-func newResourceAPINotFoundError(resource *v1alpha1.Resource) reconciliationError {
+func errorForResourceAPINotFound(resource *v1alpha1.Resource) reconciliationError {
 	return reconciliationError{
 		Reason:     v1alpha1.ResourceAPINotFound,
 		innerError: fmt.Errorf("%s CRD is not available in the cluster, this feature is not available. Please install the required Operator first. ", resource.APIVersion),
 	}
 }
 
-// newUnsupportedAPIError ...
-func newUnsupportedAPIError(instance *v1alpha1.KogitoInfra) reconciliationError {
+func errorForUnsupportedAPI(instance *v1alpha1.KogitoInfra) reconciliationError {
 	return reconciliationError{
 		Reason: v1alpha1.UnsupportedAPIKind,
 		innerError: fmt.Errorf("API %s is not supported for kind %s. Supported APIs are: %v",
@@ -63,7 +59,7 @@ func newUnsupportedAPIError(instance *v1alpha1.KogitoInfra) reconciliationError 
 	}
 }
 
-func newResourceNotReadyError(instance *v1alpha1.KogitoInfra, err error) reconciliationError {
+func errorForResourceNotReadyError(err error) reconciliationError {
 	return reconciliationError{
 		Reason:     v1alpha1.ResourceNotReady,
 		innerError: err,

--- a/pkg/controller/kogitoinfra/infinispan.go
+++ b/pkg/controller/kogitoinfra/infinispan.go
@@ -253,7 +253,7 @@ func (i *infinispanInfraResource) Reconcile(client *client.Client, instance *v1a
 	var infinispanInstance *infinispan.Infinispan
 
 	if !infrastructure.IsInfinispanAvailable(client) {
-		return false, newResourceAPINotFoundError(&instance.Spec.Resource)
+		return false, errorForResourceAPINotFound(&instance.Spec.Resource)
 	}
 
 	// Step 1: check whether user has provided custom infinispan instance reference
@@ -270,7 +270,7 @@ func (i *infinispanInfraResource) Reconcile(client *client.Client, instance *v1a
 			return false, resultErr
 		}
 		if infinispanInstance == nil {
-			return false, newResourceNotFoundError("Infinispan", instance.Spec.Resource.Name, namespace)
+			return false, errorForResourceNotFound("Infinispan", instance.Spec.Resource.Name, namespace)
 		}
 	} else {
 		// create/refer kogito-infinispan instance
@@ -279,7 +279,7 @@ func (i *infinispanInfraResource) Reconcile(client *client.Client, instance *v1a
 		if infinispanAvailable, err := infrastructure.IsInfinispanOperatorAvailable(client, instance.Namespace); err != nil {
 			return false, err
 		} else if !infinispanAvailable {
-			return false, newResourceAPINotFoundError(&instance.Spec.Resource)
+			return false, errorForResourceAPINotFound(&instance.Spec.Resource)
 		}
 		infinispanInstance, resultErr = loadDeployedInfinispanInstance(client, infrastructure.InfinispanInstanceName, instance.Namespace)
 		if resultErr != nil {
@@ -297,7 +297,7 @@ func (i *infinispanInfraResource) Reconcile(client *client.Client, instance *v1a
 	}
 	infinispanCondition := getLatestInfinispanCondition(infinispanInstance)
 	if infinispanCondition == nil || infinispanCondition.Status != string(v1.ConditionTrue) {
-		return false, newResourceNotReadyError(instance, fmt.Errorf("infinispan instance %s not ready. Waiting for Condition.Type == True", infinispanInstance.Name))
+		return false, errorForResourceNotReadyError(fmt.Errorf("infinispan instance %s not ready. Waiting for Condition.Type == True", infinispanInstance.Name))
 	}
 	if resultErr := updateInfinispanAppPropsInStatus(client, infinispanInstance, instance); resultErr != nil {
 		return false, nil

--- a/pkg/controller/kogitoinfra/kafka.go
+++ b/pkg/controller/kogitoinfra/kafka.go
@@ -88,7 +88,7 @@ func (k *kafkaInfraResource) Reconcile(client *client.Client, instance *v1alpha1
 
 	// Verify kafka
 	if !infrastructure.IsStrimziAvailable(client) {
-		return false, newResourceAPINotFoundError(&instance.Spec.Resource)
+		return false, errorForResourceAPINotFound(&instance.Spec.Resource)
 	}
 
 	if len(instance.Spec.Resource.Name) > 0 {
@@ -102,7 +102,7 @@ func (k *kafkaInfraResource) Reconcile(client *client.Client, instance *v1alpha1
 			return false, resultErr
 		} else if kafkaInstance == nil {
 			return false,
-				newResourceNotFoundError("Kafka", instance.Spec.Resource.Name, namespace)
+				errorForResourceNotFound("Kafka", instance.Spec.Resource.Name, namespace)
 		}
 	} else {
 		// create/refer kogito-kafka instance
@@ -125,7 +125,7 @@ func (k *kafkaInfraResource) Reconcile(client *client.Client, instance *v1alpha1
 	}
 	kafkaStatus := getLatestKafkaCondition(kafkaInstance)
 	if kafkaStatus == nil || kafkaStatus.Type != kafkabetav1.KafkaConditionTypeReady {
-		return false, newResourceNotReadyError(instance, fmt.Errorf("kafka instance %s not ready yet. Waiting for Condition status Ready", kafkaInstance.Name))
+		return false, errorForResourceNotReadyError(fmt.Errorf("kafka instance %s not ready yet. Waiting for Condition status Ready", kafkaInstance.Name))
 	}
 	if resultErr = updateKafkaAppPropsInStatus(kafkaInstance, instance); resultErr != nil {
 		return true, resultErr
@@ -139,7 +139,7 @@ func (k *kafkaInfraResource) Reconcile(client *client.Client, instance *v1alpha1
 func updateKafkaAppPropsInStatus(kafkaInstance *kafkabetav1.Kafka, instance *v1alpha1.KogitoInfra) error {
 	appProps, err := getKafkaAppProps(kafkaInstance)
 	if err != nil {
-		return newResourceNotReadyError(instance, err)
+		return errorForResourceNotReadyError(err)
 	}
 	instance.Status.AppProps = appProps
 	return nil
@@ -148,7 +148,7 @@ func updateKafkaAppPropsInStatus(kafkaInstance *kafkabetav1.Kafka, instance *v1a
 func updateKafkaEnvVarsInStatus(kafkaInstance *kafkabetav1.Kafka, instance *v1alpha1.KogitoInfra) error {
 	envVars, err := getKafkaEnvVars(kafkaInstance)
 	if err != nil {
-		return newResourceNotReadyError(instance, err)
+		return errorForResourceNotReadyError(err)
 	}
 	instance.Status.Env = envVars
 	return nil

--- a/pkg/controller/kogitoinfra/keycloak.go
+++ b/pkg/controller/kogitoinfra/keycloak.go
@@ -52,7 +52,7 @@ func (k *keycloakInfraResource) Reconcile(client *client.Client, instance *v1alp
 	var keycloakInstance *keycloakv1alpha1.Keycloak
 
 	if !infrastructure.IsKeycloakAvailable(client) {
-		return false, newResourceAPINotFoundError(&instance.Spec.Resource)
+		return false, errorForResourceAPINotFound(&instance.Spec.Resource)
 	}
 
 	if len(instance.Spec.Resource.Name) > 0 {
@@ -65,7 +65,7 @@ func (k *keycloakInfraResource) Reconcile(client *client.Client, instance *v1alp
 		if keycloakInstance, resultErr = loadDeployedKeycloakInstance(client, instance.Spec.Resource.Name, namespace); resultErr != nil {
 			return false, resultErr
 		} else if keycloakInstance == nil {
-			return false, newResourceNotFoundError("Keycloak", instance.Spec.Resource.Name, namespace)
+			return false, errorForResourceNotFound("Keycloak", instance.Spec.Resource.Name, namespace)
 		}
 	} else {
 		log.Debugf("Custom Keycloak instance reference is not provided")

--- a/pkg/controller/kogitoinfra/knative.go
+++ b/pkg/controller/kogitoinfra/knative.go
@@ -33,7 +33,7 @@ type knativeInfraResource struct{}
 func (i *knativeInfraResource) Reconcile(client *client.Client, instance *v1alpha1.KogitoInfra, scheme *runtime.Scheme) (requeue bool, resultErr error) {
 
 	if !infrastructure.IsKnativeEventingAvailable(client) {
-		return false, newResourceAPINotFoundError(&instance.Spec.Resource)
+		return false, errorForResourceAPINotFound(&instance.Spec.Resource)
 	}
 
 	if len(instance.Spec.Resource.Name) > 0 {
@@ -47,7 +47,7 @@ func (i *knativeInfraResource) Reconcile(client *client.Client, instance *v1alph
 		if exists, resultErr := kubernetes.ResourceC(client).Fetch(&broker); resultErr != nil {
 			return false, resultErr
 		} else if !exists {
-			return false, newResourceNotFoundError(infrastructure.KnativeEventingBrokerKind, broker.Name, broker.Namespace)
+			return false, errorForResourceNotFound(infrastructure.KnativeEventingBrokerKind, broker.Name, broker.Namespace)
 		}
 	} else {
 		return false,

--- a/pkg/controller/kogitoinfra/kogitoinfra_service.go
+++ b/pkg/controller/kogitoinfra/kogitoinfra_service.go
@@ -29,7 +29,7 @@ func getKogitoInfraResource(instance *v1alpha1.KogitoInfra) (InfraResource, erro
 	if infraRes, ok := getSupportedInfraResources()[resourceClassForInstance(instance)]; ok {
 		return infraRes, nil
 	}
-	return nil, newUnsupportedAPIError(instance)
+	return nil, errorForUnsupportedAPI(instance)
 }
 
 func resourceClassForInstance(instance *v1alpha1.KogitoInfra) string {

--- a/pkg/controller/kogitosupportingservice/explainability_reconciler_test.go
+++ b/pkg/controller/kogitosupportingservice/explainability_reconciler_test.go
@@ -32,7 +32,7 @@ func TestReconcileKogitoSupportingServiceExplainability_Reconcile(t *testing.T) 
 			Namespace: ns,
 		},
 		Spec: v1alpha1.KogitoSupportingServiceSpec{
-			ServiceType: v1alpha1.Explainablity,
+			ServiceType: v1alpha1.Explainability,
 			KogitoServiceSpec: v1alpha1.KogitoServiceSpec{
 				Infra: []string{
 					kogitoKafka.Name,

--- a/pkg/controller/kogitosupportingservice/kogitosupportingservice_controller.go
+++ b/pkg/controller/kogitosupportingservice/kogitosupportingservice_controller.go
@@ -224,10 +224,10 @@ type SupportingServiceResource interface {
 // map of all the kogitoSupportingService
 // Note: Data Index is not part of this map because it has it's own controller
 var kogitoSupportingServices = map[v1alpha1.ServiceType]SupportingServiceResource{
-	v1alpha1.Explainablity: &ExplainabilitySupportingServiceResource{},
-	v1alpha1.JobsService:   &JobsServiceSupportingServiceResource{},
-	v1alpha1.MgmtConsole:   &MgmtConsoleSupportingServiceResource{},
-	v1alpha1.TaskConsole:   &TaskConsoleSupportingServiceResource{},
-	v1alpha1.TrustyAI:      &TrustyAISupportingServiceResource{},
-	v1alpha1.TrustyUI:      &TrustyUISupportingServiceResource{},
+	v1alpha1.Explainability: &ExplainabilitySupportingServiceResource{},
+	v1alpha1.JobsService:    &JobsServiceSupportingServiceResource{},
+	v1alpha1.MgmtConsole:    &MgmtConsoleSupportingServiceResource{},
+	v1alpha1.TaskConsole:    &TaskConsoleSupportingServiceResource{},
+	v1alpha1.TrustyAI:       &TrustyAISupportingServiceResource{},
+	v1alpha1.TrustyUI:       &TrustyUISupportingServiceResource{},
 }

--- a/pkg/infrastructure/services/dashboards_test.go
+++ b/pkg/infrastructure/services/dashboards_test.go
@@ -15,9 +15,6 @@
 package services
 
 import (
-	"testing"
-	"time"
-
 	grafanav1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
@@ -25,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
 )
 
 func Test_fetchDashboardNames(t *testing.T) {
@@ -97,9 +95,8 @@ func Test_serviceDeployer_DeployGrafanaDashboards(t *testing.T) {
 		},
 	}
 
-	reconcileAfter, err := deployGrafanaDashboards(dashboards, cli, service, meta.GetRegisteredSchema(), t.Name())
+	err := deployGrafanaDashboards(dashboards, cli, service, meta.GetRegisteredSchema(), t.Name())
 	assert.NoError(t, err)
-	assert.Equal(t, time.Duration(0), reconcileAfter)
 
 	dashboard := &grafanav1.GrafanaDashboard{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/infrastructure/services/errors.go
+++ b/pkg/infrastructure/services/errors.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"fmt"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1alpha1"
+	"time"
+)
+
+const (
+	reconciliationIntervalAfterInfraError                = time.Minute
+	reconciliationIntervalAfterMessagingError            = time.Second * 30
+	reconciliationIntervalMonitoringEndpointNotAvailable = time.Second * 10
+	reconciliationIntervalAfterDashboardsError           = time.Second * 30
+)
+
+type reconciliationError struct {
+	reason                 v1alpha1.KogitoServiceConditionReason
+	reconciliationInterval time.Duration
+	innerError             error
+}
+
+// String stringer implementation
+func (e reconciliationError) String() string {
+	return e.innerError.Error()
+}
+
+// Error error implementation
+func (e reconciliationError) Error() string {
+	return e.innerError.Error()
+}
+
+func errorForInfraNotReady(service v1alpha1.KogitoService, infra *v1alpha1.KogitoInfra) reconciliationError {
+	return reconciliationError{
+		reconciliationInterval: reconciliationIntervalAfterInfraError,
+		reason:                 v1alpha1.KogitoInfraNotReadyReason,
+		innerError: fmt.Errorf("KogitoService '%s' is waiting for infra dependency; skipping deployment; KogitoInfra not ready: %s; Status: %s",
+			service.GetName(), infra.Name, infra.Status.Condition.Reason),
+	}
+}
+
+func errorForMessaging(err error) reconciliationError {
+	return reconciliationError{
+		reconciliationInterval: reconciliationIntervalAfterMessagingError,
+		reason:                 v1alpha1.MessagingIntegrationFailureReason,
+		innerError:             err,
+	}
+}
+
+func errorForMonitoring(err error) reconciliationError {
+	return reconciliationError{
+		reconciliationInterval: reconciliationIntervalMonitoringEndpointNotAvailable,
+		reason:                 v1alpha1.MonitoringIntegrationFailureReason,
+		innerError:             err,
+	}
+}
+
+func errorForDashboards(err error) reconciliationError {
+	return reconciliationError{
+		reconciliationInterval: reconciliationIntervalAfterDashboardsError,
+		reason:                 v1alpha1.MonitoringIntegrationFailureReason,
+		innerError:             err,
+	}
+}
+
+func reasonForError(err error) v1alpha1.KogitoServiceConditionReason {
+	if err == nil {
+		return ""
+	}
+	switch t := err.(type) {
+	case reconciliationError:
+		return t.reason
+	}
+	return v1alpha1.ServiceReconciliationFailure
+}
+
+func reconciliationIntervalForError(err error) time.Duration {
+	switch t := err.(type) {
+	case reconciliationError:
+		return t.reconciliationInterval
+	}
+	return 0
+}

--- a/pkg/infrastructure/services/messaging_knative.go
+++ b/pkg/infrastructure/services/messaging_knative.go
@@ -46,7 +46,7 @@ func (k *knativeMessagingDeployer) createRequiredResources(service v1alpha1.Kogi
 
 	// since we depend on Knative, let's bind a SinkBinding object to our deployment
 	sinkBinding := k.newSinkBinding(service, infra)
-	if _, err := kubernetes.ResourceC(k.cli).CreateIfNotExistsForOwner(sinkBinding, service, k.scheme); err != nil {
+	if err := kubernetes.ResourceC(k.cli).CreateIfNotExistsForOwner(sinkBinding, service, k.scheme); err != nil {
 		return err
 	}
 

--- a/pkg/test/assert_create.go
+++ b/pkg/test/assert_create.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Red Hat, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/client/meta"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// AssertCreate creates the given resource and asserts that it isn't existed before
+func AssertCreate(t *testing.T, c *client.Client, resource meta.ResourceObject) {
+	err := kubernetes.ResourceC(c).CreateIfNotExists(resource)
+	assert.NoError(t, err)
+}

--- a/test/framework/kogitobuild.go
+++ b/test/framework/kogitobuild.go
@@ -45,10 +45,10 @@ func DeployKogitoBuild(namespace string, installerType InstallerType, buildHolde
 }
 
 func crDeployKogitoBuild(buildHolder *bddtypes.KogitoBuildHolder) error {
-	if _, err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(buildHolder.KogitoBuild); err != nil {
+	if err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(buildHolder.KogitoBuild); err != nil {
 		return fmt.Errorf("Error creating example build %s: %v", buildHolder.KogitoBuild.Name, err)
 	}
-	if _, err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(buildHolder.KogitoService); err != nil {
+	if err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(buildHolder.KogitoService); err != nil {
 		return fmt.Errorf("Error creating example service %s: %v", buildHolder.KogitoService.GetName(), err)
 	}
 	return nil

--- a/test/framework/kogitoexplainability.go
+++ b/test/framework/kogitoexplainability.go
@@ -41,7 +41,7 @@ func GetKogitoExplainabilityResourceStub(namespace string, replicas int) *v1alph
 	return &v1alpha1.KogitoSupportingService{
 		ObjectMeta: NewObjectMetadata(namespace, getExplainabilityServiceName()),
 		Spec: v1alpha1.KogitoSupportingServiceSpec{
-			ServiceType:       v1alpha1.Explainablity,
+			ServiceType:       v1alpha1.Explainability,
 			KogitoServiceSpec: NewKogitoServiceSpec(int32(replicas), config.GetExplainabilityImageTag(), infrastructure.DefaultExplainabilityImageName),
 		},
 		Status: v1alpha1.KogitoSupportingServiceStatus{

--- a/test/framework/kogitoinfra.go
+++ b/test/framework/kogitoinfra.go
@@ -39,7 +39,7 @@ func InstallKogitoInfraComponent(namespace string, installerType InstallerType, 
 }
 
 func crInstallKogitoInfraComponent(infra *v1alpha1.KogitoInfra) error {
-	if _, err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(infra); err != nil {
+	if err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(infra); err != nil {
 		return fmt.Errorf("Error creating KogitoInfra: %v", err)
 	}
 	return nil

--- a/test/framework/kogitoserviceutils.go
+++ b/test/framework/kogitoserviceutils.go
@@ -141,7 +141,7 @@ func isRuntimeImageInformationSet() bool {
 }
 
 func crInstall(serviceHolder *bddtypes.KogitoServiceHolder) error {
-	if _, err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(serviceHolder.KogitoService); err != nil {
+	if err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(serviceHolder.KogitoService); err != nil {
 		return fmt.Errorf("Error creating service: %v", err)
 	}
 	return nil

--- a/test/framework/operator.go
+++ b/test/framework/operator.go
@@ -267,7 +267,7 @@ func CreateOperatorGroupIfNotExists(namespace, operatorGroupName string) (*olmap
 			TargetNamespaces: []string{namespace},
 		},
 	}
-	if _, err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(operatorGroup); err != nil {
+	if err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(operatorGroup); err != nil {
 		return nil, fmt.Errorf("Error creating OperatorGroup %s: %v", operatorGroupName, err)
 	}
 	return operatorGroup, nil
@@ -288,7 +288,7 @@ func CreateNamespacedSubscriptionIfNotExist(namespace string, subscriptionName s
 		},
 	}
 
-	if _, err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(subscription); err != nil {
+	if err := kubernetes.ResourceC(kubeClient).CreateIfNotExists(subscription); err != nil {
 		return nil, fmt.Errorf("Error creating Subscription %s: %v", subscriptionName, err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3556

Small refactoring to the Status handling for our services.

This is how it looks a KogitoInfra during third party installations:

```
oc get kogitoinfra
NAME                      RESOURCE NAME   KIND         API VERSION         STATUS   REASON
kogito-infinispan-infra                   Infinispan   infinispan.org/v1   False    ResourceAPINotFound

oc get kogitoinfra
NAME                      RESOURCE NAME   KIND         API VERSION         STATUS   REASON
kogito-infinispan-infra                   Infinispan   infinispan.org/v1   False    ResourceNotReady
```

This is how it looks the Conditions table for our services:

![Screenshot from 2020-10-30 13-57-27](https://user-images.githubusercontent.com/1538000/97734831-6ffba700-1ab8-11eb-935e-f7427a6a178a.png)

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
