### PR TITLE
[KOGITO-4159] Fix to get the OPENSHIFT_API credentials in lock

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -172,7 +172,8 @@ pipeline {
                 }
             }
             options {
-                lock("BDD tests ${OPENSHIFT_API}")
+                // Special method to get the Openshift API in the lock because env is not accessible yet
+                lock("BDD tests ${withCredentials([string(credentialsId: 'OPENSHIFT_API', variable: 'OPENSHIFT_API')]) { return env.OPENSHIFT_API }}")
             }
             stages {
                 stage('Build examples images for testing'){


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4159

Fix https://github.com/kiegroup/kogito-cloud-operator/pull/717

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change