### PR TITLE
[KOGITO-2785] - Operator nightly pipeline: add olm tests

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -66,6 +66,10 @@ pipeline {
         OPENSHIFT_CREDS_KEY = 'OPENSHIFT_CREDS'
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
+
+        // Environment required by OLM tests when run from process
+        OP_TEST_CONTAINER_OPT = '-t'
+        OP_TEST_DEBUG = 1
     }
     
     stages {
@@ -153,6 +157,11 @@ pipeline {
                         archiveArtifacts artifacts: "build/_output/bin/kogito", allowEmptyArchive: false
                     }
                 }
+            }
+        }
+        stage('Run OLM tests') {
+            steps {
+                sh 'make olm-tests'
             }
         }
         stage('Push Operator Image to Openshift Registry') {

--- a/hack/ci/run-olm-tests.sh
+++ b/hack/ci/run-olm-tests.sh
@@ -13,14 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Requirements to run OLM tests:
+# 1. Have docker installed on your system
+# 2. Passwordless sudo is required by the OLM script to run tests
+# 3. Have ansible installed on your system
+# That's it all other tools will be downloaded and installed by the OLM script.
 
 set -e
 source ./hack/ci/operator-ensure-manifests.sh
 
 export OP_TEST_PRETEST_CUSTOM_SCRIPT=${PWD}/hack/ci/olm-pretest.sh
 
+# SCRIPT_URL URL to the script used by OLM to test the operator
+SCRIPT_URL="https://raw.githubusercontent.com/operator-framework/operator-test-playbooks/master/upstream/test/test.sh"
+
 echo "\n=======> Pretest script path set to ${OP_TEST_PRETEST_CUSTOM_SCRIPT}"
 
 cd "${tempfolder}"
 
-bash <(curl -sL https://cutt.ly/WhkV76k) all  community-operators/kogito-operator/"${version}"
+bash <(curl -sL "${SCRIPT_URL}") all  community-operators/kogito-operator/"${version}"


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-2785
Tested to run successfully on: https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/kaitou786/job/olm-test/9/console
Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change