### PR TITLE
[KOGITO-3968] - Add support to deploy Kogito services from SW files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,9 +2,10 @@
 - [KOGITO-3610](https://issues.redhat.com/browse/KOGITO-3610) Updating Kogito Service interface to describe CloudEvents
 - [KOGITO-3754](https://issues.redhat.com/browse/KOGITO-3754) Making KogitoInfra create a truststore secret to hold PKCS certs for infinispan/services connections
 - [KOGITO-3874](https://issues.redhat.com/browse/KOGITO-3874) Allow configuration of readiness and liveness probes
-- [KOGITO-3215](https://issues.redhat.com/browse/KOGITO-3215) - Support cluster-scoped deployment for operator
+- [KOGITO-3215](https://issues.redhat.com/browse/KOGITO-3215) Support cluster-scoped deployment for operator
 - [KOGITO-3937](https://issues.redhat.com/browse/KOGITO-3937) Move probe configuration in to `probes` subproperty
 - [KOGITO-3898](https://issues.redhat.com/browse/KOGITO-3898) Provide CLI flags for subset of probe parameters
+- [KOGITO-3968](https://issues.redhat.com/browse/KOGITO-3968) Add support to build and deploy sw.json and sw.yaml files from source
 
 ## Bug Fixes
 - [KOGITO-3866](https://issues.redhat.com/browse/KOGITO-3866) Operator print error logs when KogitoRuntime delete

--- a/cmd/kogito/command/deploy/delete_service.go
+++ b/cmd/kogito/command/deploy/delete_service.go
@@ -32,7 +32,7 @@ func initDeleteServiceCommand(ctx *context.CommandContext, parent *cobra.Command
 		CommandContext:       *ctx,
 		Parent:               parent,
 		resourceCheckService: shared.NewResourceCheckService(),
-		buildService:         service.NewBuildService(),
+		buildService:         service.NewBuildService(ctx.Client),
 		runtimeService:       service.NewRuntimeService(),
 	}
 	cmd.RegisterHook()
@@ -86,7 +86,7 @@ func (i *deleteServiceCommand) Exec(cmd *cobra.Command, args []string) (err erro
 	if err = i.runtimeService.DeleteRuntimeService(i.Client, i.flags.name, i.flags.project); err != nil {
 		return err
 	}
-	if err = i.buildService.DeleteBuildService(i.Client, i.flags.name, i.flags.project); err != nil {
+	if err = i.buildService.DeleteBuildService(i.flags.name, i.flags.project); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/kogito/command/deploy/deploy_service.go
+++ b/cmd/kogito/command/deploy/deploy_service.go
@@ -46,7 +46,7 @@ func initDeployCommand(ctx *context.CommandContext, parent *cobra.Command) conte
 		CommandContext:       *ctx,
 		Parent:               parent,
 		resourceCheckService: shared.NewResourceCheckService(),
-		buildService:         service.NewBuildService(),
+		buildService:         service.NewBuildService(ctx.Client),
 		runtimeService:       service.NewRuntimeService(),
 	}
 
@@ -140,7 +140,7 @@ func (i *deployCommand) installBuildService(cli *client.Client, flags *deployFla
 	flags.BuildFlags.Project = project
 	flags.BuildFlags.OperatorFlags = flags.RuntimeFlags.OperatorFlags
 	flags.BuildFlags.RuntimeTypeFlags = flags.RuntimeTypeFlags
-	return i.buildService.InstallBuildService(cli, &flags.BuildFlags, resource)
+	return i.buildService.InstallBuildService(&flags.BuildFlags, resource)
 }
 
 func (i *deployCommand) installRuntimeService(cli *client.Client, flags *deployFlags, name, project string) error {

--- a/cmd/kogito/command/deploy/testdata/greetings.sw.json
+++ b/cmd/kogito/command/deploy/testdata/greetings.sw.json
@@ -1,0 +1,78 @@
+{
+  "id": "jsongreet",
+  "version": "1.0",
+  "name": "Greeting workflow",
+  "description": "JSON based greeting workflow",
+  "functions": [
+    {
+      "name": "greetFunction",
+      "type": "sysout"
+    }
+  ],
+  "states": [
+    {
+      "name": "ChooseOnLanguage",
+      "type": "switch",
+      "start": {
+        "kind": "default"
+      },
+      "dataConditions": [
+        {
+          "condition": "{{ $.[?(@.language  == 'English')] }}",
+          "transition": {
+            "nextState": "GreetInEnglish"
+          }
+        },
+        {
+          "condition": "{{ $.[?(@.language  == 'Spanish')] }}",
+          "transition": {
+            "nextState": "GreetInSpanish"
+          }
+        }
+      ],
+      "default": {
+        "transition": {
+          "nextState": "GreetInEnglish"
+        }
+      }
+    },
+    {
+      "name": "GreetInEnglish",
+      "type": "inject",
+      "data": {
+        "greeting": "Hello from JSON Workflow, "
+      },
+      "transition": {
+        "nextState": "GreetPerson"
+      }
+    },
+    {
+      "name": "GreetInSpanish",
+      "type": "inject",
+      "data": {
+        "greeting": "Saludos desde JSON Workflow, "
+      },
+      "transition": {
+        "nextState": "GreetPerson"
+      }
+    },
+    {
+      "name": "GreetPerson",
+      "type": "operation",
+      "actions": [
+        {
+          "name": "greetAction",
+          "functionRef": {
+            "refName": "greetFunction",
+            "parameters": {
+              "message": "$.greeting $.name"
+            }
+          }
+        }
+      ],
+      "end": {
+        "kind": "terminate"
+      }
+    }
+  ]
+}

--- a/cmd/kogito/command/iozip/zip_files.go
+++ b/cmd/kogito/command/iozip/zip_files.go
@@ -29,7 +29,7 @@ import (
 )
 
 var supportedExtensions = map[flag.BinaryBuildType][]string{
-	flag.SourceToImageBuild:       {".dmn", ".drl", ".bpmn", ".bpmn2", ".properties"},
+	flag.SourceToImageBuild:       {".dmn", ".drl", ".bpmn", ".bpmn2", ".properties", ".sw.json", ".sw.yaml"},
 	flag.BinaryQuarkusJvmBuild:    {".jar", ".json"},
 	flag.BinarySpringBootJvmBuild: {".jar", ".json"},
 	flag.BinaryQuarkusNativeBuild: {"-runner", ".json"},

--- a/cmd/kogito/command/shared/install_operator_test.go
+++ b/cmd/kogito/command/shared/install_operator_test.go
@@ -15,11 +15,10 @@
 package shared
 
 import (
-	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/test"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client/kubernetes"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/infrastructure"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/operator"
-	test2 "github.com/kiegroup/kogito-cloud-operator/pkg/test"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	operators "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 
@@ -38,7 +37,7 @@ const serviceAccountName = "kogito-service-viewer"
 
 func Test_InstallOperatorWithYaml(t *testing.T) {
 	ns := t.Name()
-	client := test.SetupFakeKubeCli(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	client := test.NewFakeClientBuilder().AddK8sObjects(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}).Build()
 	image := "docker.io/myrepo/custom-operator:1.0"
 
 	err := installOperatorWithYamlFiles(image, ns, false, client)
@@ -95,7 +94,7 @@ func TestMustInstallOperatorIfNotExists_WithOperatorHubOnOpenshift(t *testing.T)
 			Namespace: openshiftGlobalOperatorNamespace,
 		},
 	}
-	client := test2.NewFakeClientBuilder().AddK8sObjects(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: openshiftGlobalOperatorNamespace}}, packageManifest).OnOpenShift().SupportOLM().Build()
+	client := test.NewFakeClientBuilder().AddK8sObjects(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: openshiftGlobalOperatorNamespace}}, packageManifest).OnOpenShift().SupportOLM().Build()
 	// Operator is there in the hub and not exists in the given namespace, let's check if there's no error
 	err := InstallOperatorIfNotExists(ns, defaultOperatorImageName, client, false, false, GetDefaultChannel(), false)
 	assert.NoError(t, err)
@@ -114,7 +113,7 @@ func TestMustInstallOperatorIfNotExists_WithOperatorHubOnKubernetes(t *testing.T
 			Namespace: kubernetesGlobalOperatorNamespace,
 		},
 	}
-	client := test2.NewFakeClientBuilder().AddK8sObjects(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: kubernetesGlobalOperatorNamespace}}, packageManifest).SupportOLM().Build()
+	client := test.NewFakeClientBuilder().AddK8sObjects(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: kubernetesGlobalOperatorNamespace}}, packageManifest).SupportOLM().Build()
 	// Operator is there in the hub and not exists in the given namespace, let's check if there's no error
 	err := InstallOperatorIfNotExists(ns, defaultOperatorImageName, client, false, false, GetDefaultChannel(), false)
 	assert.NoError(t, err)
@@ -128,10 +127,10 @@ func TestMustInstallOperatorIfNotExists_WithOperatorHubOnKubernetes(t *testing.T
 func TestMustInstallOperatorIfNotExists_WithoutOperatorHub(t *testing.T) {
 	ns := t.Name()
 
-	client := test.SetupFakeKubeCli(
+	client := test.NewFakeClientBuilder().AddK8sObjects(
 		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
-		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: operatorNamespace}},
-	)
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: operatorNamespace}}).Build()
+
 	// Operator is not in the hub. Install with yaml files.
 	err := InstallOperatorIfNotExists(ns, defaultOperatorImageName, client, false, false, GetDefaultChannel(), false)
 	assert.NoError(t, err)

--- a/cmd/kogito/command/shared/resource_checks_test.go
+++ b/cmd/kogito/command/shared/resource_checks_test.go
@@ -16,11 +16,11 @@ package shared
 
 import (
 	"github.com/kiegroup/kogito-cloud-operator/pkg/apis/app/v1beta1"
+	"github.com/kiegroup/kogito-cloud-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
-	"github.com/kiegroup/kogito-cloud-operator/cmd/kogito/command/test"
 	"github.com/kiegroup/kogito-cloud-operator/pkg/client"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,9 +28,10 @@ import (
 
 func Test_EnsureProject(t *testing.T) {
 	ns := t.Name()
-	kubeCli := test.SetupFakeKubeCli(&v1.Namespace{
-		ObjectMeta: v12.ObjectMeta{Name: ns},
-	})
+	kubeCli := test.NewFakeClientBuilder().AddK8sObjects(
+		&v1.Namespace{
+			ObjectMeta: v12.ObjectMeta{Name: ns},
+		}).Build()
 	type args struct {
 		kubeCli *client.Client
 		project string
@@ -77,14 +78,14 @@ func Test_EnsureProject(t *testing.T) {
 func Test_CheckKogitoRuntimeExists_exists(t *testing.T) {
 	runtimeServiceName := "runtime-service"
 	ns := t.Name()
-	kubeCli := test.SetupFakeKubeCli(&v1.Namespace{
-		ObjectMeta: v12.ObjectMeta{Name: ns},
-	}, &v1beta1.KogitoRuntime{
-		ObjectMeta: v12.ObjectMeta{
-			Name:      runtimeServiceName,
-			Namespace: ns,
-		},
-	})
+	kubeCli := test.NewFakeClientBuilder().AddK8sObjects(
+		&v1.Namespace{ObjectMeta: v12.ObjectMeta{Name: ns}},
+		&v1beta1.KogitoRuntime{
+			ObjectMeta: v12.ObjectMeta{
+				Name:      runtimeServiceName,
+				Namespace: ns,
+			},
+		}).Build()
 	resourceCheckService := NewResourceCheckService()
 
 	err := resourceCheckService.CheckKogitoRuntimeExists(kubeCli, runtimeServiceName, ns)
@@ -96,9 +97,7 @@ func Test_CheckKogitoRuntimeExists_exists(t *testing.T) {
 func Test_CheckKogitoRuntimeExists_notExists(t *testing.T) {
 	runtimeServiceName := "runtime-service"
 	ns := t.Name()
-	kubeCli := test.SetupFakeKubeCli(&v1.Namespace{
-		ObjectMeta: v12.ObjectMeta{Name: ns},
-	})
+	kubeCli := test.NewFakeClientBuilder().AddK8sObjects(&v1.Namespace{ObjectMeta: v12.ObjectMeta{Name: ns}}).Build()
 	resourceCheckService := NewResourceCheckService()
 
 	err := resourceCheckService.CheckKogitoRuntimeExists(kubeCli, runtimeServiceName, ns)
@@ -110,14 +109,13 @@ func Test_CheckKogitoRuntimeExists_notExists(t *testing.T) {
 func Test_CheckKogitoBuildExists_exists(t *testing.T) {
 	buildServiceName := "build-service"
 	ns := t.Name()
-	kubeCli := test.SetupFakeKubeCli(&v1.Namespace{
-		ObjectMeta: v12.ObjectMeta{Name: ns},
-	}, &v1beta1.KogitoBuild{
-		ObjectMeta: v12.ObjectMeta{
-			Name:      buildServiceName,
-			Namespace: ns,
-		},
-	})
+	kubeCli := test.NewFakeClientBuilder().AddK8sObjects(&v1.Namespace{ObjectMeta: v12.ObjectMeta{Name: ns}},
+		&v1beta1.KogitoBuild{
+			ObjectMeta: v12.ObjectMeta{
+				Name:      buildServiceName,
+				Namespace: ns,
+			},
+		}).Build()
 	resourceCheckService := NewResourceCheckService()
 
 	err := resourceCheckService.CheckKogitoBuildExists(kubeCli, buildServiceName, ns)
@@ -129,9 +127,7 @@ func Test_CheckKogitoBuildExists_exists(t *testing.T) {
 func Test_CheckKogitoBuildExists_notExists(t *testing.T) {
 	buildServiceName := "build-service"
 	ns := t.Name()
-	kubeCli := test.SetupFakeKubeCli(&v1.Namespace{
-		ObjectMeta: v12.ObjectMeta{Name: ns},
-	})
+	kubeCli := test.NewFakeClientBuilder().AddK8sObjects(&v1.Namespace{ObjectMeta: v12.ObjectMeta{Name: ns}}).Build()
 	resourceCheckService := NewResourceCheckService()
 
 	err := resourceCheckService.CheckKogitoBuildExists(kubeCli, buildServiceName, ns)

--- a/cmd/kogito/command/test/common.go
+++ b/cmd/kogito/command/test/common.go
@@ -32,21 +32,20 @@ var (
 	rootCommand *cobra.Command
 )
 
-// SetupFakeKubeCli creates a fake kube client for your tests
-func SetupFakeKubeCli(initObjs ...runtime.Object) *client.Client {
-	return test.NewFakeClientBuilder().AddK8sObjects(initObjs...).Build()
+// SetupCliTest creates the CLI default test environment. The mocked Kubernetes client does not support OpenShift.
+func SetupCliTest(cli string, factory context.CommandFactory, kubeObjects ...runtime.Object) (ctx *context.CommandContext) {
+	return SetupCliTestWithKubeClient(cli, factory, test.NewFakeClientBuilder().AddK8sObjects(kubeObjects...).Build())
 }
 
-// SetupCliTest creates the infrastructure for the CLI test
-func SetupCliTest(cli string, factory context.CommandFactory, kubeObjects ...runtime.Object) (ctx *context.CommandContext) {
-	kubeCli := SetupFakeKubeCli(kubeObjects...)
+// SetupCliTestWithKubeClient Setup a CLI test environment with the given Kubernetes client
+func SetupCliTestWithKubeClient(cmd string, factory context.CommandFactory, kubeCli *client.Client) (ctx *context.CommandContext) {
 	testErr = new(bytes.Buffer)
 	testOut = new(bytes.Buffer)
 
 	ctx = &context.CommandContext{Client: kubeCli}
 
 	kogitoRootCmd := context.NewRootCommand(ctx, testOut)
-	kogitoRootCmd.Command().SetArgs(strings.Split(cli, " "))
+	kogitoRootCmd.Command().SetArgs(strings.Split(cmd, " "))
 	kogitoRootCmd.Command().SetOut(testOut)
 	kogitoRootCmd.Command().SetErr(testErr)
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
 	golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -2108,6 +2108,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180117170059-2c42eef0765b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -64,7 +64,7 @@ type Client struct {
 
 // NewForConsole will create a brand new client using the local machine
 func NewForConsole() *Client {
-	client, err := NewClientBuilder().WithDiscoveryClient().Build()
+	client, err := NewClientBuilder().WithBuildClient().WithDiscoveryClient().Build()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3968

To deploy the [SW greetings example](https://github.com/kiegroup/kogito-examples/tree/master/serverless-workflow-greeting-quarkus) from the source, do:

```bash
$ kogito deploy sw-greetings cmd/kogito/command/deploy/testdata/greetings.sw.json --image-runtime quay.io/kiegroup/kogito-quarkus-jvm-ubi8:1.0 --image-s2i quay.io/kiegroup/kogito-quarkus-ubi8-s2i:1.0

Kogito Build Service successfully installed in the Project kogito-3968.
Check the Service status by running 'oc describe kogitobuild/sw-greetings -n kogito-3968'
File(s) found: cmd/kogito/command/deploy/testdata/greetings.sw.json.
Triggering the new build
The requested file(s) was successfully uploaded to OpenShift, the build sw-greetings-builder-1 with this file(s) should now be running. To see the logs, run 'oc logs -f bc/sw-greetings-builder -n kogito-3968'
Kogito Service successfully installed in the Project kogito-3968.
Check the Service status by running 'oc describe kogitoruntime/sw-greetings -n kogito-3968'
To more easily manage your Kogito Service install Data Index Service and Process Instance Management. 
For how to install see: https://docs.jboss.org/kogito/release/latest/html_single/#con-kogito-operator-with-data-index-service_kogito-deploying-on-openshift
and https://docs.jboss.org/kogito/release/latest/html_single/#con-management-console_kogito-developing-process-services
```

Soon you should see:

```bash
$ oc get builds

NAME                     TYPE     FROM     STATUS    STARTED         DURATION
sw-greetings-builder-1   Source   Binary   Running   3 minutes ago   
```

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change