### PR TITLE
[KOGITO-4133] - API rule violation when running openapi-gen

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 
 ## Bug Fixes
 - [KOGITO-4110](https://issues.redhat.com/browse/KOGITO-4110) Single namespaced operator reacts on CRs created in different namespaces
+- [KOGITO-4133](https://issues.redhat.com/browse/KOGITO-4133) API rule violation when running openapi-gen
 
 ## Known Issues
 The protobuf ConfigMap does not update in Spring Boot due to [this issue](https://issues.redhat.com/browse/KOGITO-3406).

--- a/api/v1beta1/kogitoinfra_types.go
+++ b/api/v1beta1/kogitoinfra_types.go
@@ -86,7 +86,7 @@ type KogitoInfraStatus struct {
 	// +listType=atomic
 	// List of volumes that should be added to the services bound to this infra instance
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
-	Volume []KogitoInfraVolume `json:"volumes,omitempty"`
+	Volumes []KogitoInfraVolume `json:"volumes,omitempty"`
 }
 
 // KogitoInfraConditionReason describes the reasons for reconciliation failure

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -475,8 +475,8 @@ func (in *KogitoInfraStatus) DeepCopyInto(out *KogitoInfraStatus) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
-	if in.Volume != nil {
-		in, out := &in.Volume, &out.Volume
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
 		*out = make([]KogitoInfraVolume, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/controllers/infinispan.go
+++ b/controllers/infinispan.go
@@ -208,7 +208,7 @@ func (i *infinispanInfraReconciler) updateInfinispanVolumesInStatus(infinispanIn
 			},
 		},
 	}
-	i.instance.Status.Volume = []v1beta1.KogitoInfraVolume{volume}
+	i.instance.Status.Volumes = []v1beta1.KogitoInfraVolume{volume}
 	return nil
 }
 
@@ -406,7 +406,7 @@ func (i *infinispanInfraReconciler) Reconcile() (requeue bool, resultErr error) 
 }
 
 func hasInfinispanMountedVolume(infra *v1beta1.KogitoInfra) bool {
-	for _, volume := range infra.Status.Volume {
+	for _, volume := range infra.Status.Volumes {
 		if volume.NamedVolume.Name == infinispanCertMountName {
 			return true
 		}

--- a/controllers/kogitoinfra_controller_test.go
+++ b/controllers/kogitoinfra_controller_test.go
@@ -176,5 +176,5 @@ func Test_Reconcile_Infinispan(t *testing.T) {
 	assert.Equal(t, "PLAIN", infinispanQuarkusAppProps["quarkus.infinispan-client.sasl-mechanism"])
 	assert.Empty(t, infinispanQuarkusAppProps["quarkus.infinispan-client.auth-realm"])
 	assert.NotEmpty(t, infinispanQuarkusAppProps["quarkus.infinispan-client.trust-store"])
-	assert.Len(t, kogitoInfra.Status.Volume, 1)
+	assert.Len(t, kogitoInfra.Status.Volumes, 1)
 }

--- a/pkg/infrastructure/services/deployer_resources.go
+++ b/pkg/infrastructure/services/deployer_resources.go
@@ -259,7 +259,7 @@ func (s *serviceDeployer) fetchKogitoInfraProperties() (map[string]string, []cor
 		// fetch env properties from Kogito infra instance
 		envProp := kogitoInfraInstance.Status.RuntimeProperties[runtime].Env
 		consolidateEnvProperties = append(consolidateEnvProperties, envProp...)
-		volumes = append(volumes, kogitoInfraInstance.Status.Volume...)
+		volumes = append(volumes, kogitoInfraInstance.Status.Volumes...)
 	}
 	return consolidateAppProperties, consolidateEnvProperties, volumes, nil
 }

--- a/pkg/infrastructure/services/deployer_resources_test.go
+++ b/pkg/infrastructure/services/deployer_resources_test.go
@@ -149,8 +149,8 @@ func Test_serviceDeployer_createRequiredResources_CreateNewAppPropConfigMap(t *t
 	// we should have TLS volumes created
 	assert.Len(t, deployment.Spec.Template.Spec.Volumes, 2)                    // 1 for properties, 2 for tls
 	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, 2) // 1 for properties, 2 for tls
-	assert.Contains(t, deployment.Spec.Template.Spec.Volumes, kogitoInfinispan.Status.Volume[0].NamedVolume.ToKubeVolume())
-	assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, kogitoInfinispan.Status.Volume[0].Mount)
+	assert.Contains(t, deployment.Spec.Template.Spec.Volumes, kogitoInfinispan.Status.Volumes[0].NamedVolume.ToKubeVolume())
+	assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, kogitoInfinispan.Status.Volumes[0].Mount)
 }
 
 func Test_serviceDeployer_createRequiredResources_CreateWithAppPropConfigMap(t *testing.T) {

--- a/pkg/test/kogitoinfra.go
+++ b/pkg/test/kogitoinfra.go
@@ -78,7 +78,7 @@ func CreateFakeKogitoInfinispan(namespace string) *v1beta1.KogitoInfra {
 					},
 				},
 			},
-			Volume: []v1beta1.KogitoInfraVolume{
+			Volumes: []v1beta1.KogitoInfraVolume{
 				{
 					Mount: corev1.VolumeMount{
 						Name:      "tls-configuration",


### PR DESCRIPTION
The internal and the exposed name should be same, changing the internal name to `Volumes` since it is a list so makes more sense to me 

See: https://issues.redhat.com/browse/KOGITO-4133

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change