### PR TITLE
[KOGITO-4210] Fix probe config for Quarkus deployments

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,10 @@
 ## Enhancements  
 - [KOGITO-4245](https://issues.redhat.com/browse/KOGITO-4245) - Use Infinispan CR spec data instead of status to fetch credentials Secret 
 - [KOGITO-2317](https://issues.redhat.com/browse/KOGITO-2317) - Unify Kogito Quarkus and Spring Images
+- [KOGITO-4173](https://issues.redhat.com/browse/KOGITO-4173) - Adjust default probe URL for Quarkus
+
 ## Bug Fixes
 - [KOGITO-4332](https://issues.redhat.com/browse/KOGITO-4332) - Operator does not have rights on mongodb crds
+- [KOGITO-4210](https://issues.redhat.com/browse/KOGITO-4210) - Fix probe config for Quarkus deployments
 
 ## Known Issues
-

--- a/controllers/kogitoruntime_controller.go
+++ b/controllers/kogitoruntime_controller.go
@@ -77,6 +77,10 @@ func (r *KogitoRuntimeReconciler) Reconcile(req ctrl.Request) (result ctrl.Resul
 		return
 	}
 
+	healthCheckProbeType := services.TCPHealthCheckProbe
+	if instance.GetSpec().GetRuntime() == v1beta1.QuarkusRuntimeType {
+		healthCheckProbeType = services.QuarkusHealthCheckProbe
+	}
 	definition := services.ServiceDefinition{
 		Request:            req,
 		DefaultImageTag:    infrastructure.LatestTag,
@@ -85,6 +89,7 @@ func (r *KogitoRuntimeReconciler) Reconcile(req ctrl.Request) (result ctrl.Resul
 		OnObjectsCreate:    r.onObjectsCreate,
 		OnGetComparators:   onGetComparators,
 		CustomService:      true,
+		HealthCheckProbe:   healthCheckProbeType,
 	}
 	requeueAfter, err := services.NewServiceDeployer(definition, instance, r.Client, r.Scheme).Deploy()
 	if err != nil {

--- a/pkg/infrastructure/services/probe.go
+++ b/pkg/infrastructure/services/probe.go
@@ -31,8 +31,8 @@ const (
 	// TCPHealthCheckProbe default health check probe that binds to port 8080
 	TCPHealthCheckProbe HealthCheckProbeType = "TCP"
 
-	quarkusProbeLivenessPath  = "/health/live"
-	quarkusProbeReadinessPath = "/health/ready"
+	quarkusProbeLivenessPath  = "/q/health/live"
+	quarkusProbeReadinessPath = "/q/health/ready"
 )
 
 type healthCheckProbe struct {


### PR DESCRIPTION
## Changes
- [[KOGITO-4210](https://issues.redhat.com/browse/KOGITO-4210)] Fix probe config for Quarkus deployments
  - now checks HTTP path instead of TCP for Quarkus applications
- [[KOGITO-4173](https://issues.redhat.com/browse/KOGITO-4173)] Fix default probe URL for Quarkus
  - from `/health` to `/q/health` 
    - `/metrics` not changed as Prometheus endpoint unaffected by Quarkus update
  - custom [probe](https://github.com/kiegroup/kogito-cloud-operator/blob/0c813a597d58bafd705ee685aafd32e637d57227/kogito-operator.yaml#L1106-L1108)/[metrics](https://github.com/kiegroup/kogito-cloud-operator/blob/0c813a597d58bafd705ee685aafd32e637d57227/kogito-operator.yaml#L1045-L1047) already implemented

## Testing
### HTTP Check with Custom Probe URL
I deployed this runtime YAML with an image of `process-quarkus-example` I built with the Quarkus `smallrye-health` extension:
```yaml
apiVersion: app.kiegroup.org/v1beta1
kind: KogitoRuntime
metadata:
  name: qe
spec:
  replicas: 1
  image: quay.io/kmok/process-quarkus-example:health-no-redirect
  probes:
    livenessProbe:
      httpGet:
        path: /test/live
        port: 8080
    readinessProbe:
      httpGet:
        path: /test/ready
        port: 8080
```

The pod fails to start when it finds 404 errors on the given HTTP paths:
```
Warning  Unhealthy       10s   kubelet, crc-j55b9-master-0  Liveness probe failed: Get http://10.116.0.49:8080/test/live: dial tcp 10.116.0.49:8080: connect: connection refused
Warning  Unhealthy       10s   kubelet, crc-j55b9-master-0  Readiness probe failed: Get http://10.116.0.49:8080/test/ready: dial tcp 10.116.0.49:8080: connect: connection refused
Warning  Unhealthy       0s    kubelet, crc-j55b9-master-0  Liveness probe failed: HTTP probe failed with statuscode: 404
Warning  Unhealthy       0s    kubelet, crc-j55b9-master-0  Readiness probe failed: HTTP probe failed with statuscode: 404
```

### Default Probe URL
I deployed the same YAML from above without the custom probe paths and using the new default path of `/q/health`. The image was also built so that [redirect from `/health` to `/q/health`](https://github.com/kenfinnigan/quarkus/blob/663570cd008a0fa892b06a2ffc3d08cec3a261a1/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpBuildTimeConfig.java#L48-L54) is turned off. The pod passes the liveness/readiness check and runs.
```
[I] kmok@localhost ~/g/s/g/k/kogito-cloud-operator (KOGITO-4173-examples)> curl -LiX GET http://qe-3376.apps-crc.testing/health
HTTP/1.1 404 Not Found
content-type: text/html;charset=UTF-8
content-length: 93
set-cookie: 9788cf53c80a130ecd7a457df43007b1=16bc50fd1e6222cf3e8596e0be521daf; path=/; HttpOnly
cache-control: private

RESTEASY003210: Could not find resource for full path: http://qe-3376.apps-crc.testing/health⏎

[I] kmok@localhost ~/g/s/g/k/kogito-cloud-operator (KOGITO-4173-examples)> curl -LiX GET http://qe-3376.apps-crc.testing/q/health
HTTP/1.1 200 OK
content-type: application/json; charset=UTF-8
content-length: 46
set-cookie: 9788cf53c80a130ecd7a457df43007b1=16bc50fd1e6222cf3e8596e0be521daf; path=/; HttpOnly
cache-control: private


{
    "status": "UP",
    "checks": [
    ]
}⏎ 
```

## Related PR's
- [kie-docs](https://github.com/kiegroup/kie-docs/pull/3227): [KOGITO-4210] Quarkus apps must have health extension
- [kogito-examples](https://github.com/kiegroup/kogito-examples/pull/538): [KOGITO-4210] Add health extension to Quarkus examples

## Requirements
Many thanks for submiting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: 
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
