### PR TITLE
[1.1.x][KOGITO-4110] - Single namespaced operator reacts on CRs created in d…

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -201,12 +201,13 @@ func getWatchNamespace() string {
 	// An empty value means the operator is running with cluster scope.
 	var watchNamespaceEnvVar = "WATCH_NAMESPACE"
 
-	ns, found := os.LookupEnv(watchNamespaceEnvVar)
-	if !found {
-		log.Info("unable to get WatchNamespace, "+
-			"the manager will watch and manage resources in all namespaces",
+	ns, _ := os.LookupEnv(watchNamespaceEnvVar)
+
+	// Check if operator is running as cluster scoped
+	if len(ns) == 0 {
+		log.Info(
+			"The operator is running as cluster scoped. It will watch and manage resources in all namespaces",
 			"Env Var lookup", watchNamespaceEnvVar)
-		return ""
 	}
 	return ns
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -23,7 +23,9 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              value: ""
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['olm.targetNamespaces']
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -2190,7 +2190,9 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              value: ""
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['olm.targetNamespaces']
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
…ifferent namespaces

See: https://issues.redhat.com/browse/KOGITO-4110

cherry-pick: https://github.com/kiegroup/kogito-cloud-operator/pull/712

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change