### PR TITLE
Updating Release Notes to 1.1.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Many thanks for submitting your Pull Request :heart:! 
 
-Please make sure that your PR meets the following requirements:
+Please make sure your PR meets the following requirements:
 
 - [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
 - [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
@@ -9,3 +9,4 @@ Please make sure that your PR meets the following requirements:
 - [ ] Pull Request does not include fixes for issues other than the main ticket
 - [ ] Your feature/bug fix has a unit test that verifies it
 - [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
+- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,19 +1,11 @@
-## Enhancements
-- [KOGITO-2562](https://issues.redhat.com/browse/KOGITO-2562) - Knative Eventing resources created for Kogito Applications that uses [Knative Addon](https://github.com/kiegroup/kogito-examples/tree/stable/process-knative-quickstart-quarkus).
-- [KOGITO-816](https://issues.redhat.com/browse/KOGITO-816) - Operator provisioning for Task Console.
-- [KOGITO-1006](https://issues.redhat.com/browse/KOGITO-1006) - Add support to install Task Console to CLI.  
-- [KOGITO-3094](https://issues.redhat.com/browse/KOGITO-3094) - Provide data-index-infinispan/mongodb as independent images
-     - To switch to Mongodb persistence provider just provide the `quay.io/kiegroup/kogito-data-index-mongodb:1.0.0-snapshot` on the Kogito CR  
-- [KOGITO-3624](https://issues.redhat.com/browse/KOGITO-3624) - Grafana dashboard resources created for Kogito Applications that uses [Monitoring Addon](https://blog.kie.org/2020/07/trustyai-meets-kogito-decision-monitoring.html)
-- [KOGITO-3273](https://issues.redhat.com/browse/KOGITO-3273) - Research to remove supporting Kogito Services CRD
-- [KOGITO-3568](https://issues.redhat.com/browse/KOGITO-3273) - Remove spec.httpPort attribute from Operator and HTTP_PORT env var from Kogito images
-- [KOGITO-3376](https://issues.redhat.com/browse/KOGITO-3376) - Update protobuf ConfigMap using fetched files
-- [KOGITO-3708](https://issues.redhat.com/browse/KOGITO-3708) - Decreasing the amount of reconciliation loops for `KogitoInfra` resources when
-third party infrastructure resources are not yet available
-- [KOGITO-3556](https://issues.redhat.com/browse/KOGITO-3556) - Review CRDs Status resource update
- 
+## Enhancements  
+- [KOGITO-3610](https://issues.redhat.com/browse/KOGITO-3610) Updating Kogito Service interface to describe CloudEvents
+- [KOGITO-3754](https://issues.redhat.com/browse/KOGITO-3754) Making KogitoInfra create a truststore secret to hold PKCS certs for infinispan/services connections
+- [KOGITO-3874](https://issues.redhat.com/browse/KOGITO-3874) Allow configuration of readiness and liveness probes
+- [KOGITO-3215](https://issues.redhat.com/browse/KOGITO-3215) - Support cluster-scoped deployment for operator
+
 ## Bug Fixes
-- [KOGITO-3736](https://issues.redhat.com/browse/KOGITO-3736) - Reconciler error in Data index controller when KogitoRuntime is deployed
+- [KOGITO-3866](https://issues.redhat.com/browse/KOGITO-3866) Operator print error logs when KogitoRuntime delete
 
 ## Known Issues
 The protobuf ConfigMap does not update in Spring Boot due to [this issue](https://issues.redhat.com/browse/KOGITO-3406).


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

@Kaitou786 can we add an option to the bot to also comment in the PR when RELEASE_NOTES.md is not updated for changes on the operator (do not consider BDD changes)? 
