### PR TITLE
KOGITO-4517 - Update code base and documentation after proto files ge…

### DIFF
--- a/examples/quarkus-jvm.Dockerfile
+++ b/examples/quarkus-jvm.Dockerfile
@@ -11,4 +11,3 @@ FROM quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
 
 COPY target/*-runner.jar $KOGITO_HOME/bin
 COPY target/lib $KOGITO_HOME/bin/lib
-COPY target/classes/persistence/ $KOGITO_HOME/data/protobufs

--- a/examples/springboot.Dockerfile
+++ b/examples/springboot.Dockerfile
@@ -11,4 +11,3 @@ FROM quay.io/kiegroup/kogito-springboot-ubi8:latest
 
 # the *.jar was left to make this file project agnostic, but ideally you would need only the application binary, such as process-springboot-example.jar
 COPY target/*.jar $KOGITO_HOME/bin
-COPY target/classes/persistence/ $KOGITO_HOME/data/protobufs

--- a/test/framework/dockerfile_provider.go
+++ b/test/framework/dockerfile_provider.go
@@ -17,7 +17,6 @@ package framework
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -89,12 +88,6 @@ func (dockerfileProvider *kogitoApplicationDockerfileProviderStruct) GetDockerfi
 		dockerfileContent += "COPY target/lib $KOGITO_HOME/bin/lib\n"
 	}
 
-	// Copy protobuf files
-	persistenceDirectory := dockerfileProvider.projectLocation + "/target/classes/persistence/"
-	if fileOrDirectoryExists(persistenceDirectory) {
-		dockerfileContent += "COPY target/classes/persistence/ $KOGITO_HOME/data/protobufs"
-	}
-
 	return dockerfileContent, nil
 }
 
@@ -110,11 +103,4 @@ func fileWithSuffixExists(scannedDirectory, fileSuffix string) bool {
 		}
 	}
 	return false
-}
-
-func fileOrDirectoryExists(fileOrDirectory string) bool {
-	if _, err := os.Stat(fileOrDirectory); os.IsNotExist(err) {
-		return false
-	}
-	return true
 }


### PR DESCRIPTION
…neration refactoring

Many thanks for submitting your Pull Request :heart: :cactus: ! 

[KOGITO-4517](https://issues.redhat.com/browse/KOGITO-4517)

tl;dr Protobuf files are no longer needed to be copied. They are now available as a static resource via a REST endpoint. See the JIRA for more details.

* Removed a dead branch in the code which creates a Dockerfile. Generated protobuf files are no longer available under `target/resources/persistence` and they even don't need to be copied.
* Removed the COPY command also from example Dockerfiles.


Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change