### PR TITLE
[KOGITO-4332] Fixing role.yaml generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,3 +332,6 @@ deploy-operator-on-ocp:
 
 olm-tests:
 	./hack/ci/run-olm-tests.sh
+
+# Run this before any PR to make sure everything is updated, so CI won't fail
+before-pr: generate manifests bundle generate-installer test

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 - [KOGITO-4245](https://issues.redhat.com/browse/KOGITO-4245) - Use Infinispan CR spec data instead of status to fetch credentials Secret 
 
 ## Bug Fixes
+- [KOGITO-4332](https://issues.redhat.com/browse/KOGITO-4332) - Operator does not have rights on mongodb crds
 
 ## Known Issues
 

--- a/bundle/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kogito-operator.clusterserviceversion.yaml
@@ -114,80 +114,96 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - ""
           - app.kiegroup.org
-          - apps.openshift.io
-          - image.openshift.io
-          - build.openshift.io
-          - rbac.authorization.k8s.io
-          - route.openshift.io
           resources:
-          - '*'
+          - kogitobuilds
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
-          - ""
+          - app.kiegroup.org
           resources:
-          - namespaces
+          - kogitobuilds/status
           verbs:
           - get
+          - patch
+          - update
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
+          - kogitoinfras
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
+          - kogitoinfras/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
+          - kogitoruntimes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
+          - kogitoruntimes/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
+          - kogitosupportingservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
+          - kogitosupportingservices/status
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - apps
           resources:
-          - statefulsets
           - deployments
           - replicasets
           verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
           - create
-          - list
           - delete
-        - apiGroups:
-          - infinispan.org
-          resources:
-          - infinispans
-          verbs:
           - get
-          - create
           - list
-          - delete
-          - watch
-        - apiGroups:
-          - kafka.strimzi.io
-          resources:
-          - kafkas
-          - kafkatopics
-          verbs:
-          - get
-          - create
-          - list
-          - delete
-          - watch
-        - apiGroups:
-          - keycloak.org
-          resources:
-          - keycloaks
-          verbs:
-          - get
-          - create
-          - list
-          - delete
-          - watch
-        - apiGroups:
-          - mongodb.com
-          resources:
-          - mongodbs
-          verbs:
-          - get
-          - create
-          - list
-          - delete
+          - update
           - watch
         - apiGroups:
           - apps
@@ -198,11 +214,39 @@ spec:
           verbs:
           - update
         - apiGroups:
-          - app.kiegroup.org
+          - apps.openshift.io
           resources:
           - '*'
           verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
           - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - eventing.knative.dev
           resources:
@@ -216,34 +260,117 @@ spec:
           resources:
           - triggers
           verbs:
-          - get
-          - list
-          - watch
           - create
           - delete
+          - get
+          - list
           - update
+          - watch
         - apiGroups:
-          - sources.knative.dev
+          - image.openshift.io
           resources:
-          - sinkbindings
+          - '*'
           verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - infinispan.org
+          resources:
+          - infinispans
+          verbs:
+          - create
+          - delete
           - get
           - list
           - watch
-          - create
-          - delete
-          - update
         - apiGroups:
           - integreatly.org
           resources:
           - grafanadashboards
           verbs:
-          - get
           - create
-          - list
           - delete
-          - watch
+          - get
+          - list
           - update
+          - watch
+        - apiGroups:
+          - kafka.strimzi.io
+          resources:
+          - kafkas
+          - kafkatopics
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - keycloak.org
+          resources:
+          - keycloaks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - mongodb.com
+          resources:
+          - mongodb
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - sources.knative.dev
+          resources:
+          - sinkbindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - authentication.k8s.io
           resources:

--- a/bundle/manifests/kogito-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kogito-operator.clusterserviceversion.yaml
@@ -128,6 +128,14 @@ spec:
         - apiGroups:
           - app.kiegroup.org
           resources:
+          - kogitobuilds/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
           - kogitobuilds/status
           verbs:
           - get
@@ -145,6 +153,14 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
+          - kogitoinfras/finalizers
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - app.kiegroup.org
           resources:
@@ -168,6 +184,14 @@ spec:
         - apiGroups:
           - app.kiegroup.org
           resources:
+          - kogitoruntimes/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
           - kogitoruntimes/status
           verbs:
           - get
@@ -185,6 +209,14 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - app.kiegroup.org
+          resources:
+          - kogitosupportingservices/finalizers
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - app.kiegroup.org
           resources:
@@ -207,8 +239,6 @@ spec:
           - watch
         - apiGroups:
           - apps
-          resourceNames:
-          - kogito-operator
           resources:
           - deployments/finalizers
           verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,14 @@ rules:
 - apiGroups:
   - app.kiegroup.org
   resources:
+  - kogitobuilds/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
   - kogitobuilds/status
   verbs:
   - get
@@ -38,6 +46,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoinfras/finalizers
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - app.kiegroup.org
   resources:
@@ -61,6 +77,14 @@ rules:
 - apiGroups:
   - app.kiegroup.org
   resources:
+  - kogitoruntimes/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
   - kogitoruntimes/status
   verbs:
   - get
@@ -78,6 +102,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitosupportingservices/finalizers
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - app.kiegroup.org
   resources:
@@ -100,8 +132,6 @@ rules:
   - watch
 - apiGroups:
   - apps
-  resourceNames:
-  - kogito-operator
   resources:
   - deployments/finalizers
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,136 +1,266 @@
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: manager-role
 rules:
-  - apiGroups:
-      - ""
-      - app.kiegroup.org
-      - apps.openshift.io
-      - image.openshift.io
-      - build.openshift.io
-      - rbac.authorization.k8s.io
-      - route.openshift.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - statefulsets
-      - deployments
-      - replicasets
-    verbs:
-      - '*'
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - create
-      - list
-      - delete
-  - apiGroups:
-      - infinispan.org
-    resources:
-      - infinispans
-    verbs:
-      - get
-      - create
-      - list
-      - delete
-      - watch
-  - apiGroups:
-      - kafka.strimzi.io
-    resources:
-      - kafkas
-      - kafkatopics
-    verbs:
-      - get
-      - create
-      - list
-      - delete
-      - watch
-  - apiGroups:
-      - keycloak.org
-    resources:
-      - keycloaks
-    verbs:
-      - get
-      - create
-      - list
-      - delete
-      - watch
-  - apiGroups:
-    - mongodb.com
-    resources:
-      - mongodbs
-    verbs:
-      - get
-      - create
-      - list
-      - delete
-      - watch
-  - apiGroups:
-      - apps
-    resourceNames:
-      - kogito-operator
-    resources:
-      - deployments/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - app.kiegroup.org
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - eventing.knative.dev
-    resources:
-      - brokers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - eventing.knative.dev
-    resources:
-      - triggers
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - update
-  - apiGroups:
-      - sources.knative.dev
-    resources:
-      - sinkbindings
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - delete
-      - update
-  - apiGroups:
-      - integreatly.org
-    resources:
-      - grafanadashboards
-    verbs:
-      - get
-      - create
-      - list
-      - delete
-      - watch
-      - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitobuilds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitobuilds/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoinfras
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoinfras/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoruntimes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoruntimes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitosupportingservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitosupportingservices/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resourceNames:
+  - kogito-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - build.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - brokers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - triggers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - infinispan.org
+  resources:
+  - infinispans
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - integreatly.org
+  resources:
+  - grafanadashboards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkas
+  - kafkatopics
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - keycloak.org
+  resources:
+  - keycloaks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - mongodb.com
+  resources:
+  - mongodb
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - sources.knative.dev
+  resources:
+  - sinkbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch

--- a/controllers/kogitobuild_controller.go
+++ b/controllers/kogitobuild_controller.go
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*
-
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package controllers
 
 import (
@@ -60,22 +44,15 @@ type KogitoBuildReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the cluster for a KogitoBuild object and makes changes based on the state read
-// and what is in the KogitoBuild.Spec
-// Note:
-// The Controller will requeue the Request to be processed again if the returned error is non-nil or
-// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitobuilds,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitobuilds/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;list;delete
-// +kubebuilder:rbac:groups=infinispan.org,resources=infinispans,verbs=get;create;list;delete;watch
-// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkas;kafkatopics,verbs=get;create;list;delete;watch
-// +kubebuilder:rbac:groups=keycloak.org,resources=keycloaks,verbs=get;create;list;delete;watch
+// +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=apps,resourceNames=kogito-operator,resources=deployments/finalizers,verbs=update
-// +kubebuilder:rbac:groups=eventing.knative.dev,resources=brokers,verbs=get;list;watch
-// +kubebuilder:rbac:groups=eventing.knative.dev,resources=triggers,verbs=get;list;watch;create;delete;update
-// +kubebuilder:rbac:groups=sources.knative.dev,resources=sinkbindings,verbs=get;list;watch;create;delete;update
-// +kubebuilder:rbac:groups=integreatly.org,resources=grafanadashboards,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=build.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=image.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
+
+// Reconcile reads that state of the cluster for a KogitoBuild object and makes changes based on the state read
+// and what is in the KogitoBuild.Spec
 func (r *KogitoBuildReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, resultErr error) {
 	r.Log.Info("Reconciling for", "KogitoBuild", req.Name, "Namespace", req.Namespace)
 

--- a/controllers/kogitobuild_controller.go
+++ b/controllers/kogitobuild_controller.go
@@ -46,8 +46,9 @@ type KogitoBuildReconciler struct {
 
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitobuilds,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitobuilds/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitobuilds/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;create;list;watch;create;delete;update
-// +kubebuilder:rbac:groups=apps,resourceNames=kogito-operator,resources=deployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=build.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=image.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
 

--- a/controllers/kogitoinfra_controller.go
+++ b/controllers/kogitoinfra_controller.go
@@ -36,14 +36,9 @@ type KogitoInfraReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the cluster for a KogitoInfra object and makes changes based on the state read
-// and what is in the KogitoInfra.Spec
-// Note:
-// The Controller will requeue the Request to be processed again if the returned error is non-nil or
-// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoinfras,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoinfras/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;list;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=infinispan.org,resources=infinispans,verbs=get;create;list;delete;watch
 // +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkas;kafkatopics,verbs=get;create;list;delete;watch
 // +kubebuilder:rbac:groups=keycloak.org,resources=keycloaks,verbs=get;create;list;delete;watch
@@ -52,6 +47,10 @@ type KogitoInfraReconciler struct {
 // +kubebuilder:rbac:groups=eventing.knative.dev,resources=triggers,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=sources.knative.dev,resources=sinkbindings,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanadashboards,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=mongodb.com,resources=mongodb,verbs=get;create;list;watch;delete
+
+// Reconcile reads that state of the cluster for a KogitoInfra object and makes changes based on the state read
+// and what is in the KogitoInfra.Spec
 func (r *KogitoInfraReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Info("Reconciling for", "KogitoInfra", req.Name, "Namespace", req.Namespace)
 

--- a/controllers/kogitoinfra_controller.go
+++ b/controllers/kogitoinfra_controller.go
@@ -38,11 +38,12 @@ type KogitoInfraReconciler struct {
 
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoinfras,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoinfras/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoinfras/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=infinispan.org,resources=infinispans,verbs=get;create;list;delete;watch
 // +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkas;kafkatopics,verbs=get;create;list;delete;watch
 // +kubebuilder:rbac:groups=keycloak.org,resources=keycloaks,verbs=get;create;list;delete;watch
-// +kubebuilder:rbac:groups=apps,resourceNames=kogito-operator,resources=deployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=eventing.knative.dev,resources=brokers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=eventing.knative.dev,resources=triggers,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=sources.knative.dev,resources=sinkbindings,verbs=get;list;watch;create;delete;update

--- a/controllers/kogitoruntime_controller.go
+++ b/controllers/kogitoruntime_controller.go
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*
-
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package controllers
 
 import (
@@ -57,20 +41,20 @@ type KogitoRuntimeReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the cluster for a KogitoRuntime object and makes changes based on the state read
-// and what is in the KogitoRuntime.Spec
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoruntimes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoruntimes/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=apps,resources=statefulsets;deployments;replicasets,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;list;delete
-// +kubebuilder:rbac:groups=infinispan.org,resources=infinispans,verbs=get;create;list;delete;watch
-// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkas;kafkatopics,verbs=get;create;list;delete;watch
-// +kubebuilder:rbac:groups=keycloak.org,resources=keycloaks,verbs=get;create;list;delete;watch
 // +kubebuilder:rbac:groups=apps,resourceNames=kogito-operator,resources=deployments/finalizers,verbs=update
-// +kubebuilder:rbac:groups=eventing.knative.dev,resources=brokers,verbs=get;list;watch
-// +kubebuilder:rbac:groups=eventing.knative.dev,resources=triggers,verbs=get;list;watch;create;delete;update
-// +kubebuilder:rbac:groups=sources.knative.dev,resources=sinkbindings,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanadashboards,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=image.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=*,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=route.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=apps.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=core,resources=*,verbs=create;delete;get;list;patch;update;watch
+
+// Reconcile reads that state of the cluster for a KogitoRuntime object and makes changes based on the state read
+// and what is in the KogitoRuntime.Spec
 func (r *KogitoRuntimeReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, err error) {
 	r.Log.Info("Reconciling for", "KogitoRuntime", req.Name, "Namespace", req.Namespace)
 

--- a/controllers/kogitoruntime_controller.go
+++ b/controllers/kogitoruntime_controller.go
@@ -43,9 +43,10 @@ type KogitoRuntimeReconciler struct {
 
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoruntimes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoruntimes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitoruntimes/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;list;delete
-// +kubebuilder:rbac:groups=apps,resourceNames=kogito-operator,resources=deployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanadashboards,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=image.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=*,verbs=get;create;list;watch;create;delete;update

--- a/controllers/kogitosupportingservice_controller.go
+++ b/controllers/kogitosupportingservice_controller.go
@@ -50,9 +50,10 @@ type KogitoSupportingServiceReconciler struct {
 
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitosupportingservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitosupportingservices/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitosupportingservices/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;list;delete
-// +kubebuilder:rbac:groups=apps,resourceNames=kogito-operator,resources=deployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanadashboards,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=image.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=*,verbs=get;create;list;watch;create;delete;update

--- a/controllers/kogitosupportingservice_controller.go
+++ b/controllers/kogitosupportingservice_controller.go
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*
-
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package controllers
 
 import (
@@ -64,23 +48,20 @@ type KogitoSupportingServiceReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the cluster for a KogitoSupportingService object and makes changes based on the state read
-// and what is in the KogitoSupportingService.Spec
-// Note:
-// The Controller will requeue the Request to be processed again if the returned error is non-nil or
-// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitosupportingservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=app.kiegroup.org,resources=kogitosupportingservices/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=apps,resources=statefulsets;deployments;replicasets,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;create;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;list;delete
-// +kubebuilder:rbac:groups=infinispan.org,resources=infinispans,verbs=get;create;list;delete;watch
-// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkas;kafkatopics,verbs=get;create;list;delete;watch
-// +kubebuilder:rbac:groups=keycloak.org,resources=keycloaks,verbs=get;create;list;delete;watch
 // +kubebuilder:rbac:groups=apps,resourceNames=kogito-operator,resources=deployments/finalizers,verbs=update
-// +kubebuilder:rbac:groups=eventing.knative.dev,resources=brokers,verbs=get;list;watch
-// +kubebuilder:rbac:groups=eventing.knative.dev,resources=triggers,verbs=get;list;watch;create;delete;update
-// +kubebuilder:rbac:groups=sources.knative.dev,resources=sinkbindings,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=integreatly.org,resources=grafanadashboards,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=image.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=*,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=route.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=apps.openshift.io,resources=*,verbs=get;create;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=core,resources=*,verbs=create;delete;get;list;patch;update;watch
+
+// Reconcile reads that state of the cluster for a KogitoSupportingService object and makes changes based on the state read
+// and what is in the KogitoSupportingService.Spec
 func (r *KogitoSupportingServiceReconciler) Reconcile(req ctrl.Request) (result ctrl.Result, resultErr error) {
 	// Fetch the KogitoSupportingService instance
 	r.Log.Info("Reconciling KogitoSupportingService for", "Instance", req.Name, "Namespace", req.Namespace)

--- a/controllers/mongodb.go
+++ b/controllers/mongodb.go
@@ -210,10 +210,10 @@ func (i *mongoDBInfraReconciler) createCustomKogitoMongoDBSecret(namespace strin
 		return nil, err
 	}
 	if err := kubernetes.ResourceC(i.client).Create(secret); err != nil {
-		i.log.Error(err, "Error occurs while creating %s", "secret", secret)
+		i.log.Error(err, "Error occurs while creating", "secret", secret)
 		return nil, err
 	}
-	i.log.Debug("%s successfully created", secret)
+	i.log.Debug("Successfully created", "Secret", secret)
 	return secret, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -23,14 +23,16 @@ require (
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200321030439-57b580e57e88
 	github.com/operator-framework/operator-marketplace v0.0.0-20190919183128-4ef67b2f50e9
+	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
 	golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.18.8
 	k8s.io/apiextensions-apiserver v0.18.6
 	k8s.io/apimachinery v0.18.8

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,10 @@ github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc/go.m
 github.com/coreos/prometheus-operator v0.40.0 h1:UNjQaRud+XpFj8C7bLxA0eDm2oVwE1MP9ITUPLJkySU=
 github.com/coreos/prometheus-operator v0.40.0/go.mod h1:QOoL5cVI3b1OHgpw8s+pH+Ok4AFRp2HOUvBpqs7UWcg=
 github.com/coreos/rkt v1.30.0/go.mod h1:O634mlH6U7qk87poQifK6M2rsFNt+FyUTWNMnP1hF1U=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -1178,6 +1180,7 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
@@ -1190,11 +1193,13 @@ github.com/mattn/go-isatty v0.0.6/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.8 h1:3tS41NlGYSmhhe/8fhGRzc+z3AYCw1Fe1WAyLuujKs0=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.5/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.9/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
@@ -1412,6 +1417,7 @@ github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f h1:O62NGAXV0cNzBI6e7vI3zTHSTgPHsWIcS3Q4XC1/pAU=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/phayes/freeport v0.0.0-20171002181615-b8543db493a5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
@@ -1538,7 +1544,9 @@ github.com/rubenv/sql-migrate v0.0.0-20191025130928-9355dd04f4b3/go.mod h1:WS0rl
 github.com/rubenv/sql-migrate v0.0.0-20200212082348-64f95ea68aa3/go.mod h1:rtQlpHw+eR6UrqaS3kX1VYeaCxzCVdimDS7g5Ln4pPc=
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
 github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.0.4/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
 github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUccKSJBU0UMXJFVM=
@@ -1575,6 +1583,7 @@ github.com/shurcooL/graphql v0.0.0-20180924043259-e4a3a37e6d42/go.mod h1:AuYgA5K
 github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20180825020608-02ddb050ef6b/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
@@ -1588,6 +1597,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
@@ -2067,6 +2078,8 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f h1:Fqb3ao1hUmOR3GkUOg/Y+BadLwykBIzs5q8Ez2SbHyc=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -2428,6 +2441,8 @@ gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20190709130402-674ba3eaed22/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20191026110619-0b21df46bc1d/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -2105,6 +2105,14 @@ rules:
 - apiGroups:
   - app.kiegroup.org
   resources:
+  - kogitobuilds/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
   - kogitobuilds/status
   verbs:
   - get
@@ -2122,6 +2130,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoinfras/finalizers
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - app.kiegroup.org
   resources:
@@ -2145,6 +2161,14 @@ rules:
 - apiGroups:
   - app.kiegroup.org
   resources:
+  - kogitoruntimes/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
   - kogitoruntimes/status
   verbs:
   - get
@@ -2162,6 +2186,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitosupportingservices/finalizers
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - app.kiegroup.org
   resources:
@@ -2184,8 +2216,6 @@ rules:
   - watch
 - apiGroups:
   - apps
-  resourceNames:
-  - kogito-operator
   resources:
   - deployments/finalizers
   verbs:

--- a/kogito-operator.yaml
+++ b/kogito-operator.yaml
@@ -2087,83 +2087,100 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: kogito-operator-manager-role
 rules:
 - apiGroups:
-  - ""
   - app.kiegroup.org
-  - apps.openshift.io
-  - image.openshift.io
-  - build.openshift.io
-  - rbac.authorization.k8s.io
-  - route.openshift.io
   resources:
-  - '*'
+  - kogitobuilds
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-  - ""
+  - app.kiegroup.org
   resources:
-  - namespaces
+  - kogitobuilds/status
   verbs:
   - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoinfras
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoinfras/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoruntimes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitoruntimes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitosupportingservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - app.kiegroup.org
+  resources:
+  - kogitosupportingservices/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - apps
   resources:
-  - statefulsets
   - deployments
   - replicasets
   verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
   - create
-  - list
   - delete
-- apiGroups:
-  - infinispan.org
-  resources:
-  - infinispans
-  verbs:
   - get
-  - create
   - list
-  - delete
-  - watch
-- apiGroups:
-  - kafka.strimzi.io
-  resources:
-  - kafkas
-  - kafkatopics
-  verbs:
-  - get
-  - create
-  - list
-  - delete
-  - watch
-- apiGroups:
-  - keycloak.org
-  resources:
-  - keycloaks
-  verbs:
-  - get
-  - create
-  - list
-  - delete
-  - watch
-- apiGroups:
-  - mongodb.com
-  resources:
-  - mongodbs
-  verbs:
-  - get
-  - create
-  - list
-  - delete
+  - update
   - watch
 - apiGroups:
   - apps
@@ -2174,11 +2191,39 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - app.kiegroup.org
+  - apps.openshift.io
   resources:
   - '*'
   verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - build.openshift.io
+  resources:
   - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - eventing.knative.dev
   resources:
@@ -2192,34 +2237,117 @@ rules:
   resources:
   - triggers
   verbs:
-  - get
-  - list
-  - watch
   - create
   - delete
+  - get
+  - list
   - update
+  - watch
 - apiGroups:
-  - sources.knative.dev
+  - image.openshift.io
   resources:
-  - sinkbindings
+  - '*'
   verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - infinispan.org
+  resources:
+  - infinispans
+  verbs:
+  - create
+  - delete
   - get
   - list
   - watch
-  - create
-  - delete
-  - update
 - apiGroups:
   - integreatly.org
   resources:
   - grafanadashboards
   verbs:
-  - get
   - create
-  - list
   - delete
-  - watch
+  - get
+  - list
   - update
+  - watch
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkas
+  - kafkatopics
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - keycloak.org
+  resources:
+  - keycloaks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - mongodb.com
+  resources:
+  - mongodb
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - sources.knative.dev
+  resources:
+  - sinkbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/pkg/client/client_builder_test.go
+++ b/pkg/client/client_builder_test.go
@@ -53,7 +53,7 @@ func Test_simpleBuild(t *testing.T) {
 
 func Test_useControllerClient(t *testing.T) {
 	config := &restclient.Config{}
-	controllerCli, err := newKubeClient(config)
+	controllerCli, err := newKubeClient(config, false)
 	if err != nil {
 		t.Fatal(fmt.Sprintf("Impossible to create new Kubernetes client: %v", err))
 	}

--- a/test/framework/kubernetes.go
+++ b/test/framework/kubernetes.go
@@ -48,7 +48,7 @@ func InitKubeClient() error {
 	mux.Lock()
 	defer mux.Unlock()
 	if kubeClient == nil {
-		newClient, err := client.NewClientBuilder().WithDiscoveryClient().WithBuildClient().WithKubernetesExtensionClient().Build()
+		newClient, err := client.NewClientBuilder().UseControllerDynamicMapper().WithDiscoveryClient().WithBuildClient().WithKubernetesExtensionClient().Build()
 		if err != nil {
 			return fmt.Errorf("Error initializing kube client: %v", err)
 		}


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://kie.zulipchat.com/#narrow/stream/232676-kogito/topic/operator.20and.20mongo
JIRA: https://issues.redhat.com/browse/KOGITO-4332

While investigating this issue, I've found that the `role.yaml` file was never updated. I fixed that, but the MongoDB permissions were already there. Please see my comment in the JIRA. 

[I also opened a follow-up JIRA](https://issues.redhat.com/browse/KOGITO-4332) to fix the `*` in the resources. We need more time to review that. That's why I haven't done it in this PR. @Kaitou786, do you mind taking this one?

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change