### PR TITLE
[1.1.x][KOGITO-4004][KOGITO-4068][cherry-pick] BDD tests stages in lockable resource

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,6 +107,7 @@ String getBDDParameters(String image_cache_mode, boolean runtime_app_registry_in
     testParamsMap["load_default_config"] = true
     testParamsMap["ci"] = "jenkins"
     testParamsMap["load_factor"] = 3
+    testParamsMap['disable_maven_native_build_container'] = true
 
     testParamsMap["operator_image"] = "${OPENSHIFT_REGISTRY}/openshift/kogito-cloud-operator"
     testParamsMap["operator_tag"] = "pr-\$(echo \${GIT_COMMIT} | cut -c1-7)"

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -15,7 +15,6 @@ pipeline {
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
         timeout(time: 360, unit: 'MINUTES')
-        disableConcurrentBuilds()
     }
 
     parameters {
@@ -167,67 +166,74 @@ pipeline {
             }
         }
 
-        stage('Build examples images for testing'){
-            when {
-                expression {
-                    return shouldLaunchTests()
-                }
+        stage('Run BDD tests') {
+            options {
+                lock('BDD tests')
             }
-            steps {
-                script {
-                    // Need to login to Openshift Registry for application images to be pushed
-                    loginOpenshiftRegistry()
-                    // Needed for the native builds (see comment below)
-                    loginDockerToOpenshiftRegistry()
+            stages {
+                stage('Build examples images for testing'){
+                    when {
+                        expression {
+                            return shouldLaunchTests()
+                        }
+                    }
+                    steps {
+                        script {
+                            // Need to login to Openshift Registry for application images to be pushed
+                            loginOpenshiftRegistry()
+                            // Needed for the native builds (see comment below)
+                            loginDockerToOpenshiftRegistry()
 
-                    try {
-                        // Use docker because of https://issues.redhat.com/browse/KOGITO-3512
-                        // setting operator_namespaced=true so the operator won't be deployed for building of example images
-                        sh "make build-examples-images tags='~@native' concurrent=3 operator_namespaced=true ${getBDDParameters('never', false, 'docker')}"
-                    } catch(err) {
-                        unstable("Error building non-native examples' images. Check the junit results.")
+                            try {
+                                // Use docker because of https://issues.redhat.com/browse/KOGITO-3512
+                                // setting operator_namespaced=true so the operator won't be deployed for building of example images
+                                sh "make build-examples-images tags='~@native' concurrent=3 operator_namespaced=true ${getBDDParameters('never', false, 'docker')}"
+                            } catch(err) {
+                                unstable("Error building non-native examples' images. Check the junit results.")
+                            }
+                            
+                            try {
+                                // Optaplanner taking a lot of resources, we should not build in parallel
+                                // There seems to be a problem with podman executed from the BDD tests ... Using docker instead for now ...
+                                // setting operator_namespaced=true so the operator won't be deployed for building of example images
+                                sh "make build-examples-images tags='@native' concurrent=1 operator_namespaced=true ${getBDDParameters('never', false, 'docker')}"
+                            } catch(err) {
+                                unstable("Error building native examples' images. Check the junit results.")
+                            }
+                        }
                     }
-                    
-                    try {
-                        // Optaplanner taking a lot of resources, we should not build in parallel
-                        // There seems to be a problem with podman executed from the BDD tests ... Using docker instead for now ...
-                        // setting operator_namespaced=true so the operator won't be deployed for building of example images
-                        sh "make build-examples-images tags='@native' concurrent=1 operator_namespaced=true ${getBDDParameters('never', false, 'docker')}"
-                    } catch(err) {
-                        unstable("Error building native examples' images. Check the junit results.")
+                    post {
+                        always {
+                            archiveArtifacts artifacts: 'test/logs/*/error */*.log', allowEmptyArchive: true
+                            junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: true
+                        }
                     }
                 }
-            }
-            post {
-                always {
-                    archiveArtifacts artifacts: 'test/logs/*/error */*.log', allowEmptyArchive: true
-                    junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: true
-                }
-            }
-        }
 
-        stage('Run Full Testing') {
-            when {
-                expression { return shouldLaunchTests() }
-            }
-            steps {
-                script {
-                    // Catch and set unstable so the temp image is still pushed and we get the deployment properties, 
-                    // in case we decide to continue in the release
-                    try {
-                        // Use docker because of https://issues.redhat.com/browse/KOGITO-3512
-                        sh "make run-tests timeout=360 load_factor=1 concurrent=3 smoke=${params.SMOKE_TESTS_ONLY} ${getBDDParameters('always', true, 'docker')}"
-                    } catch(err) {
-                        unstable("Tests are failing")
+                stage('Run Full Testing') {
+                    when {
+                        expression { return shouldLaunchTests() }
                     }
-                }
-            }
-            post {
-                always {
-                    archiveArtifacts artifacts: 'test/logs/*/error */*.log', allowEmptyArchive: true
-                    archiveArtifacts artifacts: 'test/logs/*/openshift-operators/*.log', allowEmptyArchive: true
-                    junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: true
-                    sh 'cd test && go run scripts/prune_namespaces.go'
+                    steps {
+                        script {
+                            // Catch and set unstable so the temp image is still pushed and we get the deployment properties, 
+                            // in case we decide to continue in the release
+                            try {
+                                // Use docker because of https://issues.redhat.com/browse/KOGITO-3512
+                                sh "make run-tests timeout=360 load_factor=1 concurrent=3 smoke=${params.SMOKE_TESTS_ONLY} ${getBDDParameters('always', true, 'docker')}"
+                            } catch(err) {
+                                unstable("Tests are failing")
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: 'test/logs/*/error */*.log', allowEmptyArchive: true
+                            archiveArtifacts artifacts: 'test/logs/*/openshift-operators/*.log', allowEmptyArchive: true
+                            junit testResults: 'test/logs/**/junit.xml', allowEmptyResults: true
+                            sh 'cd test && go run scripts/prune_namespaces.go'
+                        }
+                    }
                 }
             }
         }

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -20,6 +20,6 @@ fi
 rm -f golint_errors
 # The command in or will fetch the latest tag available for golangci-lint and install in $GOPATH/bin/
 which golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
-golangci-lint run ./... --enable golint --timeout 2m0s
+golangci-lint run ./... --enable golint --timeout 10m0s
 
 exit ${code:0}


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4004
https://issues.redhat.com/browse/KOGITO-4068

cherry-picks:
- https://github.com/kiegroup/kogito-cloud-operator/pull/706
- https://github.com/kiegroup/kogito-cloud-operator/pull/711

lock did not apply when launching master and 1.1.x in parallel ...

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [ ] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change