### PR TITLE
KOGITO-4444 - Sanitize dashboard name

### DIFF
--- a/core/kogitoservice/dashboards_test.go
+++ b/core/kogitoservice/dashboards_test.go
@@ -15,13 +15,14 @@
 package kogitoservice
 
 import (
+	"testing"
+
 	grafanav1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/kiegroup/kogito-cloud-operator/core/operator"
 	"github.com/kiegroup/kogito-cloud-operator/core/test"
 	"github.com/kiegroup/kogito-cloud-operator/meta"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func Test_fetchDashboardNames(t *testing.T) {
@@ -89,11 +90,11 @@ func Test_serviceDeployer_DeployGrafanaDashboards(t *testing.T) {
 
 	dashboards := []GrafanaDashboard{
 		{
-			Name:             "mydashboard",
+			Name:             "my dash-board* .json",
 			RawJSONDashboard: "[]",
 		},
 		{
-			Name:             "myseconddashboard",
+			Name:             "mySecond%Dashboard@.json",
 			RawJSONDashboard: "[]",
 		},
 	}
@@ -108,7 +109,7 @@ func Test_serviceDeployer_DeployGrafanaDashboards(t *testing.T) {
 
 	dashboard := &grafanav1.GrafanaDashboard{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mydashboard",
+			Name:      "mydash-board",
 			Namespace: t.Name(),
 		},
 	}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-4444

The codegen generates valid dashboard filenames (for example `Traffic Violation.json`) based on the DMN model name, but these are not valid names for the grafana operator. This is why we need to sanitize the dashboard name before we create the `GrafanaDashboard`. 

We might change the filename on codegen side as well, but since it generates valid filenames, I think it's ok for the time being. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change