### PR TITLE
[KOGITO-4583] Revert lint to version v1.37.1

### DIFF
--- a/.github/workflows/Kogito-Operator-PR-Check.yaml
+++ b/.github/workflows/Kogito-Operator-PR-Check.yaml
@@ -14,8 +14,6 @@ jobs:
   golint:
     name: Lint
     runs-on: ubuntu-latest
-    env:
-      GOLANG_LINT_VERSION: v1.27.0
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -59,10 +57,6 @@ jobs:
           ./hack/go-fmt.sh
           changed_files=$(git status -s | grep -v 'go.mod\|go.sum\|kogito-operator.yaml\|go.tools.mod\|go.tools.sum' || :)
           [[ -z "$changed_files" ]] ||  (printf "Some files are not formatted properly: \n$changed_files\n Did you run 'make test' before sending the PR?" && exit 1)
-      - name: Install golinters
-        run: |
-          go get -u golang.org/x/lint/golint
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANG_LINT_VERSION
       - name: Check lint
         run: ./hack/go-lint.sh
 

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -21,7 +21,9 @@ if [ -s golint_errors ]  ; then
 fi
 rm -f golint_errors
 # The command in or will fetch the latest tag available for golangci-lint and install in $GOPATH/bin/
-command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+# Switch back to latest lint (commented line) once https://issues.redhat.com/browse/KOGITO-4575 is fixed
+# command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+command -v golangci-lint > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.1
 golangci-lint run ./... --enable golint --timeout 10m0s
 
 exit ${code:0}


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

https://issues.redhat.com/browse/KOGITO-4583

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-cloud-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change